### PR TITLE
refactor: visitor method to process paragraph wrapped text

### DIFF
--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -336,8 +336,7 @@ impl WidgetRef for Paragraph<'_> {
 }
 
 impl Paragraph<'_> {
-    ///
-    /// Visits the styled composed lines inside a text area for rendering or other analysis/processing.
+    /// Visits the styled wrapped text lines inside a text area for rendering or other analysis/processing.
     /// The visitor function indicates it wants the visitor iteration to terminate if it returns false.
     ///
     pub fn visit_wrapped_text<F: FnMut(&'_ WrappedLine) -> bool>(&self, text_area: &Rect, visitor: F) {

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -339,11 +339,7 @@ impl Paragraph<'_> {
     /// Visits the styled wrapped text lines inside a text area for rendering or other analysis/processing.
     /// The visitor function indicates it wants the visitor iteration to terminate if it returns false.
     ///
-    pub fn visit_wrapped_text<F: FnMut(WrappedLine) -> bool>(
-        &self,
-        text_area: &Rect,
-        visitor: F,
-    ) {
+    pub fn visit_wrapped_text<F: FnMut(WrappedLine) -> bool>(&self, text_area: &Rect, visitor: F) {
         if text_area.is_empty() {
             return;
         }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -339,7 +339,7 @@ impl Paragraph<'_> {
     /// Visits the styled wrapped text lines inside a text area for rendering or other analysis/processing.
     /// The visitor function indicates it wants the visitor iteration to terminate if it returns false.
     ///
-    pub fn visit_wrapped_text<F: FnMut(&'_ WrappedLine) -> bool>(
+    pub fn visit_wrapped_text<F: FnMut(WrappedLine) -> bool>(
         &self,
         text_area: &Rect,
         visitor: F,
@@ -364,12 +364,12 @@ impl Paragraph<'_> {
         }
     }
 
-    fn visit_with_composer<'a, C: LineComposer<'a>, F: FnMut(&'_ WrappedLine) -> bool>(
+    fn visit_with_composer<'a, C: LineComposer<'a>, F: FnMut(WrappedLine) -> bool>(
         mut composer: C,
         mut visitor: F,
     ) {
         while let Some(line) = composer.next_line() {
-            if !visitor(&line) {
+            if !visitor(line) {
                 break;
             }
         }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -339,7 +339,11 @@ impl Paragraph<'_> {
     /// Visits the styled wrapped text lines inside a text area for rendering or other analysis/processing.
     /// The visitor function indicates it wants the visitor iteration to terminate if it returns false.
     ///
-    pub fn visit_wrapped_text<F: FnMut(&'_ WrappedLine) -> bool>(&self, text_area: &Rect, visitor: F) {
+    pub fn visit_wrapped_text<F: FnMut(&'_ WrappedLine) -> bool>(
+        &self,
+        text_area: &Rect,
+        visitor: F,
+    ) {
         if text_area.is_empty() {
             return;
         }
@@ -360,7 +364,10 @@ impl Paragraph<'_> {
         }
     }
 
-    fn visit_with_composer<'a, C: LineComposer<'a>, F: FnMut(&'_ WrappedLine) -> bool>(mut composer: C, mut visitor: F) {
+    fn visit_with_composer<'a, C: LineComposer<'a>, F: FnMut(&'_ WrappedLine) -> bool>(
+        mut composer: C,
+        mut visitor: F,
+    ) {
         while let Some(line) = composer.next_line() {
             if !visitor(&line) {
                 break;


### PR DESCRIPTION
I recently wrote an edit text feature for wrapped paragraph text based on ratatui. I found that I needed a public interface to visit the wrapped text to handle the edit mode cursor placement logic consistent with text rendering.

The following pull request shows what I had to do to make this possible - I also needed the helper method get_line_offset as a bit of auxiliary public functionality in some of my logic.

Is this something you would consider taking across, or shall I remain in purgatory on this with a fork?
