### PR TITLE
feat(backend): Add convenience methods for setting up terminals

### DIFF
--- a/examples/colors_rgb.rs
+++ b/examples/colors_rgb.rs
@@ -97,7 +97,7 @@ struct ColorsWidget {
 
 fn main() -> Result<()> {
     install_error_hooks()?;
-    let terminal = CrosstermBackend::stdout().into_terminal_with_defaults()?;
+    let terminal = CrosstermBackend::stdout_with_defaults()?.to_terminal()?;
     App::default().run(terminal)?;
     Ok(())
 }

--- a/examples/colors_rgb.rs
+++ b/examples/colors_rgb.rs
@@ -97,7 +97,7 @@ struct ColorsWidget {
 
 fn main() -> Result<()> {
     install_error_hooks()?;
-    let terminal = CrosstermBackend::stdout_with_defaults()?.to_terminal()?;
+    let terminal = CrosstermBackend::stdout_with_defaults()?.into_terminal()?;
     App::default().run(terminal)?;
     Ok(())
 }

--- a/examples/colors_rgb.rs
+++ b/examples/colors_rgb.rs
@@ -97,7 +97,8 @@ struct ColorsWidget {
 
 fn main() -> Result<()> {
     install_error_hooks()?;
-    let terminal = CrosstermBackend::stdout_with_defaults()?.into_terminal()?;
+    let backend = CrosstermBackend::stdout_with_defaults()?;
+    let terminal = Terminal::new(backend)?;
     App::default().run(terminal)?;
     Ok(())
 }

--- a/examples/colors_rgb.rs
+++ b/examples/colors_rgb.rs
@@ -97,7 +97,7 @@ struct ColorsWidget {
 
 fn main() -> Result<()> {
     install_error_hooks()?;
-    let backend = CrosstermBackend::stdout_with_defaults()?;
+    let backend = CrosstermBackend::stdout()?;
     let terminal = Terminal::new(backend)?;
     App::default().run(terminal)?;
     Ok(())
@@ -268,11 +268,11 @@ fn install_error_hooks() -> Result<()> {
     let panic = panic.into_panic_hook();
     let error = error.into_eyre_hook();
     eyre::set_hook(Box::new(move |e| {
-        let _ = CrosstermBackend::reset(stdout());
+        let _ = CrosstermBackend::restore(stdout());
         error(e)
     }))?;
     panic::set_hook(Box::new(move |info| {
-        let _ = CrosstermBackend::reset(stdout());
+        let _ = CrosstermBackend::restore(stdout());
         panic(info);
     }));
     Ok(())

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -26,7 +26,7 @@ use ratatui::{
 /// [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 /// [hello-world]: https://github.com/ratatui-org/ratatui/blob/main/examples/hello_world.rs
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut terminal = CrosstermBackend::stdout_with_defaults()?.to_terminal()?;
+    let mut terminal = CrosstermBackend::stdout_with_defaults()?.into_terminal()?;
     terminal.clear()?;
     loop {
         terminal.draw(|frame| frame.render_widget(Text::raw("Hello World!"), frame.size()))?;

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -15,13 +15,8 @@
 
 use ratatui::{
     backend::CrosstermBackend,
-    crossterm::{
-        event::{self, Event, KeyCode, KeyEventKind},
-        execute,
-        terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-    },
+    crossterm::event::{self, Event, KeyCode, KeyEventKind},
     text::Text,
-    Terminal,
 };
 
 /// This is a bare minimum example. There are many approaches to running an application loop, so
@@ -31,9 +26,8 @@ use ratatui::{
 /// [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 /// [hello-world]: https://github.com/ratatui-org/ratatui/blob/main/examples/hello_world.rs
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut terminal = Terminal::new(CrosstermBackend::new(std::io::stdout()))?;
-    enable_raw_mode()?;
-    execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+    let mut terminal = CrosstermBackend::stdout().into_terminal_with_defaults()?;
+    terminal.clear()?;
     loop {
         terminal.draw(|frame| frame.render_widget(Text::raw("Hello World!"), frame.size()))?;
         if let Event::Key(key) = event::read()? {
@@ -42,7 +36,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     }
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     Ok(())
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -27,7 +27,7 @@ use ratatui::{
 /// [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 /// [hello-world]: https://github.com/ratatui-org/ratatui/blob/main/examples/hello_world.rs
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let backend = CrosstermBackend::stdout_with_defaults()?;
+    let backend = CrosstermBackend::stdout()?;
     let mut terminal = Terminal::new(backend)?;
     terminal.clear()?;
     loop {

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -14,9 +14,10 @@
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
 use ratatui::{
-    backend::{Backend, CrosstermBackend},
+    backend::CrosstermBackend,
     crossterm::event::{self, Event, KeyCode, KeyEventKind},
     text::Text,
+    Terminal,
 };
 
 /// This is a bare minimum example. There are many approaches to running an application loop, so
@@ -26,7 +27,8 @@ use ratatui::{
 /// [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 /// [hello-world]: https://github.com/ratatui-org/ratatui/blob/main/examples/hello_world.rs
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut terminal = CrosstermBackend::stdout_with_defaults()?.into_terminal()?;
+    let backend = CrosstermBackend::stdout_with_defaults()?;
+    let mut terminal = Terminal::new(backend)?;
     terminal.clear()?;
     loop {
         terminal.draw(|frame| frame.render_widget(Text::raw("Hello World!"), frame.size()))?;

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -14,7 +14,7 @@
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
 use ratatui::{
-    backend::CrosstermBackend,
+    backend::{Backend, CrosstermBackend},
     crossterm::event::{self, Event, KeyCode, KeyEventKind},
     text::Text,
 };
@@ -26,7 +26,7 @@ use ratatui::{
 /// [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 /// [hello-world]: https://github.com/ratatui-org/ratatui/blob/main/examples/hello_world.rs
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut terminal = CrosstermBackend::stdout().into_terminal_with_defaults()?;
+    let mut terminal = CrosstermBackend::stdout_with_defaults()?.to_terminal()?;
     terminal.clear()?;
     loop {
         terminal.draw(|frame| frame.render_widget(Text::raw("Hello World!"), frame.size()))?;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -104,7 +104,11 @@ use std::io;
 
 use strum::{Display, EnumString};
 
-use crate::{buffer::Cell, layout::Size, prelude::Rect, Terminal, TerminalOptions};
+use crate::{
+    buffer::Cell,
+    layout::{Rect, Size},
+    Terminal, TerminalOptions,
+};
 
 #[cfg(feature = "termion")]
 mod termion;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -104,7 +104,7 @@ use std::io;
 
 use strum::{Display, EnumString};
 
-use crate::{buffer::Cell, layout::Size, prelude::Rect};
+use crate::{buffer::Cell, layout::Size, prelude::Rect, Terminal, TerminalOptions};
 
 #[cfg(feature = "termion")]
 mod termion;
@@ -298,6 +298,42 @@ pub trait Backend {
 
     /// Flush any buffered content to the terminal screen.
     fn flush(&mut self) -> io::Result<()>;
+
+    /// Converts the `Backend` into a [`Terminal`] instance.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use ratatui::backend::{Backend, CrosstermBackend};
+    /// let terminal = CrosstermBackend::stdout().to_terminal()?;
+    /// # std::io::Result::Ok(())
+    /// ```
+    fn to_terminal(self) -> io::Result<Terminal<Self>>
+    where
+        Self: Sized,
+    {
+        Terminal::new(self)
+    }
+
+    /// Converts the `Backend` into a [`Terminal`] instance with options.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ratatui::{backend::{Backend, CrosstermBackend}, TerminalOptions, Viewport};
+    ///
+    /// let options = TerminalOptions {
+    ///     viewport: Viewport::Inline(10),
+    /// };
+    /// let terminal = CrosstermBackend::stdout().to_terminal_with_options(options)?;
+    /// # std::io::Result::Ok(())
+    /// ```
+    fn to_terminal_with_options(self, options: TerminalOptions) -> io::Result<Terminal<Self>>
+    where
+        Self: Sized,
+    {
+        Terminal::with_options(self, options)
+    }
 }
 
 #[cfg(test)]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -324,7 +324,10 @@ pub trait Backend {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use ratatui::{backend::{Backend, CrosstermBackend}, TerminalOptions, Viewport};
+    /// use ratatui::{
+    ///     backend::{Backend, CrosstermBackend},
+    ///     TerminalOptions, Viewport,
+    /// };
     ///
     /// let options = TerminalOptions {
     ///     viewport: Viewport::Inline(10),

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -107,7 +107,6 @@ use strum::{Display, EnumString};
 use crate::{
     buffer::Cell,
     layout::{Rect, Size},
-    Terminal, TerminalOptions,
 };
 
 #[cfg(feature = "termion")]
@@ -302,45 +301,6 @@ pub trait Backend {
 
     /// Flush any buffered content to the terminal screen.
     fn flush(&mut self) -> io::Result<()>;
-
-    /// Converts the `Backend` into a [`Terminal`] instance.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # use ratatui::backend::{Backend, CrosstermBackend};
-    /// let terminal = CrosstermBackend::stdout().to_terminal()?;
-    /// # std::io::Result::Ok(())
-    /// ```
-    fn into_terminal(self) -> io::Result<Terminal<Self>>
-    where
-        Self: Sized,
-    {
-        Terminal::new(self)
-    }
-
-    /// Converts the `Backend` into a [`Terminal`] instance with options.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use ratatui::{
-    ///     backend::{Backend, CrosstermBackend},
-    ///     TerminalOptions, Viewport,
-    /// };
-    ///
-    /// let options = TerminalOptions {
-    ///     viewport: Viewport::Inline(10),
-    /// };
-    /// let terminal = CrosstermBackend::stdout().to_terminal_with_options(options)?;
-    /// # std::io::Result::Ok(())
-    /// ```
-    fn to_terminal_with_options(self, options: TerminalOptions) -> io::Result<Terminal<Self>>
-    where
-        Self: Sized,
-    {
-        Terminal::with_options(self, options)
-    }
 }
 
 #[cfg(test)]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -312,7 +312,7 @@ pub trait Backend {
     /// let terminal = CrosstermBackend::stdout().to_terminal()?;
     /// # std::io::Result::Ok(())
     /// ```
-    fn to_terminal(self) -> io::Result<Terminal<Self>>
+    fn into_terminal(self) -> io::Result<Terminal<Self>>
     where
         Self: Sized,
     {

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -42,15 +42,15 @@ use crate::{
 /// alternate screen using [`CrosstermBackend::stdout_with_defaults`] or
 /// [`CrosstermBackend::stderr_with_defaults`].
 ///
-/// The `CrosstermBackend` can be converted into a [`Terminal`] instance using
-/// [`CrosstermBackend::to_terminal`].
-///
 /// If the default settings are not desired, the `CrosstermBackend` can be configured using the
 /// `with_*` methods. These methods return an [`io::Result`] containing self so that they can be
 /// chained with other methods. The settings are restored when the `CrosstermBackend` is dropped.
 /// - [`CrosstermBackend::with_raw_mode`] enables raw mode for the terminal.
 /// - [`CrosstermBackend::with_alternate_screen`] switches to the alternate screen.
 /// - [`CrosstermBackend::with_mouse_capture`] enables mouse capture.
+/// - [`CrosstermBackend::with_bracketed_paste`] enables bracketed paste.
+/// - [`CrosstermBackend::with_focus_change`] enables focus change.
+/// - [`CrosstermBackend::with_keyboard_enhancement_flags`] enables keyboard enhancement flags.
 ///
 /// If a backend is configured using the `with_*` methods, the settings are restored when the
 /// `CrosstermBackend` is dropped.

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -37,7 +37,7 @@ use crate::{
 ///
 /// Convenience methods ([`CrosstermBackend::stdout`] and [`CrosstermBackend::stderr`] are provided
 /// to create a `CrosstermBackend` with [`std::io::stdout`] or [`std::io::stderr`] as the writer
-/// with default settings to enable raw mode and switch to the alternate screen.
+/// with raw mode enabled and the terminal switched to the alternate screen.
 ///
 /// If the default settings are not desired, the `CrosstermBackend` can be configured using the
 /// `with_*` methods. These methods return an [`io::Result`] containing self so that they can be

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -22,8 +22,7 @@ use crate::{
             ContentStyle, Print, SetAttribute, SetBackgroundColor, SetColors, SetForegroundColor,
         },
         terminal::{
-            self, disable_raw_mode, enable_raw_mode, Clear, EnterAlternateScreen,
-            LeaveAlternateScreen,
+            disable_raw_mode, enable_raw_mode, Clear, EnterAlternateScreen, LeaveAlternateScreen,
         },
     },
     layout::{Rect, Size},
@@ -514,7 +513,7 @@ where
     }
 
     fn size(&self) -> io::Result<Rect> {
-        let (width, height) = terminal::size()?;
+        let (width, height) = crossterm::terminal::size()?;
         Ok(Rect::new(0, 0, width, height))
     }
 
@@ -524,7 +523,7 @@ where
             rows,
             width,
             height,
-        } = terminal::window_size()?;
+        } = crossterm::terminal::window_size()?;
         Ok(WindowSize {
             columns_rows: Size {
                 width: columns,

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -4,20 +4,18 @@
 //! [Crossterm]: https://crates.io/crates/crossterm
 use std::io::{self, Write};
 
-use crossterm::event::{
-    DisableBracketedPaste, DisableFocusChange, EnableBracketedPaste, EnableFocusChange,
-    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
-};
-
 #[cfg(feature = "underline-color")]
 use crate::crossterm::style::SetUnderlineColor;
-
 use crate::{
     backend::{Backend, ClearType, WindowSize},
     buffer::Cell,
     crossterm::{
         cursor::{Hide, MoveTo, Show},
-        event::{DisableMouseCapture, EnableMouseCapture},
+        event::{
+            DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+            EnableFocusChange, EnableMouseCapture, KeyboardEnhancementFlags,
+            PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+        },
         execute, queue,
         style::{
             Attribute as CAttribute, Attributes as CAttributes, Color as CColor, Colors,
@@ -60,8 +58,10 @@ use crate::{
 /// # Example
 ///
 /// ```rust,no_run
-/// use ratatui::backend::{Backend, CrosstermBackend};
-/// use crossterm::event::KeyboardEnhancementFlags;
+/// use ratatui::{
+///     backend::{Backend, CrosstermBackend},
+///     crossterm::event::KeyboardEnhancementFlags,
+/// };
 ///
 /// let mut terminal = CrosstermBackend::stdout_with_defaults()?.to_terminal()?;
 /// // or
@@ -87,6 +87,7 @@ use crate::{
 /// [Crossterm]: https://crates.io/crates/crossterm
 /// [Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples/README.md
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct CrosstermBackend<W: Write> {
     /// The writer used to send commands to the terminal.
     writer: W,
@@ -112,6 +113,7 @@ where
     ///
     /// ```rust,no_run
     /// use std::io;
+    ///
     /// use ratatui::backend::CrosstermBackend;
     ///
     /// let backend = CrosstermBackend::new(io::stdout());
@@ -317,8 +319,7 @@ impl<W: Write> CrosstermBackend<W> {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use ratatui::backend::CrosstermBackend;
-    /// use crossterm::event::KeyboardEnhancementFlags;
+    /// use ratatui::{backend::CrosstermBackend, crossterm::event::KeyboardEnhancementFlags};
     ///
     /// let backend = CrosstermBackend::stdout()
     ///     .with_keyboard_enhancement_flags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)?;
@@ -603,7 +604,6 @@ impl ModifierDiff {
     where
         W: io::Write,
     {
-        //use crossterm::Attribute;
         let removed = self.from - self.to;
         if removed.contains(Modifier::REVERSED) {
             queue!(w, SetAttribute(CAttribute::NoReverse))?;

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -66,7 +66,7 @@ use crate::{
 /// // or
 /// let backend = CrosstermBackend::stderr_with_defaults()?;
 /// // or with custom settings
-/// let terminal = CrosstermBackend::stdout()
+/// let backend = CrosstermBackend::stdout()
 ///     .with_raw_mode()?
 ///     .with_alternate_screen()?
 ///     .with_mouse_capture()?

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -62,18 +62,17 @@ use crate::{
 ///     crossterm::event::KeyboardEnhancementFlags,
 /// };
 ///
-/// let mut terminal = CrosstermBackend::stdout_with_defaults()?.to_terminal()?;
+/// let backend = CrosstermBackend::stdout_with_defaults()?;
 /// // or
-/// let mut terminal = CrosstermBackend::stderr_with_defaults()?.to_terminal()?;
+/// let backend = CrosstermBackend::stderr_with_defaults()?;
 /// // or with custom settings
-/// let mut terminal = CrosstermBackend::stdout()
+/// let terminal = CrosstermBackend::stdout()
 ///     .with_raw_mode()?
 ///     .with_alternate_screen()?
 ///     .with_mouse_capture()?
 ///     .with_bracketed_paste()?
 ///     .with_focus_change()?
-///     .with_keyboard_enhancement_flags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)?
-///     .to_terminal()?;
+///     .with_keyboard_enhancement_flags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)?;
 /// # std::io::Result::Ok(())
 /// ```
 ///

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -194,7 +194,7 @@ impl<W: Write> CrosstermBackend<W> {
     ///
     /// ```rust,no_run
     /// # use ratatui::backend::CrosstermBackend;
-    /// let backend = CrosstermBackend::stdout().with_raw_mode()?;
+    /// let backend = CrosstermBackend::stdout()?.with_raw_mode()?;
     /// # std::io::Result::Ok(())
     /// ```
     pub fn with_raw_mode(mut self) -> io::Result<Self> {
@@ -213,7 +213,7 @@ impl<W: Write> CrosstermBackend<W> {
     ///
     /// ```rust,no_run
     /// # use ratatui::backend::CrosstermBackend;
-    /// let backend = CrosstermBackend::stdout().with_alternate_screen()?;
+    /// let backend = CrosstermBackend::stdout()?.with_alternate_screen()?;
     /// # std::io::Result::Ok(())
     /// ```
     pub fn with_alternate_screen(mut self) -> io::Result<Self> {
@@ -232,7 +232,7 @@ impl<W: Write> CrosstermBackend<W> {
     ///
     /// ```rust,no_run
     /// # use ratatui::backend::CrosstermBackend;
-    /// let backend = CrosstermBackend::stdout().with_mouse_capture()?;
+    /// let backend = CrosstermBackend::stdout()?.with_mouse_capture()?;
     /// # std::io::Result::Ok(())
     /// ```
     pub fn with_mouse_capture(mut self) -> io::Result<Self> {
@@ -249,7 +249,7 @@ impl<W: Write> CrosstermBackend<W> {
     ///
     /// ```rust,no_run
     /// # use ratatui::backend::CrosstermBackend;
-    /// let backend = CrosstermBackend::stdout().with_bracketed_paste()?;
+    /// let backend = CrosstermBackend::stdout()?.with_bracketed_paste()?;
     /// # std::io::Result::Ok(())
     /// ```
     pub fn with_bracketed_paste(mut self) -> io::Result<Self> {
@@ -266,7 +266,7 @@ impl<W: Write> CrosstermBackend<W> {
     ///
     /// ```rust,no_run
     /// # use ratatui::backend::CrosstermBackend;
-    /// let backend = CrosstermBackend::stdout().with_focus_change()?;
+    /// let backend = CrosstermBackend::stdout()?.with_focus_change()?;
     /// # std::io::Result::Ok(())
     pub fn with_focus_change(mut self) -> io::Result<Self> {
         execute!(self.writer, EnableFocusChange)?;
@@ -283,7 +283,7 @@ impl<W: Write> CrosstermBackend<W> {
     /// ```rust,no_run
     /// use ratatui::{backend::CrosstermBackend, crossterm::event::KeyboardEnhancementFlags};
     ///
-    /// let backend = CrosstermBackend::stdout()
+    /// let backend = CrosstermBackend::stdout()?
     ///     .with_keyboard_enhancement_flags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)?;
     /// # std::io::Result::Ok(())
     /// ```

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -203,7 +203,7 @@ impl<W: Write> CrosstermBackend<W> {
         Ok(self)
     }
 
-    /// Enables raw mode for the terminal and switches to the alternate screen.
+    /// Switches to the alternate screen.
     ///
     /// Returns an [`io::Result`] containing self so that it can be chained with other methods.
     ///

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -111,11 +111,8 @@ where
     /// # Example
     ///
     /// ```rust,no_run
-    /// use std::io;
-    ///
-    /// use ratatui::backend::CrosstermBackend;
-    ///
-    /// let backend = CrosstermBackend::new(io::stdout());
+    /// # use ratatui::backend::CrosstermBackend;
+    /// let backend = CrosstermBackend::new(std::io::stdout());
     /// ```
     pub const fn new(writer: W) -> Self {
         Self {
@@ -173,8 +170,7 @@ impl CrosstermBackend<io::Stdout> {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use ratatui::backend::CrosstermBackend;
-    ///
+    /// # use ratatui::backend::CrosstermBackend;
     /// let backend = CrosstermBackend::stdout_with_defaults()?;
     /// # std::io::Result::Ok(())
     /// ```
@@ -205,8 +201,7 @@ impl CrosstermBackend<io::Stderr> {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use ratatui::backend::CrosstermBackend;
-    ///
+    /// # use ratatui::backend::CrosstermBackend;
     /// let backend = CrosstermBackend::stderr_with_defaults()?;
     /// # std::io::Result::Ok(())
     /// ```
@@ -225,8 +220,7 @@ impl<W: Write> CrosstermBackend<W> {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use ratatui::backend::CrosstermBackend;
-    ///
+    /// # use ratatui::backend::CrosstermBackend;
     /// let backend = CrosstermBackend::stdout().with_raw_mode()?;
     /// # std::io::Result::Ok(())
     /// ```
@@ -245,8 +239,7 @@ impl<W: Write> CrosstermBackend<W> {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use ratatui::backend::CrosstermBackend;
-    ///
+    /// # use ratatui::backend::CrosstermBackend;
     /// let backend = CrosstermBackend::stdout().with_alternate_screen()?;
     /// # std::io::Result::Ok(())
     /// ```
@@ -265,8 +258,7 @@ impl<W: Write> CrosstermBackend<W> {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use ratatui::backend::CrosstermBackend;
-    ///
+    /// # use ratatui::backend::CrosstermBackend;
     /// let backend = CrosstermBackend::stdout().with_mouse_capture()?;
     /// # std::io::Result::Ok(())
     /// ```
@@ -283,8 +275,7 @@ impl<W: Write> CrosstermBackend<W> {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use ratatui::backend::CrosstermBackend;
-    ///
+    /// # use ratatui::backend::CrosstermBackend;
     /// let backend = CrosstermBackend::stdout().with_bracketed_paste()?;
     /// # std::io::Result::Ok(())
     /// ```
@@ -301,8 +292,7 @@ impl<W: Write> CrosstermBackend<W> {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use ratatui::backend::CrosstermBackend;
-    ///
+    /// # use ratatui::backend::CrosstermBackend;
     /// let backend = CrosstermBackend::stdout().with_focus_change()?;
     /// # std::io::Result::Ok(())
     pub fn with_focus_change(mut self) -> io::Result<Self> {
@@ -342,15 +332,19 @@ impl<W: Write> CrosstermBackend<W> {
     /// - Disables focus change
     /// - Pops keyboard enhancement flags
     ///
-    /// Note: this met
+    /// This method is an associated method rather than an instance method to make it possible to
+    /// call without having a `CrosstermBackend` instance. This is often useful in the context of
+    /// error / panic handling.
+    ///
+    /// If you have created a `CrosstermBackend` using the `with_*` methods, the settings are
+    /// restored when the `CrosstermBackend` is dropped, so you do not need to call this method
+    /// manually.
+    ///
     /// # Example
     ///
     /// ```rust,no_run
-    /// use std::io::stdout;
-    ///
-    /// use ratatui::backend::CrosstermBackend;
-    ///
-    /// CrosstermBackend::reset(stdout())?;
+    /// # use ratatui::backend::CrosstermBackend;
+    /// CrosstermBackend::reset(std::io::stderr())?;
     /// # std::io::Result::Ok(())
     /// ```
     pub fn reset(mut writer: W) -> io::Result<()> {


### PR DESCRIPTION
Adds:
- `CrosstermBackend::stdout` and `CrosstermBackend::stderr` for creating
  backends with `std::io::stdout` and `std::io::stderr` respectively.
- `CrosstermBackend::stdout_with_defaults` and
  `CrosstermBackend::stderr_with_defaults` for creating
  backends with that use the alternate screen and raw mode.
- `CrosstermBackend::with_raw_mode` for enabling raw mode.
- `CrosstermBackend::with_alternate_screen` for switching to the
  alternate screen.
- `CrosstermBackend::with_mouse_capture` for enabling mouse support.
- `CrosstermBackend::reset` for resetting the terminal to its default
  state.
- `Drop` implementation for restoring raw mode, mouse capture, and
  alternate screen on drop.

Most applications should generally use `stdout_with_defaults` to create
a backend with raw mode and the alternate screen, and now longer need
to worry about restoring the terminal to its default state when the
application exits. The reset method can be used to restore the terminal to
its default state if needed (e.g. in a panic handler).

```rust
use ratatui::{backend::CrosstermBackend};

let backend = CrosstermBackend::stdout_with_defaults()?;
// or
let backend = CrosstermBackend::stderr_with_defaults()?;
// or with custom settings
let backend = CrosstermBackend::stdout()
    .with_raw_mode()?
    .with_alternate_screen()?
    .with_mouse_capture()?
```

```rust
use std::io::stderr();

// in a panic / error handler:
CrosstermBackend::reset(stderr())
```
