### PR TITLE
feat: Add selection of multiple marks for table widget

### DIFF
--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -1621,6 +1621,7 @@ mod tests {
         }
 
         #[test]
+        #[allow(clippy::too_many_lines)]
         fn highlight_symbol_mark_symbol_and_column_spacing_with_highlight_spacing() {
             // no highlight_symbol or mark_symbol rendered ever
             test_table_with_selection_and_marks(
@@ -1667,6 +1668,7 @@ mod tests {
                     "               ", // row 3
                 ],
             );
+
             // no highlight_symbol or mark_symbol rendered
             test_table_with_selection_and_marks(
                 HighlightSpacing::WhenSelected,
@@ -1718,6 +1720,70 @@ mod tests {
             // mark highlight symbol rendered
             test_table_with_selection_and_marks(
                 HighlightSpacing::WhenSelected,
+                15,      // width
+                0,       // spacing
+                Some(0), // selection
+                [0],     // marks
+                [
+                    " >M> ABCDE12345", /* default layout is Flex::Start but columns length
+                                        * constraints are calculated as `max_area / n_columns`,
+                                        * i.e. they are distributed amongst available space */
+                    "               ", // row 2
+                    "               ", // row 3
+                ],
+            );
+
+            // no highlight_symbol or mark_symbol rendered
+            test_table_with_selection_and_marks(
+                HighlightSpacing::Always,
+                15,   // width
+                0,    // spacing
+                None, // selection
+                [],   // marks
+                [
+                    "     ABCDE12345", /* default layout is Flex::Start but columns length
+                                        * constraints are calculated as `max_area / n_columns`,
+                                        * i.e. they are distributed amongst available space */
+                    "               ", // row 2
+                    "               ", // row 3
+                ],
+            );
+
+            // mark_symbol rendered
+            test_table_with_selection_and_marks(
+                HighlightSpacing::Always,
+                15,   // width
+                0,    // spacing
+                None, // selection
+                [0],  // marks
+                [
+                    " MMM ABCDE12345", /* default layout is Flex::Start but columns length
+                                        * constraints are calculated as `max_area / n_columns`,
+                                        * i.e. they are distributed amongst available space */
+                    "               ", // row 2
+                    "               ", // row 3
+                ],
+            );
+
+            // highlight symbol rendered with mark symbol width
+            test_table_with_selection_and_marks(
+                HighlightSpacing::Always,
+                15,      // width
+                0,       // spacing
+                Some(0), // selection
+                [],      // marks
+                [
+                    ">>>  ABCDE12345", /* default layout is Flex::Start but columns length
+                                        * constraints are calculated as `max_area / n_columns`,
+                                        * i.e. they are distributed amongst available space */
+                    "               ", // row 2
+                    "               ", // row 3
+                ],
+            );
+
+            // mark highlight symbol rendered
+            test_table_with_selection_and_marks(
+                HighlightSpacing::Always,
                 15,      // width
                 0,       // spacing
                 Some(0), // selection

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -1336,7 +1336,7 @@ mod tests {
                 "               ".into(),
                 "               ".into(),
             ]));
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
 
             state.mark(0);
 
@@ -1354,7 +1354,7 @@ mod tests {
                 "               ".into(),
                 "               ".into(),
             ]));
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
 
             state.select(Some(1));
 
@@ -1372,7 +1372,7 @@ mod tests {
                 "               ".into(),
                 "               ".into(),
             ]));
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
 
             state.unmark(0);
 
@@ -1390,7 +1390,7 @@ mod tests {
                 "               ".into(),
                 "               ".into(),
             ]));
-            assert_buffer_eq!(buf, expected);
+            assert_eq!(buf, expected);
         }
     }
 

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -1298,13 +1298,17 @@ mod tests {
         }
 
         #[test]
-        fn render_with_selected_and_marked() {
+        fn render_with_selected_marked_unmarked() {
             let rows = vec![
-                Row::new(vec!["Cell1", "Cell2"]),
-                Row::new(vec!["Cell3", "Cell4"]),
+                Row::new(vec!["Cell", "Cell"]),
+                Row::new(vec!["Cell", "Cell"]),
+                Row::new(vec!["Cell", "Cell"]),
+                Row::new(vec!["Cell", "Cell"]),
+                Row::new(vec!["Cell", "Cell"]),
+                Row::new(vec!["Cell", "Cell"]),
+                Row::new(vec!["Cell", "Cell"]),
             ];
             let table = Table::new(rows, [Constraint::Length(5); 2])
-                .highlight_style(Style::new().red())
                 .highlight_symbol("• ")
                 .mark_symbol("⦾")
                 .unmark_symbol(" ")
@@ -1313,25 +1317,77 @@ mod tests {
             let mut state = TableState::new().with_selected(0);
 
             state.mark(1);
+            state.mark(3);
+            state.mark(5);
 
-            let mut buf = Buffer::empty(Rect::new(0, 0, 15, 3));
-            StatefulWidget::render(table.clone(), Rect::new(0, 0, 15, 3), &mut buf, &mut state);
-            let expected = Buffer::with_lines(vec![
-                "• Cell1 Cell2  ".red(),
-                "⦾ Cell3 Cell4  ".into(),
+            let mut buf = Buffer::empty(Rect::new(0, 0, 15, 10));
+            StatefulWidget::render(table.clone(), Rect::new(0, 0, 15, 10), &mut buf, &mut state);
+            let expected = Buffer::with_lines(Text::from(vec![
+                "• Cell  Cell   ".into(),
+                "⦾ Cell  Cell   ".into(),
+                "  Cell  Cell   ".into(),
+                "⦾ Cell  Cell   ".into(),
+                "  Cell  Cell   ".into(),
+                "⦾ Cell  Cell   ".into(),
+                "  Cell  Cell   ".into(),
                 "               ".into(),
-            ]);
+                "               ".into(),
+                "               ".into(),
+            ]));
             assert_buffer_eq!(buf, expected);
 
             state.mark(0);
 
-            let mut buf = Buffer::empty(Rect::new(0, 0, 15, 3));
-            StatefulWidget::render(table, Rect::new(0, 0, 15, 3), &mut buf, &mut state);
-            let expected = Buffer::with_lines(vec![
-                "⦿ Cell1 Cell2  ".red(),
-                "⦾ Cell3 Cell4  ".into(),
+            let mut buf = Buffer::empty(Rect::new(0, 0, 15, 10));
+            StatefulWidget::render(table.clone(), Rect::new(0, 0, 15, 10), &mut buf, &mut state);
+            let expected = Buffer::with_lines(Text::from(vec![
+                "⦿ Cell  Cell   ".into(),
+                "⦾ Cell  Cell   ".into(),
+                "  Cell  Cell   ".into(),
+                "⦾ Cell  Cell   ".into(),
+                "  Cell  Cell   ".into(),
+                "⦾ Cell  Cell   ".into(),
+                "  Cell  Cell   ".into(),
                 "               ".into(),
-            ]);
+                "               ".into(),
+                "               ".into(),
+            ]));
+            assert_buffer_eq!(buf, expected);
+
+            state.select(Some(1));
+
+            let mut buf = Buffer::empty(Rect::new(0, 0, 15, 10));
+            StatefulWidget::render(table.clone(), Rect::new(0, 0, 15, 10), &mut buf, &mut state);
+            let expected = Buffer::with_lines(Text::from(vec![
+                "⦾ Cell  Cell   ".into(),
+                "⦿ Cell  Cell   ".into(),
+                "  Cell  Cell   ".into(),
+                "⦾ Cell  Cell   ".into(),
+                "  Cell  Cell   ".into(),
+                "⦾ Cell  Cell   ".into(),
+                "  Cell  Cell   ".into(),
+                "               ".into(),
+                "               ".into(),
+                "               ".into(),
+            ]));
+            assert_buffer_eq!(buf, expected);
+
+            state.unmark(0);
+
+            let mut buf = Buffer::empty(Rect::new(0, 0, 15, 10));
+            StatefulWidget::render(table.clone(), Rect::new(0, 0, 15, 10), &mut buf, &mut state);
+            let expected = Buffer::with_lines(Text::from(vec![
+                "  Cell  Cell   ".into(),
+                "⦿ Cell  Cell   ".into(),
+                "  Cell  Cell   ".into(),
+                "⦾ Cell  Cell   ".into(),
+                "  Cell  Cell   ".into(),
+                "⦾ Cell  Cell   ".into(),
+                "  Cell  Cell   ".into(),
+                "               ".into(),
+                "               ".into(),
+                "               ".into(),
+            ]));
             assert_buffer_eq!(buf, expected);
         }
     }

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -219,7 +219,7 @@ pub struct Table<'a> {
     /// Symbol in front of the unmarked row
     unmark_symbol: Text<'a>,
 
-    /// Symbol in front of the marked row
+    /// Symbol in front of the marked and selected row
     mark_highlight_symbol: Text<'a>,
 
     /// Decides when to allocate spacing for the row selection

--- a/src/widgets/table/table_state.rs
+++ b/src/widgets/table/table_state.rs
@@ -229,6 +229,7 @@ impl TableState {
     ///
     /// ```rust
     /// # use ratatui::{prelude::*, widgets::*};
+    /// # use itertools::Itertools;
     /// let mut state = TableState::default();
     /// state.marked().contains(&1);
     /// ```

--- a/src/widgets/table/table_state.rs
+++ b/src/widgets/table/table_state.rs
@@ -49,6 +49,7 @@
 pub struct TableState {
     pub(crate) offset: usize,
     pub(crate) selected: Option<usize>,
+    pub(crate) marked: Vec<usize>,
 }
 
 impl TableState {
@@ -64,6 +65,7 @@ impl TableState {
         Self {
             offset: 0,
             selected: None,
+            marked: vec![],
         }
     }
 
@@ -174,6 +176,77 @@ impl TableState {
         if index.is_none() {
             self.offset = 0;
         }
+    }
+
+    /// Sets the index of the row as marked
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use ratatui::{prelude::*, widgets::*};
+    /// let mut state = TableState::default();
+    /// state.mark(1);
+    /// ```
+    pub fn mark(&mut self, index: usize) {
+        if !self.marked.contains(&index) {
+            self.marked.push(index);
+        }
+    }
+
+    /// Sets the index of the row as unmarked
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use ratatui::{prelude::*, widgets::*};
+    /// let mut state = TableState::default();
+    /// state.unmark(1);
+    /// ```
+    pub fn unmark(&mut self, index: usize) {
+        self.marked.retain(|i| *i != index);
+    }
+
+    /// Toggles the index of the row as marked or unmarked
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use ratatui::{prelude::*, widgets::*};
+    /// let mut state = TableState::default();
+    /// state.toggle_mark(1);
+    /// ```
+    pub fn toggle_mark(&mut self, index: usize) {
+        if self.marked.contains(&index) {
+            self.unmark(index);
+        } else {
+            self.mark(index);
+        }
+    }
+
+    /// Returns a iterator of all marked rows
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use ratatui::{prelude::*, widgets::*};
+    /// let mut state = TableState::default();
+    /// state.marked().contains(&1);
+    /// ```
+    pub fn marked(&self) -> std::slice::Iter<'_, usize> {
+        self.marked.iter()
+    }
+
+    /// Clears all marks from all rows
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use ratatui::{prelude::*, widgets::*};
+    /// let mut state = TableState::default();
+    /// state.clear_marks();
+    /// ```
+    pub fn clear_marks(&mut self) {
+        self.marked.drain(..);
     }
 }
 

--- a/tests/state_serde.rs
+++ b/tests/state_serde.rs
@@ -94,7 +94,8 @@ const DEFAULT_STATE_REPR: &str = r#"{
   },
   "table": {
     "offset": 0,
-    "selected": null
+    "selected": null,
+    "marked": []
   },
   "scrollbar": {
     "content_length": 10,
@@ -135,7 +136,8 @@ const SELECTED_STATE_REPR: &str = r#"{
   },
   "table": {
     "offset": 0,
-    "selected": 1
+    "selected": 1,
+    "marked": []
   },
   "scrollbar": {
     "content_length": 10,
@@ -179,7 +181,8 @@ const SCROLLED_STATE_REPR: &str = r#"{
   },
   "table": {
     "offset": 4,
-    "selected": 8
+    "selected": 8,
+    "marked": []
   },
   "scrollbar": {
     "content_length": 10,

--- a/tests/state_serde.rs
+++ b/tests/state_serde.rs
@@ -14,6 +14,7 @@
 // not too happy about the redundancy in these tests,
 // but if that helps readability then it's ok i guess /shrug
 
+use pretty_assertions::assert_eq;
 use ratatui::{backend::TestBackend, prelude::*, widgets::*};
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -148,7 +149,6 @@ const SELECTED_STATE_REPR: &str = r#"{
 
 #[test]
 fn selected_state_serialize() {
-    use pretty_assertions::assert_eq;
     let mut state = AppState::default();
     state.select(1);
 

--- a/tests/state_serde.rs
+++ b/tests/state_serde.rs
@@ -146,6 +146,7 @@ const SELECTED_STATE_REPR: &str = r#"{
 
 #[test]
 fn selected_state_serialize() {
+    use pretty_assertions::assert_eq;
     let mut state = AppState::default();
     state.select(1);
 


### PR DESCRIPTION
This PR allows users to display a mark next to multiple rows. The marked rows are stored in the table.

e.g. here's a table with 2 rows marked and the first row selected (i.e. where the cursor currently is located).

```
• Cell Cell     // e.g. unmarked and selected row
⦾ Cell Cell    // e.g. marked row
  Cell Cell    // e.g. unmarked row
  Cell Cell    // e.g. unmarked row
⦾ Cell Cell    // e.g. marked row
  Cell Cell    // e.g. unmarked row    
```

If we move the cursor down 1, the marked row and the currently selected row overlap:

```
  Cell Cell     // e.g. unmarked row
⦿ Cell Cell    // e.g. marked and selected row
  Cell Cell    // e.g. unmarked row
  Cell Cell    // e.g. unmarked row
⦾ Cell Cell    // e.g. marked row
  Cell Cell    // e.g. unmarked row    
```

The index for all marked rows can be retrieved from `TableState::marked()`. This PR adds other methods to the `TableState` struct to manipulate the marks.