### PR TITLE
feat(color-eyre): Add color eyre to the default app terminal setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ unicode-width = "0.1.13"
 anyhow = "1.0.71"
 argh = "0.1.12"
 better-panic = "0.3.0"
+color-eyre = "0.6.2"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 derive_builder = "0.20.0"
 fakeit = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ rust-version = "1.74.0"
 bitflags = "2.3"
 cassowary = "0.3"
 compact_str = "0.7.1"
+color-eyre = { version = "0.6.2", optional = true }
 crossterm = { version = "0.27", optional = true }
 document-features = { version = "0.2.7", optional = true }
 itertools = "0.13"
@@ -49,7 +50,6 @@ unicode-width = "0.1.13"
 anyhow = "1.0.71"
 argh = "0.1.12"
 better-panic = "0.3.0"
-color-eyre = "0.6.2"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 derive_builder = "0.20.0"
 fakeit = "1.1"
@@ -106,7 +106,7 @@ use_self = "warn"
 ## By default, we enable the crossterm backend as this is a reasonable choice for most applications
 ## as it is supported on Linux/Mac/Windows systems. We also enable the `underline-color` feature
 ## which allows you to set the underline color of text.
-default = ["crossterm", "underline-color"]
+default = ["crossterm", "underline-color", "color-eyre"]
 #! Generally an application will only use one backend, so you should only enable one of the following features:
 ## enables the [`CrosstermBackend`](backend::CrosstermBackend) backend and adds a dependency on [`crossterm`].
 crossterm = ["dep:crossterm"]
@@ -116,6 +116,12 @@ termion = ["dep:termion"]
 termwiz = ["dep:termwiz"]
 
 #! The following optional features are available for all backends:
+
+## enables the [`color-eyre`](color_eyre) crate which provides a better error handling experience.
+## See [`CrosstermBackend::with_color_eyre_hooks`](crate::backend::CrosstermBackend::with_color_eyre_hooks)
+## for more details.
+color-eyre = ["dep:color-eyre"]
+
 ## enables serialization and deserialization of style and color types using the [`serde`] crate.
 ## This is useful if you want to save themes to a file.
 serde = ["dep:serde", "bitflags/serde", "compact_str/serde"]

--- a/examples/colors_rgb.rs
+++ b/examples/colors_rgb.rs
@@ -97,7 +97,7 @@ struct ColorsWidget {
 
 fn main() -> Result<()> {
     install_error_hooks()?;
-    let terminal = CrosstermBackend::stdout().into_terminal_with_defaults()?;
+    let terminal = CrosstermBackend::stdout_with_defaults()?.to_terminal()?;
     App::default().run(terminal)?;
     Ok(())
 }

--- a/examples/colors_rgb.rs
+++ b/examples/colors_rgb.rs
@@ -26,13 +26,9 @@
 // is useful when the state is only used by the widget and doesn't need to be shared with
 // other widgets.
 
-use std::{
-    io::stdout,
-    panic,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
-use color_eyre::{config::HookBuilder, eyre, Result};
+use color_eyre::Result;
 use palette::{convert::FromColorUnclamped, Okhsv, Srgb};
 use ratatui::{
     backend::{Backend, CrosstermBackend},
@@ -257,22 +253,4 @@ impl ColorsWidget {
             self.colors.push(row);
         }
     }
-}
-
-/// Install `color_eyre` panic and error hooks
-///
-/// The hooks restore the terminal to a usable state before printing the error message.
-fn install_error_hooks() -> Result<()> {
-    let (panic, error) = HookBuilder::default().into_hooks();
-    let panic = panic.into_panic_hook();
-    let error = error.into_eyre_hook();
-    eyre::set_hook(Box::new(move |e| {
-        let _ = CrosstermBackend::reset(stdout());
-        error(e)
-    }))?;
-    panic::set_hook(Box::new(move |info| {
-        let _ = CrosstermBackend::reset(stdout());
-        panic(info);
-    }));
-    Ok(())
 }

--- a/examples/colors_rgb.rs
+++ b/examples/colors_rgb.rs
@@ -92,7 +92,6 @@ struct ColorsWidget {
 }
 
 fn main() -> Result<()> {
-    install_error_hooks()?;
     let terminal = CrosstermBackend::stdout_with_defaults()?.to_terminal()?;
     App::default().run(terminal)?;
     Ok(())

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -15,13 +15,8 @@
 
 use ratatui::{
     backend::CrosstermBackend,
-    crossterm::{
-        event::{self, Event, KeyCode, KeyEventKind},
-        execute,
-        terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-    },
+    crossterm::event::{self, Event, KeyCode, KeyEventKind},
     text::Text,
-    Terminal,
 };
 
 /// This is a bare minimum example. There are many approaches to running an application loop, so
@@ -31,9 +26,8 @@ use ratatui::{
 /// [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 /// [hello-world]: https://github.com/ratatui-org/ratatui/blob/main/examples/hello_world.rs
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut terminal = Terminal::new(CrosstermBackend::new(std::io::stdout()))?;
-    enable_raw_mode()?;
-    execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+    let mut terminal = CrosstermBackend::stdout().into_terminal_with_defaults()?;
+    terminal.clear()?;
     loop {
         terminal.draw(|frame| frame.render_widget(Text::raw("Hello World!"), frame.size()))?;
         if let Event::Key(key) = event::read()? {
@@ -42,7 +36,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     }
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     Ok(())
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -14,7 +14,7 @@
 //! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
 
 use ratatui::{
-    backend::CrosstermBackend,
+    backend::{Backend, CrosstermBackend},
     crossterm::event::{self, Event, KeyCode, KeyEventKind},
     text::Text,
 };
@@ -26,7 +26,7 @@ use ratatui::{
 /// [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
 /// [hello-world]: https://github.com/ratatui-org/ratatui/blob/main/examples/hello_world.rs
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut terminal = CrosstermBackend::stdout().into_terminal_with_defaults()?;
+    let mut terminal = CrosstermBackend::stdout_with_defaults()?.to_terminal()?;
     terminal.clear()?;
     loop {
         terminal.draw(|frame| frame.render_widget(Text::raw("Hello World!"), frame.size()))?;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -104,7 +104,11 @@ use std::io;
 
 use strum::{Display, EnumString};
 
-use crate::{buffer::Cell, layout::Size, prelude::Rect, Terminal, TerminalOptions};
+use crate::{
+    buffer::Cell,
+    layout::{Rect, Size},
+    Terminal, TerminalOptions,
+};
 
 #[cfg(feature = "termion")]
 mod termion;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -104,7 +104,7 @@ use std::io;
 
 use strum::{Display, EnumString};
 
-use crate::{buffer::Cell, layout::Size, prelude::Rect};
+use crate::{buffer::Cell, layout::Size, prelude::Rect, Terminal, TerminalOptions};
 
 #[cfg(feature = "termion")]
 mod termion;
@@ -298,6 +298,42 @@ pub trait Backend {
 
     /// Flush any buffered content to the terminal screen.
     fn flush(&mut self) -> io::Result<()>;
+
+    /// Converts the `Backend` into a [`Terminal`] instance.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use ratatui::backend::{Backend, CrosstermBackend};
+    /// let terminal = CrosstermBackend::stdout().to_terminal()?;
+    /// # std::io::Result::Ok(())
+    /// ```
+    fn to_terminal(self) -> io::Result<Terminal<Self>>
+    where
+        Self: Sized,
+    {
+        Terminal::new(self)
+    }
+
+    /// Converts the `Backend` into a [`Terminal`] instance with options.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ratatui::{backend::{Backend, CrosstermBackend}, TerminalOptions, Viewport};
+    ///
+    /// let options = TerminalOptions {
+    ///     viewport: Viewport::Inline(10),
+    /// };
+    /// let terminal = CrosstermBackend::stdout().to_terminal_with_options(options)?;
+    /// # std::io::Result::Ok(())
+    /// ```
+    fn to_terminal_with_options(self, options: TerminalOptions) -> io::Result<Terminal<Self>>
+    where
+        Self: Sized,
+    {
+        Terminal::with_options(self, options)
+    }
 }
 
 #[cfg(test)]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -324,7 +324,10 @@ pub trait Backend {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use ratatui::{backend::{Backend, CrosstermBackend}, TerminalOptions, Viewport};
+    /// use ratatui::{
+    ///     backend::{Backend, CrosstermBackend},
+    ///     TerminalOptions, Viewport,
+    /// };
     ///
     /// let options = TerminalOptions {
     ///     viewport: Viewport::Inline(10),

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -28,6 +28,7 @@ use crate::{
     },
     layout::{Rect, Size},
     style::{Color, Modifier, Style},
+    Terminal, TerminalOptions,
 };
 
 /// A [`Backend`] implementation that uses [Crossterm] to render to the terminal.

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -4,20 +4,18 @@
 //! [Crossterm]: https://crates.io/crates/crossterm
 use std::io::{self, Write};
 
-use crossterm::event::{
-    DisableBracketedPaste, DisableFocusChange, EnableBracketedPaste, EnableFocusChange,
-    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
-};
-
 #[cfg(feature = "underline-color")]
 use crate::crossterm::style::SetUnderlineColor;
-
 use crate::{
     backend::{Backend, ClearType, WindowSize},
     buffer::Cell,
     crossterm::{
         cursor::{Hide, MoveTo, Show},
-        event::{DisableMouseCapture, EnableMouseCapture},
+        event::{
+            DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+            EnableFocusChange, EnableMouseCapture, KeyboardEnhancementFlags,
+            PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+        },
         execute, queue,
         style::{
             Attribute as CAttribute, Attributes as CAttributes, Color as CColor, Colors,
@@ -60,8 +58,10 @@ use crate::{
 /// # Example
 ///
 /// ```rust,no_run
-/// use ratatui::backend::{Backend, CrosstermBackend};
-/// use crossterm::event::KeyboardEnhancementFlags;
+/// use ratatui::{
+///     backend::{Backend, CrosstermBackend},
+///     crossterm::event::KeyboardEnhancementFlags,
+/// };
 ///
 /// let mut terminal = CrosstermBackend::stdout_with_defaults()?.to_terminal()?;
 /// // or
@@ -87,6 +87,7 @@ use crate::{
 /// [Crossterm]: https://crates.io/crates/crossterm
 /// [Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples/README.md
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct CrosstermBackend<W: Write> {
     /// The writer used to send commands to the terminal.
     writer: W,
@@ -112,6 +113,7 @@ where
     ///
     /// ```rust,no_run
     /// use std::io;
+    ///
     /// use ratatui::backend::CrosstermBackend;
     ///
     /// let backend = CrosstermBackend::new(io::stdout());
@@ -317,8 +319,7 @@ impl<W: Write> CrosstermBackend<W> {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use ratatui::backend::CrosstermBackend;
-    /// use crossterm::event::KeyboardEnhancementFlags;
+    /// use ratatui::{backend::CrosstermBackend, crossterm::event::KeyboardEnhancementFlags};
     ///
     /// let backend = CrosstermBackend::stdout()
     ///     .with_keyboard_enhancement_flags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)?;
@@ -603,7 +604,6 @@ impl ModifierDiff {
     where
         W: io::Write,
     {
-        //use crossterm::Attribute;
         let removed = self.from - self.to;
         if removed.contains(Modifier::REVERSED) {
             queue!(w, SetAttribute(CAttribute::NoReverse))?;

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -2,7 +2,7 @@
 //! the [Crossterm] crate to interact with the terminal.
 //!
 //! [Crossterm]: https://crates.io/crates/crossterm
-use std::io::{self, Write};
+use std::io;
 
 #[cfg(feature = "underline-color")]
 use crate::crossterm::style::SetUnderlineColor;
@@ -88,7 +88,7 @@ use crate::{
 /// [Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples/README.md
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 #[allow(clippy::struct_excessive_bools)]
-pub struct CrosstermBackend<W: Write> {
+pub struct CrosstermBackend<W: io::Write> {
     /// The writer used to send commands to the terminal.
     writer: W,
     restore_raw_mode_on_drop: bool,
@@ -99,10 +99,7 @@ pub struct CrosstermBackend<W: Write> {
     restore_keyboard_enhancement_flags_on_drop: bool,
 }
 
-impl<W> CrosstermBackend<W>
-where
-    W: Write,
-{
+impl<W: io::Write> CrosstermBackend<W> {
     /// Creates a new `CrosstermBackend` with the given writer.
     ///
     /// Applications will typically use [`CrosstermBackend::stdout`] or [`CrosstermBackend::stderr`]
@@ -219,7 +216,7 @@ impl CrosstermBackend<io::Stderr> {
     }
 }
 
-impl<W: Write> CrosstermBackend<W> {
+impl<W: io::Write> CrosstermBackend<W> {
     /// Enables default settings for the terminal backend.
     ///
     /// This enables raw mode and switches to the alternate screen. Mouse support is not enabled.
@@ -238,12 +235,12 @@ impl<W: Write> CrosstermBackend<W> {
     /// let backend = CrosstermBackend::stdout().with_defaults()?;
     /// # std::io::Result::Ok(())
     /// ```
-    pub fn with_defaults(mut self) -> io::Result<Self> {
+    pub fn with_defaults(self) -> io::Result<Self> {
         let backend = self.with_raw_mode()?.with_alternate_screen()?;
         #[cfg(feature = "color-eyre")]
         let backend = backend.with_color_eyre_hooks()?;
         #[cfg(not(feature = "color-eyre"))]
-        let backend = backend.with_panic_hook()?;
+        let backend = backend.with_panic_hook();
         Ok(backend)
     }
 
@@ -376,7 +373,8 @@ impl<W: Write> CrosstermBackend<W> {
     /// let backend = CrosstermBackend::stdout().with_panic_hook()?;
     /// ```
     #[cfg(not(feature = "color-eyre"))]
-    pub fn with_panic_hook(self) -> io::Result<Self> {
+    #[must_use]
+    pub fn with_panic_hook(self) -> Self {
         use std::panic;
 
         let hook = panic::take_hook();
@@ -384,7 +382,7 @@ impl<W: Write> CrosstermBackend<W> {
             let _ = CrosstermBackend::reset(io::stderr());
             hook(info);
         }));
-        Ok(self)
+        self
     }
 
     /// Installs the color-eyre panic and error report hooks.
@@ -397,6 +395,7 @@ impl<W: Write> CrosstermBackend<W> {
     /// use ratatui::backend::CrosstermBackend;
     ///
     /// let backend = CrosstermBackend::stdout().with_color_eyre_hooks()?;
+    /// # std::io::Result::Ok(())
     /// ```
     #[cfg(feature = "color-eyre")]
     pub fn with_color_eyre_hooks(self) -> io::Result<Self> {
@@ -455,7 +454,7 @@ impl<W: Write> CrosstermBackend<W> {
     }
 }
 
-impl<W: Write> Drop for CrosstermBackend<W> {
+impl<W: io::Write> Drop for CrosstermBackend<W> {
     fn drop(&mut self) {
         // note that these are not checked for errors because there is nothing that can be done if
         // they fail. The terminal is likely in a bad state, and the application is exiting anyway.
@@ -481,10 +480,7 @@ impl<W: Write> Drop for CrosstermBackend<W> {
     }
 }
 
-impl<W> Write for CrosstermBackend<W>
-where
-    W: Write,
-{
+impl<W: io::Write> io::Write for CrosstermBackend<W> {
     /// Writes a buffer of bytes to the underlying buffer.
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.writer.write(buf)
@@ -496,10 +492,7 @@ where
     }
 }
 
-impl<W> Backend for CrosstermBackend<W>
-where
-    W: Write,
-{
+impl<W: io::Write> Backend for CrosstermBackend<W> {
     fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
@@ -687,10 +680,7 @@ struct ModifierDiff {
 }
 
 impl ModifierDiff {
-    fn queue<W>(self, mut w: W) -> io::Result<()>
-    where
-        W: io::Write,
-    {
+    fn queue<W: io::Write>(self, mut w: W) -> io::Result<()> {
         let removed = self.from - self.to;
         if removed.contains(Modifier::REVERSED) {
             queue!(w, SetAttribute(CAttribute::NoReverse))?;

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -28,7 +28,6 @@ use crate::{
     },
     layout::{Rect, Size},
     style::{Color, Modifier, Style},
-    Terminal, TerminalOptions,
 };
 
 /// A [`Backend`] implementation that uses [Crossterm] to render to the terminal.
@@ -181,7 +180,7 @@ impl CrosstermBackend<io::Stdout> {
     /// # std::io::Result::Ok(())
     /// ```
     pub fn stdout_with_defaults() -> io::Result<Self> {
-        Self::stdout().with_raw_mode()?.with_alternate_screen()
+        Self::stdout().with_defaults()
     }
 }
 
@@ -216,14 +215,38 @@ impl CrosstermBackend<io::Stderr> {
     /// # std::io::Result::Ok(())
     /// ```
     pub fn stderr_with_defaults() -> io::Result<Self> {
-        let backend = Self::stderr().with_raw_mode()?.with_alternate_screen()?;
-        #[cfg(feature = "color-eyre")]
-        let backend = backend.with_color_eyre_hooks()?;
-        Ok(backend)
+        Self::stderr().with_defaults()
     }
 }
 
 impl<W: Write> CrosstermBackend<W> {
+    /// Enables default settings for the terminal backend.
+    ///
+    /// This enables raw mode and switches to the alternate screen. Mouse support is not enabled.
+    ///
+    /// If the `color-eyre` feature is enabled, the color-eyre panic and error report hooks are
+    /// installed. Otherwise, a panic hook is installed that resets the terminal to its default
+    /// state before panicking.
+    ///
+    /// Returns an [`io::Result`] containing self so that it can be chained with other methods.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ratatui::backend::CrosstermBackend;
+    ///
+    /// let backend = CrosstermBackend::stdout().with_defaults()?;
+    /// # std::io::Result::Ok(())
+    /// ```
+    pub fn with_defaults(mut self) -> io::Result<Self> {
+        let backend = self.with_raw_mode()?.with_alternate_screen()?;
+        #[cfg(feature = "color-eyre")]
+        let backend = backend.with_color_eyre_hooks()?;
+        #[cfg(not(feature = "color-eyre"))]
+        let backend = backend.with_panic_hook()?;
+        Ok(backend)
+    }
+
     /// Enables raw mode for the terminal.
     ///
     /// Returns an [`io::Result`] containing self so that it can be chained with other methods.
@@ -341,6 +364,29 @@ impl<W: Write> CrosstermBackend<W> {
         Ok(self)
     }
 
+    /// Installs a panic hook that resets the terminal to its default state before panicking.
+    ///
+    /// This is a convenience method that sets up the panic hook for the terminal backend.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ratatui::backend::CrosstermBackend;
+    ///
+    /// let backend = CrosstermBackend::stdout().with_panic_hook()?;
+    /// ```
+    #[cfg(not(feature = "color-eyre"))]
+    pub fn with_panic_hook(self) -> io::Result<Self> {
+        use std::panic;
+
+        let hook = panic::take_hook();
+        panic::set_hook(Box::new(move |info| {
+            let _ = CrosstermBackend::reset(io::stderr());
+            hook(info);
+        }));
+        Ok(self)
+    }
+
     /// Installs the color-eyre panic and error report hooks.
     ///
     /// This is a convenience method that sets up the color-eyre hooks for the terminal backend.
@@ -353,7 +399,7 @@ impl<W: Write> CrosstermBackend<W> {
     /// let backend = CrosstermBackend::stdout().with_color_eyre_hooks()?;
     /// ```
     #[cfg(feature = "color-eyre")]
-    pub fn with_color_eyre_hooks(self) -> color_eyre::Result<Self> {
+    pub fn with_color_eyre_hooks(self) -> io::Result<Self> {
         use std::{io::stderr, panic};
 
         use color_eyre::{config::HookBuilder, eyre};
@@ -365,7 +411,8 @@ impl<W: Write> CrosstermBackend<W> {
             // ignore errors here because we are already in an error state
             let _ = CrosstermBackend::reset(stderr());
             error(e)
-        }))?;
+        }))
+        .map_err(|error| io::Error::other(error))?;
         panic::set_hook(Box::new(move |info| {
             // ignore errors here because we are already in an error state
             let _ = CrosstermBackend::reset(stderr());

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -204,6 +204,9 @@ impl CrosstermBackend<io::Stderr> {
     ///
     /// Raw mode and alternate screen are restored when the `CrosstermBackend` is dropped.
     ///
+    /// If the `color-eyre` feature is enabled, the color-eyre panic and error report hooks are
+    /// installed.
+    ///
     /// # Example
     ///
     /// ```rust,no_run
@@ -213,7 +216,10 @@ impl CrosstermBackend<io::Stderr> {
     /// # std::io::Result::Ok(())
     /// ```
     pub fn stderr_with_defaults() -> io::Result<Self> {
-        Self::stderr().with_raw_mode()?.with_alternate_screen()
+        let backend = Self::stderr().with_raw_mode()?.with_alternate_screen()?;
+        #[cfg(feature = "color-eyre")]
+        let backend = backend.with_color_eyre_hooks()?;
+        Ok(backend)
     }
 }
 
@@ -332,6 +338,39 @@ impl<W: Write> CrosstermBackend<W> {
     ) -> io::Result<Self> {
         execute!(self.writer, PushKeyboardEnhancementFlags(flags))?;
         self.restore_keyboard_enhancement_flags_on_drop = true;
+        Ok(self)
+    }
+
+    /// Installs the color-eyre panic and error report hooks.
+    ///
+    /// This is a convenience method that sets up the color-eyre hooks for the terminal backend.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use ratatui::backend::CrosstermBackend;
+    ///
+    /// let backend = CrosstermBackend::stdout().with_color_eyre_hooks()?;
+    /// ```
+    #[cfg(feature = "color-eyre")]
+    pub fn with_color_eyre_hooks(self) -> color_eyre::Result<Self> {
+        use std::{io::stderr, panic};
+
+        use color_eyre::{config::HookBuilder, eyre};
+
+        let (panic, error) = HookBuilder::default().into_hooks();
+        let panic = panic.into_panic_hook();
+        let error = error.into_eyre_hook();
+        eyre::set_hook(Box::new(move |e| {
+            // ignore errors here because we are already in an error state
+            let _ = CrosstermBackend::reset(stderr());
+            error(e)
+        }))?;
+        panic::set_hook(Box::new(move |info| {
+            // ignore errors here because we are already in an error state
+            let _ = CrosstermBackend::reset(stderr());
+            panic(info);
+        }));
         Ok(self)
     }
 


### PR DESCRIPTION
Apps can now enable color-eyre hooks using the with_color_eyre_hooks
method on CrosstermBackend. This is also added to the default features
in the Cargo.toml file, and the defaults that are applied to terminals
created using CrosstermBackend::into_terminal_with_defaults.
