### PR TITLE
chore: rename ratatui-org to ratatui

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,11 @@
-# See https://help.github.com/articles/about-codeowners/
+# See <https://help.github.com/articles/about-codeowners/>
+
 # for more info about CODEOWNERS file
 
 # It uses the same pattern rule for gitignore file
-# https://git-scm.com/docs/gitignore#_pattern_format
+
+# <https://git-scm.com/docs/gitignore#_pattern_format>
 
 # Maintainers
-* @ratatui-org/maintainers
+
+* @ratatui/maintainers

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -4,7 +4,7 @@ This document contains a list of breaking changes in each version and some notes
 between versions. It is compiled manually from the commit history and changelog. We also tag PRs on
 GitHub with a [breaking change] label.
 
-[breaking change]: (https://github.com/ratatui-org/ratatui/issues?q=label%3A%22breaking+change%22)
+[breaking change]: (https://github.com/ratatui/ratatui/issues?q=label%3A%22breaking+change%22)
 
 ## Summary
 
@@ -69,14 +69,14 @@ This is a quick summary of the sections below:
 
 ### `Backend::size` returns `Size` instead of `Rect` ([#1254])
 
-[#1254]: https://github.com/ratatui-org/ratatui/pull/1254
+[#1254]: https://github.com/ratatui/ratatui/pull/1254
 
 The `Backend::size` method returns a `Size` instead of a `Rect`.
 There is no need for the position here as it was always 0,0.
 
 ### `Backend` trait migrates to `get/set_cursor_position` ([#1284])
 
-[#1284]: https://github.com/ratatui-org/ratatui/pull/1284
+[#1284]: https://github.com/ratatui/ratatui/pull/1284
 
 If you just use the types implementing the `Backend` trait, you will see deprecation hints but
 nothing is a breaking change for you.
@@ -87,7 +87,7 @@ and a default implementation for them exists.
 
 ### Ratatui now requires Crossterm 0.28.0 ([#1278])
 
-[#1278]: https://github.com/ratatui-org/ratatui/pull/1278
+[#1278]: https://github.com/ratatui/ratatui/pull/1278
 
 Crossterm is updated to version 0.28.0, which is a semver incompatible version with the previous
 version (0.27.0). Ratatui re-exports the version of crossterm that it is compatible with under
@@ -95,8 +95,8 @@ version (0.27.0). Ratatui re-exports the version of crossterm that it is compati
 
 ### `Axis::labels()` now accepts `IntoIterator<Into<Line>>` ([#1273] and [#1283])
 
-[#1273]: https://github.com/ratatui-org/ratatui/pull/1173
-[#1283]: https://github.com/ratatui-org/ratatui/pull/1283
+[#1273]: https://github.com/ratatui/ratatui/pull/1173
+[#1283]: https://github.com/ratatui/ratatui/pull/1283
 
 Previously Axis::labels accepted `Vec<Span>`. Any code that uses conversion methods that infer the
 type will need to be rewritten as the compiler cannot infer the correct type.
@@ -108,7 +108,7 @@ type will need to be rewritten as the compiler cannot infer the correct type.
 
 ### `Layout::init_cache` no longer returns bool and takes a `NonZeroUsize` instead of `usize` ([#1245])
 
-[#1245]: https://github.com/ratatui-org/ratatui/pull/1245
+[#1245]: https://github.com/ratatui/ratatui/pull/1245
 
 ```diff
 - let is_initialized = Layout::init_cache(100);
@@ -117,7 +117,7 @@ type will need to be rewritten as the compiler cannot infer the correct type.
 
 ### `ratatui::terminal` module is now private ([#1160])
 
-[#1160]: https://github.com/ratatui-org/ratatui/pull/1160
+[#1160]: https://github.com/ratatui/ratatui/pull/1160
 
 The `terminal` module is now private and can not be used directly. The types under this module are
 exported from the root of the crate. This reduces clashes with other modules in the backends that
@@ -130,21 +130,21 @@ are also named terminal, and confusion about module exports for newer Rust users
 
 ### `ToText` no longer has a lifetime ([#1234])
 
-[#1234]: https://github.com/ratatui-org/ratatui/pull/1234
+[#1234]: https://github.com/ratatui/ratatui/pull/1234
 
 This change simplifies the trait and makes it easier to implement.
 
 ### `Frame::size` is deprecated and renamed to `Frame::area`
 
-[#1293]: https://github.com/ratatui-org/ratatui/pull/1293
+[#1293]: https://github.com/ratatui/ratatui/pull/1293
 
 `Frame::size` is renamed to `Frame::area` as it's the more correct name.
 
-## [v0.27.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.27.0)
+## [v0.27.0](https://github.com/ratatui/ratatui/releases/tag/v0.27.0)
 
 ### List no clamps the selected index to list ([#1159])
 
-[#1149]: https://github.com/ratatui-org/ratatui/pull/1149
+[#1149]: https://github.com/ratatui/ratatui/pull/1149
 
 The `List` widget now clamps the selected index to the bounds of the list when navigating with
 `first`, `last`, `previous`, and `next`, as well as when setting the index directly with `select`.
@@ -205,11 +205,11 @@ A change is only necessary if you were matching on all variants of the `MouseEve
 wildcard. In this case, you need to either handle the two new variants, `MouseLeft` and
 `MouseRight`, or add a wildcard.
 
-[#1106]: https://github.com/ratatui-org/ratatui/pull/1106
+[#1106]: https://github.com/ratatui/ratatui/pull/1106
 
 ### `Rect::inner` takes `Margin` directly instead of reference ([#1008])
 
-[#1008]: https://github.com/ratatui-org/ratatui/pull/1008
+[#1008]: https://github.com/ratatui/ratatui/pull/1008
 
 `Margin` needs to be passed without reference now.
 
@@ -223,7 +223,7 @@ wildcard. In this case, you need to either handle the two new variants, `MouseLe
 
 ### `Buffer::filled` takes `Cell` directly instead of reference ([#1148])
 
-[#1148]: https://github.com/ratatui-org/ratatui/pull/1148
+[#1148]: https://github.com/ratatui/ratatui/pull/1148
 
 `Buffer::filled` moves the `Cell` instead of taking a reference.
 
@@ -234,14 +234,14 @@ wildcard. In this case, you need to either handle the two new variants, `MouseLe
 
 ### `Stylize::bg()` now accepts `Into<Color>` ([#1103])
 
-[#1103]: https://github.com/ratatui-org/ratatui/pull/1103
+[#1103]: https://github.com/ratatui/ratatui/pull/1103
 
 Previously, `Stylize::bg()` accepted `Color` but now accepts `Into<Color>`. This allows more
 flexible types from calling scopes, though it can break some type inference in the calling scope.
 
 ### Remove deprecated `List::start_corner` and `layout::Corner` ([#759])
 
-[#759]: https://github.com/ratatui-org/ratatui/pull/759
+[#759]: https://github.com/ratatui/ratatui/pull/759
 
 `List::start_corner` was deprecated in v0.25. Use `List::direction` and `ListDirection` instead.
 
@@ -264,7 +264,7 @@ flexible types from calling scopes, though it can break some type inference in t
 
 ### `LineGauge::gauge_style` is deprecated ([#565])
 
-[#565]: https://github.com/ratatui-org/ratatui/pull/1148
+[#565]: https://github.com/ratatui/ratatui/pull/1148
 
 `LineGauge::gauge_style` is deprecated and replaced with `LineGauge::filled_style` and `LineGauge::unfilled_style`:
 
@@ -275,11 +275,11 @@ let gauge = LineGauge::default()
 + .unfilled_style(Style::default().fg(Color::White));
 ```
 
-## [v0.26.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.26.0)
+## [v0.26.0](https://github.com/ratatui/ratatui/releases/tag/v0.26.0)
 
 ### `Flex::Start` is the new default flex mode for `Layout` ([#881])
 
-[#881]: https://github.com/ratatui-org/ratatui/pull/881
+[#881]: https://github.com/ratatui/ratatui/pull/881
 
 Previously, constraints would stretch to fill all available space, violating constraints if
 necessary.
@@ -300,7 +300,7 @@ existing layouts with `Flex::Start`. However, to get old behavior, use `Flex::Le
 
 ### `Table::new()` now accepts `IntoIterator<Item: Into<Row<'a>>>` ([#774])
 
-[#774]: https://github.com/ratatui-org/ratatui/pull/774
+[#774]: https://github.com/ratatui/ratatui/pull/774
 
 Previously, `Table::new()` accepted `IntoIterator<Item=Row<'a>>`. The argument change to
 `IntoIterator<Item: Into<Row<'a>>>`, This allows more flexible types from calling scopes, though it
@@ -317,7 +317,7 @@ This can be resolved either by providing an explicit type (e.g. `Vec::<Row>::new
 
 ### `Tabs::new()` now accepts `IntoIterator<Item: Into<Line<'a>>>` ([#776])
 
-[#776]: https://github.com/ratatui-org/ratatui/pull/776
+[#776]: https://github.com/ratatui/ratatui/pull/776
 
 Previously, `Tabs::new()` accepted `Vec<T>` where `T: Into<Line<'a>>`. This allows more flexible
 types from calling scopes, though it can break some type inference in the calling scope.
@@ -333,7 +333,7 @@ by removing the call to `.collect()`.
 
 ### Table::default() now sets segment_size to None and column_spacing to ([#751])
 
-[#751]: https://github.com/ratatui-org/ratatui/pull/751
+[#751]: https://github.com/ratatui/ratatui/pull/751
 
 The default() implementation of Table now sets the column_spacing field to 1 and the segment_size
 field to `SegmentSize::None`. This will affect the rendering of a small amount of apps.
@@ -343,7 +343,7 @@ To use the previous default values, call `table.segment_size(Default::default())
 
 ### `patch_style` & `reset_style` now consumes and returns `Self` ([#754])
 
-[#754]: https://github.com/ratatui-org/ratatui/pull/754
+[#754]: https://github.com/ratatui/ratatui/pull/754
 
 Previously, `patch_style` and `reset_style` in `Text`, `Line` and `Span` were using a mutable
 reference to `Self`. To be more consistent with the rest of `ratatui`, which is using fluent
@@ -369,7 +369,7 @@ The following example shows how to migrate for `Line`, but the same applies for 
 
 ### `Block` style methods cannot be used in a const context ([#720])
 
-[#720]: https://github.com/ratatui-org/ratatui/pull/720
+[#720]: https://github.com/ratatui/ratatui/pull/720
 
 Previously the `style()`, `border_style()` and `title_style()` methods could be used to create a
 `Block` in a constant context. These now accept `Into<Style>` instead of `Style`. These methods no
@@ -377,7 +377,7 @@ longer can be called from a constant context.
 
 ### `Line` now has a `style` field that applies to the entire line ([#708])
 
-[#708]: https://github.com/ratatui-org/ratatui/pull/708
+[#708]: https://github.com/ratatui/ratatui/pull/708
 
 Previously the style of a `Line` was stored in the `Span`s that make up the line. Now the `Line`
 itself has a `style` field, which can be set with the `Line::styled` method. Any code that creates
@@ -401,11 +401,11 @@ the `Span::style` field.
       .alignment(Alignment::Left);
 ```
 
-## [v0.25.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.25.0)
+## [v0.25.0](https://github.com/ratatui/ratatui/releases/tag/v0.25.0)
 
 ### Removed `Axis::title_style` and `Buffer::set_background` ([#691])
 
-[#691]: https://github.com/ratatui-org/ratatui/pull/691
+[#691]: https://github.com/ratatui/ratatui/pull/691
 
 These items were deprecated since 0.10.
 
@@ -419,7 +419,7 @@ These items were deprecated since 0.10.
 
 ### `List::new()` now accepts `IntoIterator<Item = Into<ListItem<'a>>>` ([#672])
 
-[#672]: https://github.com/ratatui-org/ratatui/pull/672
+[#672]: https://github.com/ratatui/ratatui/pull/672
 
 Previously `List::new()` took `Into<Vec<ListItem<'a>>>`. This change will throw a compilation
 error for `IntoIterator`s with an indeterminate item (e.g. empty vecs).
@@ -434,7 +434,7 @@ E.g.
 
 ### The default `Tabs::highlight_style` is now `Style::new().reversed()` ([#635])
 
-[#635]: https://github.com/ratatui-org/ratatui/pull/635
+[#635]: https://github.com/ratatui/ratatui/pull/635
 
 Previously the default highlight style for tabs was `Style::default()`, which meant that a `Tabs`
 widget in the default configuration would not show any indication of the selected tab.
@@ -446,7 +446,7 @@ widget in the default configuration would not show any indication of the selecte
 
 ### `Table::new()` now requires specifying the widths of the columns ([#664])
 
-[#664]: https://github.com/ratatui-org/ratatui/pull/664
+[#664]: https://github.com/ratatui/ratatui/pull/664
 
 Previously `Table`s could be constructed without `widths`. In almost all cases this is an error.
 A new `widths` parameter is now mandatory on `Table::new()`. Existing code of the form:
@@ -472,7 +472,7 @@ or complex, it may be convenient to replace `Table::new` with `Table::default().
 
 ### `Table::widths()` now accepts `IntoIterator<Item = AsRef<Constraint>>` ([#663])
 
-[#663]: https://github.com/ratatui-org/ratatui/pull/663
+[#663]: https://github.com/ratatui/ratatui/pull/663
 
 Previously `Table::widths()` took a slice (`&'a [Constraint]`). This change will introduce clippy
 `needless_borrow` warnings for places where slices are passed to this method. To fix these, remove
@@ -488,7 +488,7 @@ E.g.
 
 ### Layout::new() now accepts direction and constraint parameters ([#557])
 
-[#557]: https://github.com/ratatui-org/ratatui/pull/557
+[#557]: https://github.com/ratatui/ratatui/pull/557
 
 Previously layout new took no parameters. Existing code should either use `Layout::default()` or
 the new constructor.
@@ -505,18 +505,18 @@ let layout = layout::default()
 let layout = layout::new(Direction::Vertical, [Constraint::Min(1), Constraint::Max(2)]);
 ```
 
-## [v0.24.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.24.0)
+## [v0.24.0](https://github.com/ratatui/ratatui/releases/tag/v0.24.0)
 
 ### `ScrollbarState` field type changed from `u16` to `usize` ([#456])
 
-[#456]: https://github.com/ratatui-org/ratatui/pull/456
+[#456]: https://github.com/ratatui/ratatui/pull/456
 
 In order to support larger content lengths, the `position`, `content_length` and
 `viewport_content_length` methods on `ScrollbarState` now take `usize` instead of `u16`
 
 ### `BorderType::line_symbols` renamed to `border_symbols` ([#529])
 
-[#529]: https://github.com/ratatui-org/ratatui/issues/529
+[#529]: https://github.com/ratatui/ratatui/issues/529
 
 Applications can now set custom borders on a `Block` by calling `border_set()`. The
 `BorderType::line_symbols()` is renamed to `border_symbols()` and now returns a new struct
@@ -530,7 +530,7 @@ Applications can now set custom borders on a `Block` by calling `border_set()`. 
 
 ### Generic `Backend` parameter removed from `Frame` ([#530])
 
-[#530]: https://github.com/ratatui-org/ratatui/issues/530
+[#530]: https://github.com/ratatui/ratatui/issues/530
 
 `Frame` is no longer generic over Backend. Code that accepted `Frame<Backend>` will now need to
 accept `Frame`. To migrate existing code, remove any generic parameters from code that uses an
@@ -544,7 +544,7 @@ instance of a Frame. E.g.:
 
 ### `Stylize` shorthands now consume rather than borrow `String` ([#466])
 
-[#466]: https://github.com/ratatui-org/ratatui/issues/466
+[#466]: https://github.com/ratatui/ratatui/issues/466
 
 In order to support using `Stylize` shorthands (e.g. `"foo".red()`) on temporary `String` values, a
 new implementation of `Stylize` was added that returns a `Span<'static>`. This causes the value to
@@ -562,7 +562,7 @@ longer compile. E.g.
 
 ### Deprecated `Spans` type removed (replaced with `Line`) ([#426])
 
-[#426]: https://github.com/ratatui-org/ratatui/issues/426
+[#426]: https://github.com/ratatui/ratatui/issues/426
 
 `Spans` was replaced with `Line` in 0.21.0. `Buffer::set_spans` was replaced with
 `Buffer::set_line`.
@@ -575,11 +575,11 @@ longer compile. E.g.
 + buffer.set_line(0, 0, line, 10);
 ```
 
-## [v0.23.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.23.0)
+## [v0.23.0](https://github.com/ratatui/ratatui/releases/tag/v0.23.0)
 
 ### `Scrollbar::track_symbol()` now takes an `Option<&str>` instead of `&str` ([#360])
 
-[#360]: https://github.com/ratatui-org/ratatui/issues/360
+[#360]: https://github.com/ratatui/ratatui/issues/360
 
 The track symbol of `Scrollbar` is now optional, this method now takes an optional value.
 
@@ -591,7 +591,7 @@ The track symbol of `Scrollbar` is now optional, this method now takes an option
 
 ### `Scrollbar` symbols moved to `symbols::scrollbar` and `widgets::scrollbar` module is private ([#330])
 
-[#330]: https://github.com/ratatui-org/ratatui/issues/330
+[#330]: https://github.com/ratatui/ratatui/issues/330
 
 The symbols for defining scrollbars have been moved to the `symbols` module from the
 `widgets::scrollbar` module which is no longer public. To update your code update any imports to the
@@ -605,31 +605,31 @@ new module locations. E.g.:
 
 ### MSRV updated to 1.67 ([#361])
 
-[#361]: https://github.com/ratatui-org/ratatui/issues/361
+[#361]: https://github.com/ratatui/ratatui/issues/361
 
 The MSRV of ratatui is now 1.67 due to an MSRV update in a dependency (`time`).
 
-## [v0.22.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.22.0)
+## [v0.22.0](https://github.com/ratatui/ratatui/releases/tag/v0.22.0)
 
 ### `bitflags` updated to 2.3 ([#205])
 
-[#205]: https://github.com/ratatui-org/ratatui/issues/205
+[#205]: https://github.com/ratatui/ratatui/issues/205
 
 The `serde` representation of `bitflags` has changed. Any existing serialized types that have
 Borders or Modifiers will need to be re-serialized. This is documented in the [`bitflags`
 changelog](https://github.com/bitflags/bitflags/blob/main/CHANGELOG.md#200-rc2)..
 
-## [v0.21.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.21.0)
+## [v0.21.0](https://github.com/ratatui/ratatui/releases/tag/v0.21.0)
 
 ### MSRV is 1.65.0 ([#171])
 
-[#171]: https://github.com/ratatui-org/ratatui/issues/171
+[#171]: https://github.com/ratatui/ratatui/issues/171
 
 The minimum supported rust version is now 1.65.0.
 
 ### `Terminal::with_options()` stabilized to allow configuring the viewport ([#114])
 
-[#114]: https://github.com/ratatui-org/ratatui/issues/114
+[#114]: https://github.com/ratatui/ratatui/issues/114
 
 In order to support inline viewports, the unstable method `Terminal::with_options()` was stabilized
 and `ViewPort` was changed from a struct to an enum.
@@ -646,7 +646,7 @@ let terminal = Terminal::with_options(backend, TerminalOptions {
 
 ### Code that binds `Into<Text<'a>>` now requires type annotations ([#168])
 
-[#168]: https://github.com/ratatui-org/ratatui/issues/168
+[#168]: https://github.com/ratatui/ratatui/issues/168
 
 A new type `Masked` was introduced that implements `From<Text<'a>>`. This causes any code that
 previously did not need to use type annotations to fail to compile. To fix this, annotate or call
@@ -660,7 +660,7 @@ previously did not need to use type annotations to fail to compile. To fix this,
 
 ### `Marker::Block` now renders as a block rather than a bar character ([#133])
 
-[#133]: https://github.com/ratatui-org/ratatui/issues/133
+[#133]: https://github.com/ratatui/ratatui/issues/133
 
 Code using the `Block` marker that previously rendered using a half block character (`'▀'``) now
 renders using the full block character (`'█'`). A new marker variant`Bar` is introduced to replace
@@ -672,20 +672,20 @@ the existing code.
 + let canvas = Canvas::default().marker(Marker::Bar);
 ```
 
-## [v0.20.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.20.0)
+## [v0.20.0](https://github.com/ratatui/ratatui/releases/tag/v0.20.0)
 
 v0.20.0 was the first release of Ratatui - versions prior to this were release as tui-rs. See the
 [Changelog](./CHANGELOG.md) for more details.
 
 ### MSRV is update to 1.63.0 ([#80])
 
-[#80]: https://github.com/ratatui-org/ratatui/issues/80
+[#80]: https://github.com/ratatui/ratatui/issues/80
 
 The minimum supported rust version is 1.63.0
 
 ### List no longer ignores empty string in items ([#42])
 
-[#42]: https://github.com/ratatui-org/ratatui/issues/42
+[#42]: https://github.com/ratatui/ratatui/issues/42
 
 The following code now renders 3 items instead of 2. Code which relies on the previous behavior will
 need to manually filter empty items prior to display.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.28.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.28.0) - 2024-08-07
+## [0.28.0](https://github.com/ratatui/ratatui/releases/tag/v0.28.0) - 2024-08-07
 
 _"If you are what you eat, then I only want to eat the good stuff." – Remy_
 
@@ -14,15 +14,15 @@ We have also refined the terminal module and added brand new methods for cursor 
 
 ✨ **Release highlights**: <https://ratatui.rs/highlights/v028/>
 
-⚠️ List of breaking changes can be found [here](https://github.com/ratatui-org/ratatui/blob/main/BREAKING-CHANGES.md).
+⚠️ List of breaking changes can be found [here](https://github.com/ratatui/ratatui/blob/main/BREAKING-CHANGES.md).
 
 ### Features
 
-- [8d4a102](https://github.com/ratatui-org/ratatui/commit/8d4a1026ab410a52570737c6d62edcd0a205091e) *(barchart)* Allow axes to accept Lines by @joshka in [#1273](https://github.com/ratatui-org/ratatui/pull/1273) [**breaking**]
+- [8d4a102](https://github.com/ratatui/ratatui/commit/8d4a1026ab410a52570737c6d62edcd0a205091e) _(barchart)_ Allow axes to accept Lines by @joshka in [#1273](https://github.com/ratatui/ratatui/pull/1273) [**breaking**]
   >
-  > Fixes:https://github.com/ratatui-org/ratatui/issues/1272
+  > Fixes:<https://github.com/ratatui/ratatui/issues/1272>
 
-- [a23ecd9](https://github.com/ratatui-org/ratatui/commit/a23ecd9b456ab2aa4dc858fe31461a6224b40fe3) *(buffer)* Add Buffer::cell, cell_mut and index implementations by @joshka in [#1084](https://github.com/ratatui-org/ratatui/pull/1084)
+- [a23ecd9](https://github.com/ratatui/ratatui/commit/a23ecd9b456ab2aa4dc858fe31461a6224b40fe3) _(buffer)_ Add Buffer::cell, cell_mut and index implementations by @joshka in [#1084](https://github.com/ratatui/ratatui/pull/1084)
 
   > Code which previously called `buf.get(x, y)` or `buf.get_mut(x, y)`
   > should now use index operators, or be transitioned to `buff.cell()` or
@@ -53,39 +53,39 @@ We have also refined the terminal module and added brand new methods for cursor 
   > the buffer for a longer time than our normal deprecation approach (2
   > major release)
   >
-  > Addresses part of: https://github.com/ratatui-org/ratatui/issues/1011
+  > Addresses part of: <https://github.com/ratatui/ratatui/issues/1011>
   >
   > ---------
 
-- [afe1534](https://github.com/ratatui-org/ratatui/commit/afe15349c87efefc5c9f0385f8f145f4b9c42c0a) *(chart)* Accept `IntoIterator` for axis labels by @EdJoPaTo in [#1283](https://github.com/ratatui-org/ratatui/pull/1283) [**breaking**]
+- [afe1534](https://github.com/ratatui/ratatui/commit/afe15349c87efefc5c9f0385f8f145f4b9c42c0a) _(chart)_ Accept `IntoIterator` for axis labels by @EdJoPaTo in [#1283](https://github.com/ratatui/ratatui/pull/1283) [**breaking**]
 
   > BREAKING CHANGES: #1273 is already breaking and this only advances the
   > already breaking part
 
-- [5b51018](https://github.com/ratatui-org/ratatui/commit/5b51018501c859d4e6ee0ff55e010310bda5511f) *(chart)* Add GraphType::Bar by @joshka in [#1205](https://github.com/ratatui-org/ratatui/pull/1205)
+- [5b51018](https://github.com/ratatui/ratatui/commit/5b51018501c859d4e6ee0ff55e010310bda5511f) _(chart)_ Add GraphType::Bar by @joshka in [#1205](https://github.com/ratatui/ratatui/pull/1205)
 
   > ![Demo](https://vhs.charm.sh/vhs-50v7I5n7lQF7tHCb1VCmFc.gif)
 
-- [f97e07c](https://github.com/ratatui-org/ratatui/commit/f97e07c08a332e257efabdbe3f8bb306aec2a8eb) *(frame)* Replace Frame::size() with Frame::area() by @EdJoPaTo in [#1293](https://github.com/ratatui-org/ratatui/pull/1293)
+- [f97e07c](https://github.com/ratatui/ratatui/commit/f97e07c08a332e257efabdbe3f8bb306aec2a8eb) _(frame)_ Replace Frame::size() with Frame::area() by @EdJoPaTo in [#1293](https://github.com/ratatui/ratatui/pull/1293)
 
   > Area is the more correct term for the result of this method.
   > The Frame::size() method is marked as deprecated and will be
   > removed around Ratatui version 0.30 or later.
   >
-  > Fixes:https://github.com/ratatui-org/ratatui/pull/1254#issuecomment-2268061409
+  > Fixes:<https://github.com/ratatui/ratatui/pull/1254#issuecomment-2268061409>
 
-- [5b89bd0](https://github.com/ratatui-org/ratatui/commit/5b89bd04a8a4860dc5040150464b45d1909184db) *(layout)* Add Size::ZERO and Position::ORIGIN constants by @EdJoPaTo in [#1253](https://github.com/ratatui-org/ratatui/pull/1253)
+- [5b89bd0](https://github.com/ratatui/ratatui/commit/5b89bd04a8a4860dc5040150464b45d1909184db) _(layout)_ Add Size::ZERO and Position::ORIGIN constants by @EdJoPaTo in [#1253](https://github.com/ratatui/ratatui/pull/1253)
 
-- [b2aa843](https://github.com/ratatui-org/ratatui/commit/b2aa843b310d8df77d16670c302b247fc0315372) *(layout)* Enable serde for Margin, Position, Rect, Size by @EdJoPaTo in [#1255](https://github.com/ratatui-org/ratatui/pull/1255)
+- [b2aa843](https://github.com/ratatui/ratatui/commit/b2aa843b310d8df77d16670c302b247fc0315372) _(layout)_ Enable serde for Margin, Position, Rect, Size by @EdJoPaTo in [#1255](https://github.com/ratatui/ratatui/pull/1255)
 
-- [36d49e5](https://github.com/ratatui-org/ratatui/commit/36d49e549b9e19e87e71c23afaee274fa7415fde) *(table)* Select first, last, etc to table state by @robertpsoane in [#1198](https://github.com/ratatui-org/ratatui/pull/1198)
+- [36d49e5](https://github.com/ratatui/ratatui/commit/36d49e549b9e19e87e71c23afaee274fa7415fde) _(table)_ Select first, last, etc to table state by @robertpsoane in [#1198](https://github.com/ratatui/ratatui/pull/1198)
 
   > Add select_previous, select_next, select_first & select_last to
   > TableState
   >
   > Used equivalent API as in ListState
 
-- [3bb374d](https://github.com/ratatui-org/ratatui/commit/3bb374df88c79429767d9eb788bda2e65b3ba412) *(terminal)* Add Terminal::try_draw() method by @joshka in [#1209](https://github.com/ratatui-org/ratatui/pull/1209)
+- [3bb374d](https://github.com/ratatui/ratatui/commit/3bb374df88c79429767d9eb788bda2e65b3ba412) _(terminal)_ Add Terminal::try_draw() method by @joshka in [#1209](https://github.com/ratatui/ratatui/pull/1209)
 
   > This makes it easier to write fallible rendering methods that can use
   > the `?` operator
@@ -98,7 +98,7 @@ We have also refined the terminal module and added brand new methods for cursor 
   > })?;
   > ```
 
-- [3725262](https://github.com/ratatui-org/ratatui/commit/3725262ca384d28a46e03013023a19677b5a35fe) *(text)* Add `Add` and `AddAssign` implementations for `Line`, `Span`, and `Text` by @joshka in [#1236](https://github.com/ratatui-org/ratatui/pull/1236)
+- [3725262](https://github.com/ratatui/ratatui/commit/3725262ca384d28a46e03013023a19677b5a35fe) _(text)_ Add `Add` and `AddAssign` implementations for `Line`, `Span`, and `Text` by @joshka in [#1236](https://github.com/ratatui/ratatui/pull/1236)
 
   > This enables:
   >
@@ -118,12 +118,12 @@ We have also refined the terminal module and added brand new methods for cursor 
   > line.extend(vec![Span::raw("1"), Span::raw("2"), Span::raw("3")]);
   > ```
 
-- [c34fb77](https://github.com/ratatui-org/ratatui/commit/c34fb778183b8360ac0a273af16c695c33632b39) *(text)* Remove unnecessary lifetime from ToText trait by @joshka in [#1234](https://github.com/ratatui-org/ratatui/pull/1234) [**breaking**]
+- [c34fb77](https://github.com/ratatui/ratatui/commit/c34fb778183b8360ac0a273af16c695c33632b39) _(text)_ Remove unnecessary lifetime from ToText trait by @joshka in [#1234](https://github.com/ratatui/ratatui/pull/1234) [**breaking**]
   >
   > BREAKING CHANGE:The ToText trait no longer has a lifetime parameter.
   > This change simplifies the trait and makes it easier implement.
 
-- [c68ee6c](https://github.com/ratatui-org/ratatui/commit/c68ee6c64a7c48955a7b26db1db57f8427e35e5c) *(uncategorized)* Add `get/set_cursor_position()` methods to Terminal and Backend by @EdJoPaTo in [#1284](https://github.com/ratatui-org/ratatui/pull/1284) [**breaking**]
+- [c68ee6c](https://github.com/ratatui/ratatui/commit/c68ee6c64a7c48955a7b26db1db57f8427e35e5c) _(uncategorized)_ Add `get/set_cursor_position()` methods to Terminal and Backend by @EdJoPaTo in [#1284](https://github.com/ratatui/ratatui/pull/1284) [**breaking**]
 
   > The new methods return/accept `Into<Position>` which can be either a Position or a (u16, u16) tuple.
   >
@@ -134,7 +134,7 @@ We have also refined the terminal module and added brand new methods for cursor 
   > let position = terminal.set_cursor_position()?;
   > ```
 
-- [b70cd03](https://github.com/ratatui-org/ratatui/commit/b70cd03c029d91acd4709c2b91c735b8d796987c) *(uncategorized)* Add ListState / TableState scroll_down_by() / scroll_up_by() methods by @josueBarretogit in [#1267](https://github.com/ratatui-org/ratatui/pull/1267)
+- [b70cd03](https://github.com/ratatui/ratatui/commit/b70cd03c029d91acd4709c2b91c735b8d796987c) _(uncategorized)_ Add ListState / TableState scroll_down_by() / scroll_up_by() methods by @josueBarretogit in [#1267](https://github.com/ratatui/ratatui/pull/1267)
 
   > Implement new methods `scroll_down_by(u16)` and `scroll_up_by(u16)` for
   > both `Liststate` and `Tablestate`.
@@ -143,7 +143,7 @@ We have also refined the terminal module and added brand new methods for cursor 
 
 ### Bug Fixes
 
-- [864cd9f](https://github.com/ratatui-org/ratatui/commit/864cd9ffef47c43269fa16e773fc7c6e06d13bf3) *(testbackend)* Prevent area mismatch by @EdJoPaTo in [#1252](https://github.com/ratatui-org/ratatui/pull/1252)
+- [864cd9f](https://github.com/ratatui/ratatui/commit/864cd9ffef47c43269fa16e773fc7c6e06d13bf3) _(testbackend)_ Prevent area mismatch by @EdJoPaTo in [#1252](https://github.com/ratatui/ratatui/pull/1252)
 
   > Removes the height and width fields from TestBackend, which can get
   > out of sync with the Buffer, which currently clamps to 255,255.
@@ -152,9 +152,9 @@ We have also refined the terminal module and added brand new methods for cursor 
   > possible to read older data, but data generated after this change
   > can't be read by older versions.
 
-- [7e1bab0](https://github.com/ratatui-org/ratatui/commit/7e1bab049bc5acd4a5cb13189e8f86fec5813ab8) *(buffer)* Dont render control characters by @EdJoPaTo in [#1226](https://github.com/ratatui-org/ratatui/pull/1226)
+- [7e1bab0](https://github.com/ratatui/ratatui/commit/7e1bab049bc5acd4a5cb13189e8f86fec5813ab8) _(buffer)_ Dont render control characters by @EdJoPaTo in [#1226](https://github.com/ratatui/ratatui/pull/1226)
 
-- [c08b522](https://github.com/ratatui-org/ratatui/commit/c08b522d34ef3bfae37342ba1bff897cb320971e) *(chart)* Allow removing all the axis labels by @EdJoPaTo in [#1282](https://github.com/ratatui-org/ratatui/pull/1282)
+- [c08b522](https://github.com/ratatui/ratatui/commit/c08b522d34ef3bfae37342ba1bff897cb320971e) _(chart)_ Allow removing all the axis labels by @EdJoPaTo in [#1282](https://github.com/ratatui/ratatui/pull/1282)
 
   > `axis.labels(vec![])` removes all the labels correctly.
   >
@@ -163,7 +163,7 @@ We have also refined the terminal module and added brand new methods for cursor 
   > prevents weird cases by removing the mix-up of `Option::None`
   > and `Vec::is_empty`, and simplifies the implementation code.
 
-- [03f3124](https://github.com/ratatui-org/ratatui/commit/03f3124c1d83294788213fb4195a708f86eecd4f) *(paragraph)* Line_width, and line_count include block borders by @airblast-dev in [#1235](https://github.com/ratatui-org/ratatui/pull/1235)
+- [03f3124](https://github.com/ratatui/ratatui/commit/03f3124c1d83294788213fb4195a708f86eecd4f) _(paragraph)_ Line_width, and line_count include block borders by @airblast-dev in [#1235](https://github.com/ratatui/ratatui/pull/1235)
 
   > The `line_width`, and `line_count` methods for `Paragraph` would not
   > take into account the `Block` if one was set. This will now correctly
@@ -171,9 +171,9 @@ We have also refined the terminal module and added brand new methods for cursor 
   >
   > Fixes:#1233
 
-- [3ca920e](https://github.com/ratatui-org/ratatui/commit/3ca920e881f2f78ada27e0ff19a9705bb194e533) *(span)* Prevent panic on rendering out of y bounds by @EdJoPaTo in [#1257](https://github.com/ratatui-org/ratatui/pull/1257)
+- [3ca920e](https://github.com/ratatui/ratatui/commit/3ca920e881f2f78ada27e0ff19a9705bb194e533) _(span)_ Prevent panic on rendering out of y bounds by @EdJoPaTo in [#1257](https://github.com/ratatui/ratatui/pull/1257)
 
-- [84cb164](https://github.com/ratatui-org/ratatui/commit/84cb16483a76f1eb28f31f4a99075edfd78635f4) *(terminal)* Make terminal module private by @joshka in [#1260](https://github.com/ratatui-org/ratatui/pull/1260) [**breaking**]
+- [84cb164](https://github.com/ratatui/ratatui/commit/84cb16483a76f1eb28f31f4a99075edfd78635f4) _(terminal)_ Make terminal module private by @joshka in [#1260](https://github.com/ratatui/ratatui/pull/1260) [**breaking**]
 
   > This is a simplification of the public API that is helpful for new users
   > that are not familiar with how rust re-exports work, and helps avoid
@@ -188,66 +188,66 @@ We have also refined the terminal module and added brand new methods for cursor 
   > + use ratatui::{CompletedFrame, Frame, Terminal, TerminalOptions, ViewPort};
   > ```
   >
-  > Fixes:https://github.com/ratatui-org/ratatui/issues/1210
+  > Fixes:<https://github.com/ratatui/ratatui/issues/1210>
 
-- [29c8c84](https://github.com/ratatui-org/ratatui/commit/29c8c84fd05692e8981fc21ae55102bf29835431) *(uncategorized)* Ignore newlines in Span's Display impl by @SUPERCILEX in [#1270](https://github.com/ratatui-org/ratatui/pull/1270)
+- [29c8c84](https://github.com/ratatui/ratatui/commit/29c8c84fd05692e8981fc21ae55102bf29835431) _(uncategorized)_ Ignore newlines in Span's Display impl by @SUPERCILEX in [#1270](https://github.com/ratatui/ratatui/pull/1270)
 
-- [cd93547](https://github.com/ratatui-org/ratatui/commit/cd93547db869aab3dbca49f11667a8091a7077bd) *(uncategorized)* Remove unnecessary synchronization in layout cache by @SUPERCILEX in [#1245](https://github.com/ratatui-org/ratatui/pull/1245)
+- [cd93547](https://github.com/ratatui/ratatui/commit/cd93547db869aab3dbca49f11667a8091a7077bd) _(uncategorized)_ Remove unnecessary synchronization in layout cache by @SUPERCILEX in [#1245](https://github.com/ratatui/ratatui/pull/1245)
   >
   > Layout::init_cache no longer returns bool and takes a NonZeroUsize instead of usize
   >
   > The cache is a thread-local, so doesn't make much sense to require
   > synchronized initialization.
 
-- [b344f95](https://github.com/ratatui-org/ratatui/commit/b344f95b7cfc3b90221c84cfef8afcf6944bafc1) *(uncategorized)* Only apply style to first line when rendering a `Line` by @joshka in [#1247](https://github.com/ratatui-org/ratatui/pull/1247)
+- [b344f95](https://github.com/ratatui/ratatui/commit/b344f95b7cfc3b90221c84cfef8afcf6944bafc1) _(uncategorized)_ Only apply style to first line when rendering a `Line` by @joshka in [#1247](https://github.com/ratatui/ratatui/pull/1247)
 
   > A `Line` widget should only apply its style to the first line when
   > rendering and not the entire area. This is because the `Line` widget
   > should only render a single line of text. This commit fixes the issue by
   > clamping the area to a single line before rendering the text.
 
-- [7ddfbc0](https://github.com/ratatui-org/ratatui/commit/7ddfbc0010400f39756a66a666702176e508c5ea) *(uncategorized)* Unnecessary allocations when creating Lines by @SUPERCILEX in [#1237](https://github.com/ratatui-org/ratatui/pull/1237)
+- [7ddfbc0](https://github.com/ratatui/ratatui/commit/7ddfbc0010400f39756a66a666702176e508c5ea) _(uncategorized)_ Unnecessary allocations when creating Lines by @SUPERCILEX in [#1237](https://github.com/ratatui/ratatui/pull/1237)
 
-- [84f3341](https://github.com/ratatui-org/ratatui/commit/84f334163be2945ca8f5da9e0b244b6413a4d329) *(uncategorized)* Clippy lints from rust 1.80.0 by @joshka in [#1238](https://github.com/ratatui-org/ratatui/pull/1238)
+- [84f3341](https://github.com/ratatui/ratatui/commit/84f334163be2945ca8f5da9e0b244b6413a4d329) _(uncategorized)_ Clippy lints from rust 1.80.0 by @joshka in [#1238](https://github.com/ratatui/ratatui/pull/1238)
 
 ### Refactor
 
-- [bb68bc6](https://github.com/ratatui-org/ratatui/commit/bb68bc6968219dacea8f3c272bb99d142d2f3253) *(backend)* Return `Size` from `Backend::size` instead of `Rect` by @EdJoPaTo in [#1254](https://github.com/ratatui-org/ratatui/pull/1254) [**breaking**]
+- [bb68bc6](https://github.com/ratatui/ratatui/commit/bb68bc6968219dacea8f3c272bb99d142d2f3253) _(backend)_ Return `Size` from `Backend::size` instead of `Rect` by @EdJoPaTo in [#1254](https://github.com/ratatui/ratatui/pull/1254) [**breaking**]
 
   > The `Backend::size` method returns a `Size` instead of a `Rect`.
   > There is no need for the position here as it was always 0,0.
 
-- [e81663b](https://github.com/ratatui-org/ratatui/commit/e81663bec07f46433db7b6eb0154ca48e9389bdb) *(list)* Split up list.rs into smaller modules by @joshka in [#1204](https://github.com/ratatui-org/ratatui/pull/1204)
+- [e81663b](https://github.com/ratatui/ratatui/commit/e81663bec07f46433db7b6eb0154ca48e9389bdb) _(list)_ Split up list.rs into smaller modules by @joshka in [#1204](https://github.com/ratatui/ratatui/pull/1204)
 
-- [e707ff1](https://github.com/ratatui-org/ratatui/commit/e707ff11d15b5ee10ef2cffc934bb132ee8a1ead) *(uncategorized)* Internally use Position struct by @EdJoPaTo in [#1256](https://github.com/ratatui-org/ratatui/pull/1256)
+- [e707ff1](https://github.com/ratatui/ratatui/commit/e707ff11d15b5ee10ef2cffc934bb132ee8a1ead) _(uncategorized)_ Internally use Position struct by @EdJoPaTo in [#1256](https://github.com/ratatui/ratatui/pull/1256)
 
-- [32a0b26](https://github.com/ratatui-org/ratatui/commit/32a0b265253cb83cbf1d51784abf150fed7ef82f) *(uncategorized)* Simplify WordWrapper implementation by @tranzystorekk in [#1193](https://github.com/ratatui-org/ratatui/pull/1193)
+- [32a0b26](https://github.com/ratatui/ratatui/commit/32a0b265253cb83cbf1d51784abf150fed7ef82f) _(uncategorized)_ Simplify WordWrapper implementation by @tranzystorekk in [#1193](https://github.com/ratatui/ratatui/pull/1193)
 
 ### Documentation
 
-- [6ce447c](https://github.com/ratatui-org/ratatui/commit/6ce447c4f344ae7bec11d7f98cdc49ccac800df8) *(block)* Add docs about style inheritance by @joshka in [#1190](https://github.com/ratatui-org/ratatui/pull/1190)
+- [6ce447c](https://github.com/ratatui/ratatui/commit/6ce447c4f344ae7bec11d7f98cdc49ccac800df8) _(block)_ Add docs about style inheritance by @joshka in [#1190](https://github.com/ratatui/ratatui/pull/1190)
   >
-  > Fixes:https://github.com/ratatui-org/ratatui/issues/1129
+  > Fixes:<https://github.com/ratatui/ratatui/issues/1129>
 
-- [55e0880](https://github.com/ratatui-org/ratatui/commit/55e0880d2fef35b328901b4194d39101fe26a9e9) *(block)* Update block documentation by @leohscl in [#1206](https://github.com/ratatui-org/ratatui/pull/1206)
+- [55e0880](https://github.com/ratatui/ratatui/commit/55e0880d2fef35b328901b4194d39101fe26a9e9) _(block)_ Update block documentation by @leohscl in [#1206](https://github.com/ratatui/ratatui/pull/1206)
 
   > Update block documentation with constructor methods and setter methods
   > in the main doc comment Added an example for using it to surround
   > widgets
   >
-  > Fixes:https://github.com/ratatui-org/ratatui/issues/914
+  > Fixes:<https://github.com/ratatui/ratatui/issues/914>
 
-- [f2fa1ae](https://github.com/ratatui-org/ratatui/commit/f2fa1ae9aa6f456615c519dcb17d7d3b8177bfb8) *(breaking-changes)* Add missing code block by @orhun in [#1291](https://github.com/ratatui-org/ratatui/pull/1291)
+- [f2fa1ae](https://github.com/ratatui/ratatui/commit/f2fa1ae9aa6f456615c519dcb17d7d3b8177bfb8) _(breaking-changes)_ Add missing code block by @orhun in [#1291](https://github.com/ratatui/ratatui/pull/1291)
 
-- [f687af7](https://github.com/ratatui-org/ratatui/commit/f687af7c0d1dfc87302d2cf3b9ef7c7d58edb2d3) *(breaking-changes)* Mention removed lifetime of ToText trait by @orhun in [#1292](https://github.com/ratatui-org/ratatui/pull/1292)
+- [f687af7](https://github.com/ratatui/ratatui/commit/f687af7c0d1dfc87302d2cf3b9ef7c7d58edb2d3) _(breaking-changes)_ Mention removed lifetime of ToText trait by @orhun in [#1292](https://github.com/ratatui/ratatui/pull/1292)
 
-- [d468463](https://github.com/ratatui-org/ratatui/commit/d468463fc6aff426131f3ff61dc63291b90b37d1) *(breaking-changes)* Fix the PR link by @orhun in [#1294](https://github.com/ratatui-org/ratatui/pull/1294)
+- [d468463](https://github.com/ratatui/ratatui/commit/d468463fc6aff426131f3ff61dc63291b90b37d1) _(breaking-changes)_ Fix the PR link by @orhun in [#1294](https://github.com/ratatui/ratatui/pull/1294)
 
-- [1b9bdd4](https://github.com/ratatui-org/ratatui/commit/1b9bdd425cb68bbb5f57900175ad88a9b211f607) *(contributing)* Fix minor issues by @EdJoPaTo in [#1300](https://github.com/ratatui-org/ratatui/pull/1300)
+- [1b9bdd4](https://github.com/ratatui/ratatui/commit/1b9bdd425cb68bbb5f57900175ad88a9b211f607) _(contributing)_ Fix minor issues by @EdJoPaTo in [#1300](https://github.com/ratatui/ratatui/pull/1300)
 
-- [5f7a7fb](https://github.com/ratatui-org/ratatui/commit/5f7a7fbe19ecf36c5060a6ba8835d92029a15777) *(examples)* Update barcharts gifs by @joshka in [#1306](https://github.com/ratatui-org/ratatui/pull/1306)
+- [5f7a7fb](https://github.com/ratatui/ratatui/commit/5f7a7fbe19ecf36c5060a6ba8835d92029a15777) _(examples)_ Update barcharts gifs by @joshka in [#1306](https://github.com/ratatui/ratatui/pull/1306)
 
-- [fe4eeab](https://github.com/ratatui-org/ratatui/commit/fe4eeab676e8db69a1e4f878173cdda0d96d5f7f) *(examples)* Simplify the barchart example by @joshka in [#1079](https://github.com/ratatui-org/ratatui/pull/1079)
+- [fe4eeab](https://github.com/ratatui/ratatui/commit/fe4eeab676e8db69a1e4f878173cdda0d96d5f7f) _(examples)_ Simplify the barchart example by @joshka in [#1079](https://github.com/ratatui/ratatui/pull/1079)
 
   > The `barchart` example has been split into two examples: `barchart` and
   > `barchart-grouped`. The `barchart` example now shows a simple barchart
@@ -261,7 +261,7 @@ We have also refined the terminal module and added brand new methods for cursor 
   >
   > ---------
 
-- [6e7b4e4](https://github.com/ratatui-org/ratatui/commit/6e7b4e4d55abcfeb3ffa598086ab227604b26ff7) *(examples)* Add async example by @joshka in [#1248](https://github.com/ratatui-org/ratatui/pull/1248)
+- [6e7b4e4](https://github.com/ratatui/ratatui/commit/6e7b4e4d55abcfeb3ffa598086ab227604b26ff7) _(examples)_ Add async example by @joshka in [#1248](https://github.com/ratatui/ratatui/pull/1248)
 
   > This example demonstrates how to use Ratatui with widgets that fetch
   > data asynchronously. It uses the `octocrab` crate to fetch a list of
@@ -269,21 +269,21 @@ We have also refined the terminal module and added brand new methods for cursor 
   > variable named `GITHUB_TOKEN` with a valid GitHub personal access
   > token. The token does not need any special permissions.
 
-- [935a718](https://github.com/ratatui-org/ratatui/commit/935a7187c273e0efc876d094d6247d50e28677a3) *(examples)* Add missing examples to README by @kibibyt3 in [#1225](https://github.com/ratatui-org/ratatui/pull/1225)
+- [935a718](https://github.com/ratatui/ratatui/commit/935a7187c273e0efc876d094d6247d50e28677a3) _(examples)_ Add missing examples to README by @kibibyt3 in [#1225](https://github.com/ratatui/ratatui/pull/1225)
   >
   > Resolves:#1014
 
-- [50e5674](https://github.com/ratatui-org/ratatui/commit/50e5674a20edad0d95bd103522b21df35b38430b) *(examples)* Fix: fix typos in tape files by @kibibyt3 in [#1224](https://github.com/ratatui-org/ratatui/pull/1224)
+- [50e5674](https://github.com/ratatui/ratatui/commit/50e5674a20edad0d95bd103522b21df35b38430b) _(examples)_ Fix: fix typos in tape files by @kibibyt3 in [#1224](https://github.com/ratatui/ratatui/pull/1224)
 
-- [810da72](https://github.com/ratatui-org/ratatui/commit/810da72f26acd8761031d9a822957df9588ac406) *(examples)* Fix hyperlink example tape by @kibibyt3 in [#1222](https://github.com/ratatui-org/ratatui/pull/1222)
+- [810da72](https://github.com/ratatui/ratatui/commit/810da72f26acd8761031d9a822957df9588ac406) _(examples)_ Fix hyperlink example tape by @kibibyt3 in [#1222](https://github.com/ratatui/ratatui/pull/1222)
 
-- [5eeb1cc](https://github.com/ratatui-org/ratatui/commit/5eeb1ccbc4e1e1dff4979647f87e91c515a56fd5) *(github)* Create CODE_OF_CONDUCT.md by @joshka in [#1279](https://github.com/ratatui-org/ratatui/pull/1279)
+- [5eeb1cc](https://github.com/ratatui/ratatui/commit/5eeb1ccbc4e1e1dff4979647f87e91c515a56fd5) _(github)_ Create CODE_OF_CONDUCT.md by @joshka in [#1279](https://github.com/ratatui/ratatui/pull/1279)
 
-- [7c0665c](https://github.com/ratatui-org/ratatui/commit/7c0665cb0e34eff3ca427d2ada81f043f20cea00) *(layout)* Fix typo in example by @EmiOnGit in [#1217](https://github.com/ratatui-org/ratatui/pull/1217)
+- [7c0665c](https://github.com/ratatui/ratatui/commit/7c0665cb0e34eff3ca427d2ada81f043f20cea00) _(layout)_ Fix typo in example by @EmiOnGit in [#1217](https://github.com/ratatui/ratatui/pull/1217)
 
-- [272d059](https://github.com/ratatui-org/ratatui/commit/272d0591a7efc09897a2566969fbafcb2423fdbc) *(paragraph)* Update main docs by @joshka in [#1202](https://github.com/ratatui-org/ratatui/pull/1202)
+- [272d059](https://github.com/ratatui/ratatui/commit/272d0591a7efc09897a2566969fbafcb2423fdbc) _(paragraph)_ Update main docs by @joshka in [#1202](https://github.com/ratatui/ratatui/pull/1202)
 
-- [bb71e5f](https://github.com/ratatui-org/ratatui/commit/bb71e5ffd484fa3296d014d72d8a0521f56c7876) *(readme)* Remove MSRV by @EdJoPaTo in [#1266](https://github.com/ratatui-org/ratatui/pull/1266)
+- [bb71e5f](https://github.com/ratatui/ratatui/commit/bb71e5ffd484fa3296d014d72d8a0521f56c7876) _(readme)_ Remove MSRV by @EdJoPaTo in [#1266](https://github.com/ratatui/ratatui/pull/1266)
 
   > This notice was useful when the `Cargo.toml` had no standardized field
   > for this. Now it's easier to look it up in the `Cargo.toml` and it's
@@ -291,25 +291,25 @@ We have also refined the terminal module and added brand new methods for cursor 
   > quite some time so it's better to just omit it rather than having
   > something wrong that will be forgotten again in the future.
 
-- [8857037](https://github.com/ratatui-org/ratatui/commit/8857037bfff52104affa3c764dea0f3370cc702c) *(terminal)* Fix imports by @EdJoPaTo in [#1263](https://github.com/ratatui-org/ratatui/pull/1263)
+- [8857037](https://github.com/ratatui/ratatui/commit/8857037bfff52104affa3c764dea0f3370cc702c) _(terminal)_ Fix imports by @EdJoPaTo in [#1263](https://github.com/ratatui/ratatui/pull/1263)
 
-- [2fd5ae6](https://github.com/ratatui-org/ratatui/commit/2fd5ae64bf1440fccf072c1b6aa3dc03dc9ac1ec) *(widgets)* Document stability of WidgetRef by @joshka in [#1288](https://github.com/ratatui-org/ratatui/pull/1288)
+- [2fd5ae6](https://github.com/ratatui/ratatui/commit/2fd5ae64bf1440fccf072c1b6aa3dc03dc9ac1ec) _(widgets)_ Document stability of WidgetRef by @joshka in [#1288](https://github.com/ratatui/ratatui/pull/1288)
 
   > Addresses some confusion about when to implement `WidgetRef` vs `impl
   > Widget for &W`. Notes the stability rationale and links to an issue that
   > helps explain the context of where we're at in working this out.
 
-- [716c931](https://github.com/ratatui-org/ratatui/commit/716c93136e0c0f11e62364fdc9b32ec58036851e) *(uncategorized)* Document crossterm breaking change by @joshka in [#1281](https://github.com/ratatui-org/ratatui/pull/1281)
+- [716c931](https://github.com/ratatui/ratatui/commit/716c93136e0c0f11e62364fdc9b32ec58036851e) _(uncategorized)_ Document crossterm breaking change by @joshka in [#1281](https://github.com/ratatui/ratatui/pull/1281)
 
-- [f775030](https://github.com/ratatui-org/ratatui/commit/f77503050ffbe4dd2d4949cb22b451a2b0fe9296) *(uncategorized)* Update main lib.rs / README examples by @joshka in [#1280](https://github.com/ratatui-org/ratatui/pull/1280)
+- [f775030](https://github.com/ratatui/ratatui/commit/f77503050ffbe4dd2d4949cb22b451a2b0fe9296) _(uncategorized)_ Update main lib.rs / README examples by @joshka in [#1280](https://github.com/ratatui/ratatui/pull/1280)
 
-- [8433d09](https://github.com/ratatui-org/ratatui/commit/8433d0958bd0a384383bdefe28e6146de1332e17) *(uncategorized)* Update demo image by @joshka in [#1276](https://github.com/ratatui-org/ratatui/pull/1276)
+- [8433d09](https://github.com/ratatui/ratatui/commit/8433d0958bd0a384383bdefe28e6146de1332e17) _(uncategorized)_ Update demo image by @joshka in [#1276](https://github.com/ratatui/ratatui/pull/1276)
 
-  > Follow up to https://github.com/ratatui-org/ratatui/pull/1203
+  > Follow up to <https://github.com/ratatui/ratatui/pull/1203>
 
 ### Performance
 
-- [663486f](https://github.com/ratatui-org/ratatui/commit/663486f1e8deae6287d4d0051dfab0682b700423) *(list)* Avoid extra allocations when rendering `List` by @airblast-dev in [#1244](https://github.com/ratatui-org/ratatui/pull/1244)
+- [663486f](https://github.com/ratatui/ratatui/commit/663486f1e8deae6287d4d0051dfab0682b700423) _(list)_ Avoid extra allocations when rendering `List` by @airblast-dev in [#1244](https://github.com/ratatui/ratatui/pull/1244)
 
   > When rendering a `List`, each `ListItem` would be cloned. Removing the
   > clone, and replacing `Widget::render` with `WidgetRef::render_ref` saves
@@ -319,7 +319,7 @@ We have also refined the terminal module and added brand new methods for cursor 
   > Based on the results of running the "list" benchmark locally;
   > Performance is improved by %1-3 for all `render` benchmarks for `List`.
 
-- [4753b72](https://github.com/ratatui-org/ratatui/commit/4753b7241bf3f33b9d953d301f83baa547e7037c) *(reflow)* Eliminate most WordWrapper allocations by @SUPERCILEX in [#1239](https://github.com/ratatui-org/ratatui/pull/1239)
+- [4753b72](https://github.com/ratatui/ratatui/commit/4753b7241bf3f33b9d953d301f83baa547e7037c) _(reflow)_ Eliminate most WordWrapper allocations by @SUPERCILEX in [#1239](https://github.com/ratatui/ratatui/pull/1239)
 
   > On large paragraphs (~1MB), this saves hundreds of thousands of
   > allocations.
@@ -328,7 +328,7 @@ We have also refined the terminal module and added brand new methods for cursor 
   > Instead of allocating new buffers each time, allocate the buffers once
   > and clear them before reuse.
 
-- [be3eb75](https://github.com/ratatui-org/ratatui/commit/be3eb75ea58127caad6696a21d794f5f99e0dfd6) *(table)* Avoid extra allocations when rendering `Table` by @airblast-dev in [#1242](https://github.com/ratatui-org/ratatui/pull/1242)
+- [be3eb75](https://github.com/ratatui/ratatui/commit/be3eb75ea58127caad6696a21d794f5f99e0dfd6) _(table)_ Avoid extra allocations when rendering `Table` by @airblast-dev in [#1242](https://github.com/ratatui/ratatui/pull/1242)
 
   > When rendering a `Table` the `Text` stored inside of a `Cell` gets
   > cloned before rendering. This removes the clone and uses `WidgetRef`
@@ -336,9 +336,9 @@ We have also refined the terminal module and added brand new methods for cursor 
   > avoids an allocation when rendering the highlight symbol if it contains
   > an owned value.
 
-- [f04bf85](https://github.com/ratatui-org/ratatui/commit/f04bf855cbc28e0ae29eaf678f26425a05f2295e) *(uncategorized)* Add buffer benchmarks by @joshka in [#1303](https://github.com/ratatui-org/ratatui/pull/1303)
+- [f04bf85](https://github.com/ratatui/ratatui/commit/f04bf855cbc28e0ae29eaf678f26425a05f2295e) _(uncategorized)_ Add buffer benchmarks by @joshka in [#1303](https://github.com/ratatui/ratatui/pull/1303)
 
-- [e6d2e04](https://github.com/ratatui-org/ratatui/commit/e6d2e04bcf2340c901ba1513ddaf84d358751768) *(uncategorized)* Move benchmarks into a single benchmark harness by @joshka in [#1302](https://github.com/ratatui-org/ratatui/pull/1302)
+- [e6d2e04](https://github.com/ratatui/ratatui/commit/e6d2e04bcf2340c901ba1513ddaf84d358751768) _(uncategorized)_ Move benchmarks into a single benchmark harness by @joshka in [#1302](https://github.com/ratatui/ratatui/pull/1302)
 
   > Consolidates the benchmarks into a single executable rather than having
   > to create a new cargo.toml setting per and makes it easier to rearrange
@@ -346,7 +346,7 @@ We have also refined the terminal module and added brand new methods for cursor 
 
 ### Styling
 
-- [a80a8a6](https://github.com/ratatui-org/ratatui/commit/a80a8a6a473274aa44a4543d945760123f9d5407) *(format)* Lint markdown by @joshka in [#1131](https://github.com/ratatui-org/ratatui/pull/1131)
+- [a80a8a6](https://github.com/ratatui/ratatui/commit/a80a8a6a473274aa44a4543d945760123f9d5407) _(format)_ Lint markdown by @joshka in [#1131](https://github.com/ratatui/ratatui/pull/1131)
 
   > - **chore: Fix line endings for changelog**
   > - **chore: cleanup markdown lints**
@@ -357,36 +357,36 @@ We have also refined the terminal module and added brand new methods for cursor 
 
 ### Testing
 
-- [32d0695](https://github.com/ratatui-org/ratatui/commit/32d0695cc2d56900d8a6246d9d876393294dd94e) *(buffer)* Ensure emojis are rendered by @EdJoPaTo in [#1258](https://github.com/ratatui-org/ratatui/pull/1258)
+- [32d0695](https://github.com/ratatui/ratatui/commit/32d0695cc2d56900d8a6246d9d876393294dd94e) _(buffer)_ Ensure emojis are rendered by @EdJoPaTo in [#1258](https://github.com/ratatui/ratatui/pull/1258)
 
 ### Miscellaneous Tasks
 
-- [82b70fd](https://github.com/ratatui-org/ratatui/commit/82b70fd329885f8ab3cb972b6fe117bc27e3d96a) *(ci)* Integrate cargo-semver-checks by @orhun in [#1166](https://github.com/ratatui-org/ratatui/pull/1166)
+- [82b70fd](https://github.com/ratatui/ratatui/commit/82b70fd329885f8ab3cb972b6fe117bc27e3d96a) _(ci)_ Integrate cargo-semver-checks by @orhun in [#1166](https://github.com/ratatui/ratatui/pull/1166)
 
   > >
   > [`cargo-semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks):
   > Lint your crate API changes for semver violations.
 
-- [c245c13](https://github.com/ratatui-org/ratatui/commit/c245c13cc14ac8c483c4aeb6e2e3b4f8e387b791) *(ci)* Onboard bencher for tracking benchmarks by @orhun in [#1174](https://github.com/ratatui-org/ratatui/pull/1174)
+- [c245c13](https://github.com/ratatui/ratatui/commit/c245c13cc14ac8c483c4aeb6e2e3b4f8e387b791) _(ci)_ Onboard bencher for tracking benchmarks by @orhun in [#1174](https://github.com/ratatui/ratatui/pull/1174)
   >
-  > https://bencher.dev/console/projects/ratatui-org
+  > <https://bencher.dev/console/projects/ratatui-org>
   >
   > Closes:#1092
 
-- [efef0d0](https://github.com/ratatui-org/ratatui/commit/efef0d0dc0872ed2b0c5d865ef008698f3051d10) *(ci)* Change label from `breaking change` to `Type: Breaking Change` by @kdheepak in [#1243](https://github.com/ratatui-org/ratatui/pull/1243)
+- [efef0d0](https://github.com/ratatui/ratatui/commit/efef0d0dc0872ed2b0c5d865ef008698f3051d10) _(ci)_ Change label from `breaking change` to `Type: Breaking Change` by @kdheepak in [#1243](https://github.com/ratatui/ratatui/pull/1243)
 
   > This PR changes the label that is auto attached to a PR with a breaking
   > change per the conventional commits specification.
 
-- [41a9100](https://github.com/ratatui-org/ratatui/commit/41a910004dfe69de135845fac900dd4240a865c7) *(github)* Use the GitHub organization team as codeowners by @EdJoPaTo in [#1081](https://github.com/ratatui-org/ratatui/pull/1081)
+- [41a9100](https://github.com/ratatui/ratatui/commit/41a910004dfe69de135845fac900dd4240a865c7) _(github)_ Use the GitHub organization team as codeowners by @EdJoPaTo in [#1081](https://github.com/ratatui/ratatui/pull/1081)
 
   > Use GitHub organization team in CODEOWNERS and create MAINTAINERS.md
 
-- [3e7458f](https://github.com/ratatui-org/ratatui/commit/3e7458fdb8051b9a62aac551372d5592e7f59eb7) *(github)* Add forums and faqs to the issue template by @joshka in [#1201](https://github.com/ratatui-org/ratatui/pull/1201)
+- [3e7458f](https://github.com/ratatui/ratatui/commit/3e7458fdb8051b9a62aac551372d5592e7f59eb7) _(github)_ Add forums and faqs to the issue template by @joshka in [#1201](https://github.com/ratatui/ratatui/pull/1201)
 
-- [45fcab7](https://github.com/ratatui-org/ratatui/commit/45fcab7497650685781434e27abf3ddf0459aead) *(uncategorized)* Add rect::rows benchmark by @joshka in [#1301](https://github.com/ratatui-org/ratatui/pull/1301)
+- [45fcab7](https://github.com/ratatui/ratatui/commit/45fcab7497650685781434e27abf3ddf0459aead) _(uncategorized)_ Add rect::rows benchmark by @joshka in [#1301](https://github.com/ratatui/ratatui/pull/1301)
 
-- [edc2af9](https://github.com/ratatui-org/ratatui/commit/edc2af98223229656480dd30e03f1230b0aba919) *(uncategorized)* Replace big_text with hardcoded logo by @joshka in [#1203](https://github.com/ratatui-org/ratatui/pull/1203)
+- [edc2af9](https://github.com/ratatui/ratatui/commit/edc2af98223229656480dd30e03f1230b0aba919) _(uncategorized)_ Replace big_text with hardcoded logo by @joshka in [#1203](https://github.com/ratatui/ratatui/pull/1203)
 
   > big_text.rs was a copy of the code from tui-big-text and was getting
   > gradually out of sync with the original crate. It was also rendering
@@ -394,30 +394,30 @@ We have also refined the terminal module and added brand new methods for cursor 
   > the big_text.rs file with a much smaller string representation of the
   > Ratatui logo.
   >
-  > ![demo2](https://raw.githubusercontent.com/ratatui-org/ratatui/images/examples/demo2-destroy.gif)
+  > ![demo2](https://raw.githubusercontent.com/ratatui/ratatui/images/examples/demo2-destroy.gif)
 
-- [c2d3850](https://github.com/ratatui-org/ratatui/commit/c2d38509b4d6a5d80f721c08d4e8727a37475aa6) *(uncategorized)* Use LF line endings for CHANGELOG.md instead of CRLF by @joshka in [#1269](https://github.com/ratatui-org/ratatui/pull/1269)
+- [c2d3850](https://github.com/ratatui/ratatui/commit/c2d38509b4d6a5d80f721c08d4e8727a37475aa6) _(uncategorized)_ Use LF line endings for CHANGELOG.md instead of CRLF by @joshka in [#1269](https://github.com/ratatui/ratatui/pull/1269)
 
-- [a9fe428](https://github.com/ratatui-org/ratatui/commit/a9fe4284acfa6ca01260c11b0f64f8f610272d20) *(uncategorized)* Update cargo-deny config by @EdJoPaTo in [#1265](https://github.com/ratatui-org/ratatui/pull/1265)
+- [a9fe428](https://github.com/ratatui/ratatui/commit/a9fe4284acfa6ca01260c11b0f64f8f610272d20) _(uncategorized)_ Update cargo-deny config by @EdJoPaTo in [#1265](https://github.com/ratatui/ratatui/pull/1265)
 
   > Update `cargo-deny` config (noticed in
-  > https://github.com/ratatui-org/ratatui/pull/1263#pullrequestreview-2215488414)
+  > <https://github.com/ratatui/ratatui/pull/1263#pullrequestreview-2215488414>)
   >
-  > See https://github.com/EmbarkStudios/cargo-deny/pull/611
+  > See <https://github.com/EmbarkStudios/cargo-deny/pull/611>
 
-- [ffc4300](https://github.com/ratatui-org/ratatui/commit/ffc43005589c9baf90db839f5388d3783d59e963) *(uncategorized)* Remove executable flag for rs files by @EdJoPaTo in [#1262](https://github.com/ratatui-org/ratatui/pull/1262)
+- [ffc4300](https://github.com/ratatui/ratatui/commit/ffc43005589c9baf90db839f5388d3783d59e963) _(uncategorized)_ Remove executable flag for rs files by @EdJoPaTo in [#1262](https://github.com/ratatui/ratatui/pull/1262)
 
-- [7bab9f0](https://github.com/ratatui-org/ratatui/commit/7bab9f0d802e154f3551f895399398a4d43d489f) *(uncategorized)* Add more CompactString::const_new instead of new by @joshka in [#1230](https://github.com/ratatui-org/ratatui/pull/1230)
+- [7bab9f0](https://github.com/ratatui/ratatui/commit/7bab9f0d802e154f3551f895399398a4d43d489f) _(uncategorized)_ Add more CompactString::const_new instead of new by @joshka in [#1230](https://github.com/ratatui/ratatui/pull/1230)
 
-- [ccf83e6](https://github.com/ratatui-org/ratatui/commit/ccf83e6d7610bf74f4ab02e0b1e2fe0e55ad9e78) *(uncategorized)* Update labels in issue templates by @joshka in [#1212](https://github.com/ratatui-org/ratatui/pull/1212)
+- [ccf83e6](https://github.com/ratatui/ratatui/commit/ccf83e6d7610bf74f4ab02e0b1e2fe0e55ad9e78) _(uncategorized)_ Update labels in issue templates by @joshka in [#1212](https://github.com/ratatui/ratatui/pull/1212)
 
 ### Build
 
-- [379dab9](https://github.com/ratatui-org/ratatui/commit/379dab9cdb8f1836836dc3ad6bf411088d610f37) *(uncategorized)* Cleanup dev dependencies by @EdJoPaTo in [#1231](https://github.com/ratatui-org/ratatui/pull/1231)
+- [379dab9](https://github.com/ratatui/ratatui/commit/379dab9cdb8f1836836dc3ad6bf411088d610f37) _(uncategorized)_ Cleanup dev dependencies by @EdJoPaTo in [#1231](https://github.com/ratatui/ratatui/pull/1231)
 
 ### Continuous Integration
 
-- [476ac87](https://github.com/ratatui-org/ratatui/commit/476ac87c9937de8863d2e884efdac19c8c1e43d2) *(uncategorized)* Split up lint job by @EdJoPaTo in [#1264](https://github.com/ratatui-org/ratatui/pull/1264)
+- [476ac87](https://github.com/ratatui/ratatui/commit/476ac87c9937de8863d2e884efdac19c8c1e43d2) _(uncategorized)_ Split up lint job by @EdJoPaTo in [#1264](https://github.com/ratatui/ratatui/pull/1264)
 
   > This helps with identifying what failed right from the title. Also steps
   > after a failing one are now always executed.
@@ -425,17 +425,19 @@ We have also refined the terminal module and added brand new methods for cursor 
   > Also shortens the steps a bit by removing obvious names.
 
 ### New Contributors
-* @SUPERCILEX made their first contribution in [#1239](https://github.com/ratatui-org/ratatui/pull/1239)
-* @josueBarretogit made their first contribution in [#1267](https://github.com/ratatui-org/ratatui/pull/1267)
-* @airblast-dev made their first contribution in [#1242](https://github.com/ratatui-org/ratatui/pull/1242)
-* @kibibyt3 made their first contribution in [#1225](https://github.com/ratatui-org/ratatui/pull/1225)
-* @EmiOnGit made their first contribution in [#1217](https://github.com/ratatui-org/ratatui/pull/1217)
-* @leohscl made their first contribution in [#1206](https://github.com/ratatui-org/ratatui/pull/1206)
-* @robertpsoane made their first contribution in [#1198](https://github.com/ratatui-org/ratatui/pull/1198)
 
-**Full Changelog**: https://github.com/ratatui-org/ratatui/compare/v0.27.0...0.28.0
+- @SUPERCILEX made their first contribution in [#1239](https://github.com/ratatui/ratatui/pull/1239)
 
-## [0.27.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.27.0) - 2024-06-24
+- @josueBarretogit made their first contribution in [#1267](https://github.com/ratatui/ratatui/pull/1267)
+- @airblast-dev made their first contribution in [#1242](https://github.com/ratatui/ratatui/pull/1242)
+- @kibibyt3 made their first contribution in [#1225](https://github.com/ratatui/ratatui/pull/1225)
+- @EmiOnGit made their first contribution in [#1217](https://github.com/ratatui/ratatui/pull/1217)
+- @leohscl made their first contribution in [#1206](https://github.com/ratatui/ratatui/pull/1206)
+- @robertpsoane made their first contribution in [#1198](https://github.com/ratatui/ratatui/pull/1198)
+
+**Full Changelog**: <https://github.com/ratatui/ratatui/compare/v0.27.0...0.28.0>
+
+## [0.27.0](https://github.com/ratatui/ratatui/releases/tag/v0.27.0) - 2024-06-24
 
 In this version, we have focused on enhancing usability and functionality with new features like
 background styles for LineGauge, palette colors, and various other improvements including
@@ -443,11 +445,11 @@ improved performance. Also, we added brand new examples for tracing and creating
 
 ✨ **Release highlights**: <https://ratatui.rs/highlights/v027/>
 
-⚠️ List of breaking changes can be found [here](https://github.com/ratatui-org/ratatui/blob/main/BREAKING-CHANGES.md).
+⚠️ List of breaking changes can be found [here](https://github.com/ratatui/ratatui/blob/main/BREAKING-CHANGES.md).
 
 ### Features
 
-- [eef1afe](https://github.com/ratatui-org/ratatui/commit/eef1afe9155089dca489a9159c368a5ac07e7585) _(linegauge)_ Allow LineGauge background styles by @nowNick in [#565](https://github.com/ratatui-org/ratatui/pull/565)
+- [eef1afe](https://github.com/ratatui/ratatui/commit/eef1afe9155089dca489a9159c368a5ac07e7585) _(linegauge)_ Allow LineGauge background styles by @nowNick in [#565](https://github.com/ratatui/ratatui/pull/565)
 
   ```text
   This PR deprecates `gauge_style` in favor of `filled_style` and
@@ -456,11 +458,11 @@ improved performance. Also, we added brand new examples for tracing and creating
   `cargo run --example=line_gauge --features=crossterm`
   ```
 
-  https://github.com/ratatui-org/ratatui/assets/5149215/5fb2ce65-8607-478f-8be4-092e08612f5b
+  <https://github.com/ratatui/ratatui/assets/5149215/5fb2ce65-8607-478f-8be4-092e08612f5b>
 
-  Implements:<https://github.com/ratatui-org/ratatui/issues/424>
+  Implements:<https://github.com/ratatui/ratatui/issues/424>
 
-- [1365620](https://github.com/ratatui-org/ratatui/commit/13656206064b53c7f86f179b570c7769399212a3) _(borders)_ Add FULL and EMPTY border sets by @joshka in [#1182](https://github.com/ratatui-org/ratatui/pull/1182)
+- [1365620](https://github.com/ratatui/ratatui/commit/13656206064b53c7f86f179b570c7769399212a3) _(borders)_ Add FULL and EMPTY border sets by @joshka in [#1182](https://github.com/ratatui/ratatui/pull/1182)
 
   `border::FULL` uses a full block symbol, while `border::EMPTY` uses an
   empty space. This is useful for when you need to allocate space for the
@@ -474,13 +476,13 @@ let block = Block::bordered().title("Title").border_set(border::FULL);
 let block = Block::bordered().title("Title").border_set(border::EMPTY);
 ```
 
-- [7a48c5b](https://github.com/ratatui-org/ratatui/commit/7a48c5b11b3d51b915ccc187d0499b6e0e88b89d) _(cell)_ Add EMPTY and (const) new method by @EdJoPaTo in [#1143](https://github.com/ratatui-org/ratatui/pull/1143)
+- [7a48c5b](https://github.com/ratatui/ratatui/commit/7a48c5b11b3d51b915ccc187d0499b6e0e88b89d) _(cell)_ Add EMPTY and (const) new method by @EdJoPaTo in [#1143](https://github.com/ratatui/ratatui/pull/1143)
 
   ```text
   This simplifies calls to `Buffer::filled` in tests.
   ```
 
-- [3f2f2cd](https://github.com/ratatui-org/ratatui/commit/3f2f2cd6abf67a04809ff314025a462a3c2e2446) _(docs)_ Add tracing example by @joshka in [#1192](https://github.com/ratatui-org/ratatui/pull/1192)
+- [3f2f2cd](https://github.com/ratatui/ratatui/commit/3f2f2cd6abf67a04809ff314025a462a3c2e2446) _(docs)_ Add tracing example by @joshka in [#1192](https://github.com/ratatui/ratatui/pull/1192)
 
   ```text
   Add an example that demonstrates logging to a file for:
@@ -496,22 +498,22 @@ cat tracing.log
 
 ![Made with VHS](https://vhs.charm.sh/vhs-21jgJCedh2YnFDONw0JW7l.gif)
 
-- [1520ed9](https://github.com/ratatui-org/ratatui/commit/1520ed9d106f99580a9e529212e43dac06a2f6d2) _(layout)_ Impl Display for Position and Size by @joshka in [#1162](https://github.com/ratatui-org/ratatui/pull/1162)
+- [1520ed9](https://github.com/ratatui/ratatui/commit/1520ed9d106f99580a9e529212e43dac06a2f6d2) _(layout)_ Impl Display for Position and Size by @joshka in [#1162](https://github.com/ratatui/ratatui/pull/1162)
 
-- [46977d8](https://github.com/ratatui-org/ratatui/commit/46977d88519d28ccac1c94e171af0c9cca071dbc) _(list)_ Add list navigation methods (first, last, previous, next) by @joshka in [#1159](https://github.com/ratatui-org/ratatui/pull/1159) [**breaking**]
+- [46977d8](https://github.com/ratatui/ratatui/commit/46977d88519d28ccac1c94e171af0c9cca071dbc) _(list)_ Add list navigation methods (first, last, previous, next) by @joshka in [#1159](https://github.com/ratatui/ratatui/pull/1159) [**breaking**]
 
   ```text
   Also cleans up the list example significantly (see also
-  <https://github.com/ratatui-org/ratatui/issues/1157>)
+  <https://github.com/ratatui/ratatui/issues/1157>)
   ```
 
-  Fixes:<https://github.com/ratatui-org/ratatui/pull/1159>
+  Fixes:<https://github.com/ratatui/ratatui/pull/1159>
 
   BREAKING CHANGE:The `List` widget now clamps the selected index to the
   bounds of the list when navigating with `first`, `last`, `previous`, and
   `next`, as well as when setting the index directly with `select`.
 
-- [10d7788](https://github.com/ratatui-org/ratatui/commit/10d778866edea55207ff3f03d063c9fec619b9c9) _(style)_ Add conversions from the palette crate colors by @joshka in [#1172](https://github.com/ratatui-org/ratatui/pull/1172)
+- [10d7788](https://github.com/ratatui/ratatui/commit/10d778866edea55207ff3f03d063c9fec619b9c9) _(style)_ Add conversions from the palette crate colors by @joshka in [#1172](https://github.com/ratatui/ratatui/pull/1172)
 
   ````text
   This is behind the "palette" feature flag.
@@ -525,7 +527,7 @@ cat tracing.log
   ```
   ````
 
-- [7ef2dae](https://github.com/ratatui-org/ratatui/commit/7ef2daee060a7fe964a8de64eafcb6062228e035) _(text)_ support conversion from Display to Span, Line and Text by @orhun in [#1167](https://github.com/ratatui-org/ratatui/pull/1167)
+- [7ef2dae](https://github.com/ratatui/ratatui/commit/7ef2daee060a7fe964a8de64eafcb6062228e035) _(text)_ support conversion from Display to Span, Line and Text by @orhun in [#1167](https://github.com/ratatui/ratatui/pull/1167)
 
   ````text
   Now you can create `Line` and `Text` from numbers like so:
@@ -536,7 +538,7 @@ cat tracing.log
   ```
   ````
 
-- [74a32af](https://github.com/ratatui-org/ratatui/commit/74a32afbaef8851f9462b27094d88d518e56addf) _(uncategorized)_ Re-export backends from the ratatui crate by @joshka in [#1151](https://github.com/ratatui-org/ratatui/pull/1151)
+- [74a32af](https://github.com/ratatui/ratatui/commit/74a32afbaef8851f9462b27094d88d518e56addf) _(uncategorized)_ Re-export backends from the ratatui crate by @joshka in [#1151](https://github.com/ratatui/ratatui/pull/1151)
 
   ```text
   `crossterm`, `termion`, and `termwiz` can now be accessed as
@@ -550,9 +552,9 @@ cat tracing.log
   `termwiz::` with `ratatui::termwiz::`.
   ```
 
-- [3594180](https://github.com/ratatui-org/ratatui/commit/35941809e11ab43309dd83a8f67bb375f5e7ff2b) _(uncategorized)_ Make Stylize's `.bg(color)` generic by @kdheepak in [#1103](https://github.com/ratatui-org/ratatui/pull/1103) [**breaking**]
+- [3594180](https://github.com/ratatui/ratatui/commit/35941809e11ab43309dd83a8f67bb375f5e7ff2b) _(uncategorized)_ Make Stylize's `.bg(color)` generic by @kdheepak in [#1103](https://github.com/ratatui/ratatui/pull/1103) [**breaking**]
 
-- [0b5fd6b](https://github.com/ratatui-org/ratatui/commit/0b5fd6bf8eb64662df96900faea3608d4cbb3984) _(uncategorized)_ Add writer() and writer_mut() to termion and crossterm backends by @enricozb in [#991](https://github.com/ratatui-org/ratatui/pull/991)
+- [0b5fd6b](https://github.com/ratatui/ratatui/commit/0b5fd6bf8eb64662df96900faea3608d4cbb3984) _(uncategorized)_ Add writer() and writer_mut() to termion and crossterm backends by @enricozb in [#991](https://github.com/ratatui/ratatui/pull/991)
 
   ```text
   It is sometimes useful to obtain access to the writer if we want to see
@@ -562,21 +564,21 @@ cat tracing.log
 
 ### Bug Fixes
 
-- [efa965e](https://github.com/ratatui-org/ratatui/commit/efa965e1e806c60cb1bdb2d1715f960db0857704) _(line)_ Remove newlines when converting strings to Lines by @joshka in [#1191](https://github.com/ratatui-org/ratatui/pull/1191)
+- [efa965e](https://github.com/ratatui/ratatui/commit/efa965e1e806c60cb1bdb2d1715f960db0857704) _(line)_ Remove newlines when converting strings to Lines by @joshka in [#1191](https://github.com/ratatui/ratatui/pull/1191)
 
   `Line::from("a\nb")` now returns a line with two `Span`s instead of 1
 
-  Fixes:https://github.com/ratatui-org/ratatui/issues/1111
+  Fixes:<https://github.com/ratatui/ratatui/issues/1111>
 
-- [d370aa7](https://github.com/ratatui-org/ratatui/commit/d370aa75af99da3e0c41ceb28e2d02ee81cd2538) _(span)_ Ensure that zero-width characters are rendered correctly by @joshka in [#1165](https://github.com/ratatui-org/ratatui/pull/1165)
+- [d370aa7](https://github.com/ratatui/ratatui/commit/d370aa75af99da3e0c41ceb28e2d02ee81cd2538) _(span)_ Ensure that zero-width characters are rendered correctly by @joshka in [#1165](https://github.com/ratatui/ratatui/pull/1165)
 
-- [127d706](https://github.com/ratatui-org/ratatui/commit/127d706ee4876a58230f42f4a730b18671eae167) _(table)_ Ensure render offset without selection properly by @joshka in [#1187](https://github.com/ratatui-org/ratatui/pull/1187)
+- [127d706](https://github.com/ratatui/ratatui/commit/127d706ee4876a58230f42f4a730b18671eae167) _(table)_ Ensure render offset without selection properly by @joshka in [#1187](https://github.com/ratatui/ratatui/pull/1187)
 
-  Fixes:<https://github.com/ratatui-org/ratatui/issues/1179>
+  Fixes:<https://github.com/ratatui/ratatui/issues/1179>
 
-- [4bfdc15](https://github.com/ratatui-org/ratatui/commit/4bfdc15b80ba14489d359ab1f88564c3bd016c19) _(uncategorized)_ Render of &str and String doesn't respect area.width by @thscharler in [#1177](https://github.com/ratatui-org/ratatui/pull/1177)
+- [4bfdc15](https://github.com/ratatui/ratatui/commit/4bfdc15b80ba14489d359ab1f88564c3bd016c19) _(uncategorized)_ Render of &str and String doesn't respect area.width by @thscharler in [#1177](https://github.com/ratatui/ratatui/pull/1177)
 
-- [e6871b9](https://github.com/ratatui-org/ratatui/commit/e6871b9e21c25acf1e203f4860198c37aa9429a1) _(uncategorized)_ Avoid unicode-width breaking change in tests by @joshka in [#1171](https://github.com/ratatui-org/ratatui/pull/1171)
+- [e6871b9](https://github.com/ratatui/ratatui/commit/e6871b9e21c25acf1e203f4860198c37aa9429a1) _(uncategorized)_ Avoid unicode-width breaking change in tests by @joshka in [#1171](https://github.com/ratatui/ratatui/pull/1171)
 
   ```text
   unicode-width 0.1.13 changed the width of \u{1} from 0 to 1.
@@ -587,7 +589,7 @@ cat tracing.log
   https://github.com/unicode-rs/unicode-width/issues/55
   ```
 
-- [7f3efb0](https://github.com/ratatui-org/ratatui/commit/7f3efb02e6f846fc72079f0921abd2cee09d2d83) _(uncategorized)_ Pin unicode-width crate to 0.1.13 by @joshka in [#1170](https://github.com/ratatui-org/ratatui/pull/1170)
+- [7f3efb0](https://github.com/ratatui/ratatui/commit/7f3efb02e6f846fc72079f0921abd2cee09d2d83) _(uncategorized)_ Pin unicode-width crate to 0.1.13 by @joshka in [#1170](https://github.com/ratatui/ratatui/pull/1170)
 
   ```text
   semver breaking change in 0.1.13
@@ -596,21 +598,21 @@ cat tracing.log
   <!-- Please read CONTRIBUTING.md before submitting any pull request. -->
   ```
 
-- [42cda6d](https://github.com/ratatui-org/ratatui/commit/42cda6d28706bf83308787ca784f374f6c286a02) _(uncategorized)_ Prevent panic from string_slice by @EdJoPaTo in [#1140](https://github.com/ratatui-org/ratatui/pull/1140)
+- [42cda6d](https://github.com/ratatui/ratatui/commit/42cda6d28706bf83308787ca784f374f6c286a02) _(uncategorized)_ Prevent panic from string_slice by @EdJoPaTo in [#1140](https://github.com/ratatui/ratatui/pull/1140)
 
   <https://rust-lang.github.io/rust-clippy/master/index.html#string_slice>
 
 ### Refactor
 
-- [73fd367](https://github.com/ratatui-org/ratatui/commit/73fd367a740924ce80ef7a0cd13a66b5094f7a54) _(block)_ Group builder pattern methods by @EdJoPaTo in [#1134](https://github.com/ratatui-org/ratatui/pull/1134)
+- [73fd367](https://github.com/ratatui/ratatui/commit/73fd367a740924ce80ef7a0cd13a66b5094f7a54) _(block)_ Group builder pattern methods by @EdJoPaTo in [#1134](https://github.com/ratatui/ratatui/pull/1134)
 
-- [257db62](https://github.com/ratatui-org/ratatui/commit/257db6257f392a07ee238b439344d91566beb740) _(cell)_ Must_use and simplify style() by @EdJoPaTo in [#1124](https://github.com/ratatui-org/ratatui/pull/1124)
+- [257db62](https://github.com/ratatui/ratatui/commit/257db6257f392a07ee238b439344d91566beb740) _(cell)_ Must_use and simplify style() by @EdJoPaTo in [#1124](https://github.com/ratatui/ratatui/pull/1124)
 
   ```text
   <!-- Please read CONTRIBUTING.md before submitting any pull request. -->
   ```
 
-- [bf20369](https://github.com/ratatui-org/ratatui/commit/bf2036987f04d83f4f2b8338fab1b4fd7f4cc81d) _(cell)_ Reset instead of applying default by @EdJoPaTo in [#1127](https://github.com/ratatui-org/ratatui/pull/1127)
+- [bf20369](https://github.com/ratatui/ratatui/commit/bf2036987f04d83f4f2b8338fab1b4fd7f4cc81d) _(cell)_ Reset instead of applying default by @EdJoPaTo in [#1127](https://github.com/ratatui/ratatui/pull/1127)
 
   ```text
   Using reset is clearer to me what actually happens. On the other case a
@@ -618,13 +620,13 @@ cat tracing.log
   does the same in a less clear way.
   ```
 
-- [7d175f8](https://github.com/ratatui-org/ratatui/commit/7d175f85c1905c08adf547dd37cc89c63039f480) _(lint)_ Fix new lint warnings by @EdJoPaTo in [#1178](https://github.com/ratatui-org/ratatui/pull/1178)
+- [7d175f8](https://github.com/ratatui/ratatui/commit/7d175f85c1905c08adf547dd37cc89c63039f480) _(lint)_ Fix new lint warnings by @EdJoPaTo in [#1178](https://github.com/ratatui/ratatui/pull/1178)
 
-- [cf67ed9](https://github.com/ratatui-org/ratatui/commit/cf67ed9b884347cef034b09e0e9f9d4aff74ab0a) _(lint)_ Use clippy::or_fun_call by @EdJoPaTo in [#1138](https://github.com/ratatui-org/ratatui/pull/1138)
+- [cf67ed9](https://github.com/ratatui/ratatui/commit/cf67ed9b884347cef034b09e0e9f9d4aff74ab0a) _(lint)_ Use clippy::or_fun_call by @EdJoPaTo in [#1138](https://github.com/ratatui/ratatui/pull/1138)
 
   <https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call>
 
-- [4770e71](https://github.com/ratatui-org/ratatui/commit/4770e715819475cdca2f2ccdbac00cba203cd6d2) _(list)_ Remove deprecated `start_corner` and `Corner` by @Valentin271 in [#759](https://github.com/ratatui-org/ratatui/pull/759) [**breaking**]
+- [4770e71](https://github.com/ratatui/ratatui/commit/4770e715819475cdca2f2ccdbac00cba203cd6d2) _(list)_ Remove deprecated `start_corner` and `Corner` by @Valentin271 in [#759](https://github.com/ratatui/ratatui/pull/759) [**breaking**]
 
   `List::start_corner` was deprecated in v0.25. Use `List::direction` and
   `ListDirection` instead.
@@ -646,13 +648,13 @@ cat tracing.log
 
 `layout::Corner` is removed entirely.
 
-- [4f77910](https://github.com/ratatui-org/ratatui/commit/4f7791079edd16b54dc8cdfc95bb72b282a09576) _(padding)_ Add Padding::ZERO as a constant by @EdJoPaTo in [#1133](https://github.com/ratatui-org/ratatui/pull/1133)
+- [4f77910](https://github.com/ratatui/ratatui/commit/4f7791079edd16b54dc8cdfc95bb72b282a09576) _(padding)_ Add Padding::ZERO as a constant by @EdJoPaTo in [#1133](https://github.com/ratatui/ratatui/pull/1133)
 
   ```text
   Deprecate Padding::zero()
   ```
 
-- [8061813](https://github.com/ratatui-org/ratatui/commit/8061813f324c08e11196e62fca22c2f6b9216b7e) _(uncategorized)_ Expand glob imports by @joshka in [#1152](https://github.com/ratatui-org/ratatui/pull/1152)
+- [8061813](https://github.com/ratatui/ratatui/commit/8061813f324c08e11196e62fca22c2f6b9216b7e) _(uncategorized)_ Expand glob imports by @joshka in [#1152](https://github.com/ratatui/ratatui/pull/1152)
 
   ```text
   Consensus is that explicit imports make it easier to understand the
@@ -661,21 +663,21 @@ cat tracing.log
   imports (widget::*, Constraint::*, KeyCode::*, etc.) everywhere else.
   Prelude glob imports not in examples are not covered by this PR.
 
-  See https://github.com/ratatui-org/ratatui/issues/1150 for more details.
+  See https://github.com/ratatui/ratatui/issues/1150 for more details.
   ```
 
-- [d929971](https://github.com/ratatui-org/ratatui/commit/d92997105bde15a1fd43829466ec8cc46bffe121) _(uncategorized)_ Dont manually impl Default for defaults by @EdJoPaTo in [#1142](https://github.com/ratatui-org/ratatui/pull/1142)
+- [d929971](https://github.com/ratatui/ratatui/commit/d92997105bde15a1fd43829466ec8cc46bffe121) _(uncategorized)_ Dont manually impl Default for defaults by @EdJoPaTo in [#1142](https://github.com/ratatui/ratatui/pull/1142)
 
   ```text
   Replace `impl Default` by `#[derive(Default)]` when its implementation
   equals.
   ```
 
-- [8a60a56](https://github.com/ratatui-org/ratatui/commit/8a60a561c95691912cbf41d55866abafcba0127d) _(uncategorized)_ Needless_pass_by_ref_mut by @EdJoPaTo in [#1137](https://github.com/ratatui-org/ratatui/pull/1137)
+- [8a60a56](https://github.com/ratatui/ratatui/commit/8a60a561c95691912cbf41d55866abafcba0127d) _(uncategorized)_ Needless_pass_by_ref_mut by @EdJoPaTo in [#1137](https://github.com/ratatui/ratatui/pull/1137)
 
   <https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut>
 
-- [1de9a82](https://github.com/ratatui-org/ratatui/commit/1de9a82b7a871a83995d224785cae139c6f4787b) _(uncategorized)_ Simplify if let by @EdJoPaTo in [#1135](https://github.com/ratatui-org/ratatui/pull/1135)
+- [1de9a82](https://github.com/ratatui/ratatui/commit/1de9a82b7a871a83995d224785cae139c6f4787b) _(uncategorized)_ Simplify if let by @EdJoPaTo in [#1135](https://github.com/ratatui/ratatui/pull/1135)
 
   ```text
   While looking through lints
@@ -685,21 +687,21 @@ cat tracing.log
 
 ### Documentation
 
-- [1908b06](https://github.com/ratatui-org/ratatui/commit/1908b06b4a497ff1cfb2c8d8c165d2a241ee1864) _(borders)_ Add missing closing code blocks by @orhun in [#1195](https://github.com/ratatui-org/ratatui/pull/1195)
+- [1908b06](https://github.com/ratatui/ratatui/commit/1908b06b4a497ff1cfb2c8d8c165d2a241ee1864) _(borders)_ Add missing closing code blocks by @orhun in [#1195](https://github.com/ratatui/ratatui/pull/1195)
 
-- [38bb196](https://github.com/ratatui-org/ratatui/commit/38bb19640449c7a3eee3a2fba6450071395e5e06) _(breaking-changes)_ Mention `LineGauge::gauge_style` by @orhun in [#1194](https://github.com/ratatui-org/ratatui/pull/1194)
+- [38bb196](https://github.com/ratatui/ratatui/commit/38bb19640449c7a3eee3a2fba6450071395e5e06) _(breaking-changes)_ Mention `LineGauge::gauge_style` by @orhun in [#1194](https://github.com/ratatui/ratatui/pull/1194)
 
   see #565
 
-- [07efde5](https://github.com/ratatui-org/ratatui/commit/07efde5233752e1bcb7ae94a91b9e36b7fadb01b) _(examples)_ Add hyperlink example by @joshka in [#1063](https://github.com/ratatui-org/ratatui/pull/1063)
+- [07efde5](https://github.com/ratatui/ratatui/commit/07efde5233752e1bcb7ae94a91b9e36b7fadb01b) _(examples)_ Add hyperlink example by @joshka in [#1063](https://github.com/ratatui/ratatui/pull/1063)
 
-- [7fdccaf](https://github.com/ratatui-org/ratatui/commit/7fdccafd52f4ddad1a3c9dda59fada59af21ecfa) _(examples)_ Add vhs tapes for constraint-explorer and minimal examples by @joshka in [#1164](https://github.com/ratatui-org/ratatui/pull/1164)
+- [7fdccaf](https://github.com/ratatui/ratatui/commit/7fdccafd52f4ddad1a3c9dda59fada59af21ecfa) _(examples)_ Add vhs tapes for constraint-explorer and minimal examples by @joshka in [#1164](https://github.com/ratatui/ratatui/pull/1164)
 
-- [4f307e6](https://github.com/ratatui-org/ratatui/commit/4f307e69db058891675d0f12d75ef49006c511d6) _(examples)_ Simplify paragraph example by @joshka in [#1169](https://github.com/ratatui-org/ratatui/pull/1169)
+- [4f307e6](https://github.com/ratatui/ratatui/commit/4f307e69db058891675d0f12d75ef49006c511d6) _(examples)_ Simplify paragraph example by @joshka in [#1169](https://github.com/ratatui/ratatui/pull/1169)
 
-  Related:https://github.com/ratatui-org/ratatui/issues/1157
+  Related:<https://github.com/ratatui/ratatui/issues/1157>
 
-- [f429f68](https://github.com/ratatui-org/ratatui/commit/f429f688da536a52266144e63a1a7897ec6b7f26) _(examples)_ Remove lifetimes from the List example by @matta in [#1132](https://github.com/ratatui-org/ratatui/pull/1132)
+- [f429f68](https://github.com/ratatui/ratatui/commit/f429f688da536a52266144e63a1a7897ec6b7f26) _(examples)_ Remove lifetimes from the List example by @matta in [#1132](https://github.com/ratatui/ratatui/pull/1132)
 
   ```text
   Simplify the List example by removing lifetimes not strictly necessary
@@ -709,9 +711,9 @@ cat tracing.log
   `From` trait.
   ```
 
-- [308c1df](https://github.com/ratatui-org/ratatui/commit/308c1df6495ee4373f808007a1566ca7e9279933) _(readme)_ Add links to forum by @joshka in [#1188](https://github.com/ratatui-org/ratatui/pull/1188)
+- [308c1df](https://github.com/ratatui/ratatui/commit/308c1df6495ee4373f808007a1566ca7e9279933) _(readme)_ Add links to forum by @joshka in [#1188](https://github.com/ratatui/ratatui/pull/1188)
 
-- [2f8a936](https://github.com/ratatui-org/ratatui/commit/2f8a9363fc6c54fe2b10792c9f57fbb40b06bc0f) _(uncategorized)_ Fix links on docs.rs by @EdJoPaTo in [#1144](https://github.com/ratatui-org/ratatui/pull/1144)
+- [2f8a936](https://github.com/ratatui/ratatui/commit/2f8a9363fc6c54fe2b10792c9f57fbb40b06bc0f) _(uncategorized)_ Fix links on docs.rs by @EdJoPaTo in [#1144](https://github.com/ratatui/ratatui/pull/1144)
 
   ```text
   This also results in a more readable Cargo.toml as the locations of the
@@ -725,9 +727,9 @@ cat tracing.log
 
 ### Performance
 
-- [4ce67fc](https://github.com/ratatui-org/ratatui/commit/4ce67fc84e3bc472e9ae97aece85f8ffae091834) _(buffer)_ Filled moves the cell to be filled by @EdJoPaTo in [#1148](https://github.com/ratatui-org/ratatui/pull/1148) [**breaking**]
+- [4ce67fc](https://github.com/ratatui/ratatui/commit/4ce67fc84e3bc472e9ae97aece85f8ffae091834) _(buffer)_ Filled moves the cell to be filled by @EdJoPaTo in [#1148](https://github.com/ratatui/ratatui/pull/1148) [**breaking**]
 
-- [8b447ec](https://github.com/ratatui-org/ratatui/commit/8b447ec4d6276c3110285e663417487ff18dafc1) _(rect)_ `Rect::inner` takes `Margin` directly instead of reference by @EdJoPaTo in [#1008](https://github.com/ratatui-org/ratatui/pull/1008) [**breaking**]
+- [8b447ec](https://github.com/ratatui/ratatui/commit/8b447ec4d6276c3110285e663417487ff18dafc1) _(rect)_ `Rect::inner` takes `Margin` directly instead of reference by @EdJoPaTo in [#1008](https://github.com/ratatui/ratatui/pull/1008) [**breaking**]
 
   BREAKING CHANGE:Margin needs to be passed without reference now.
 
@@ -741,11 +743,11 @@ cat tracing.log
 
 ### Styling
 
-- [df4b706](https://github.com/ratatui-org/ratatui/commit/df4b706674de806bdf2a1fb8c04d0654b6b0b891) _(uncategorized)_ Enable more rustfmt settings by @EdJoPaTo in [#1125](https://github.com/ratatui-org/ratatui/pull/1125)
+- [df4b706](https://github.com/ratatui/ratatui/commit/df4b706674de806bdf2a1fb8c04d0654b6b0b891) _(uncategorized)_ Enable more rustfmt settings by @EdJoPaTo in [#1125](https://github.com/ratatui/ratatui/pull/1125)
 
 ### Testing
 
-- [d6587bc](https://github.com/ratatui-org/ratatui/commit/d6587bc6b0db955aeac6af167e1b8ef81a3afcc9) _(style)_ Use rstest by @EdJoPaTo in [#1136](https://github.com/ratatui-org/ratatui/pull/1136)
+- [d6587bc](https://github.com/ratatui/ratatui/commit/d6587bc6b0db955aeac6af167e1b8ef81a3afcc9) _(style)_ Use rstest by @EdJoPaTo in [#1136](https://github.com/ratatui/ratatui/pull/1136)
 
   ```text
   <!-- Please read CONTRIBUTING.md before submitting any pull request. -->
@@ -753,7 +755,7 @@ cat tracing.log
 
 ### Miscellaneous Tasks
 
-- [7b45f74](https://github.com/ratatui-org/ratatui/commit/7b45f74b719ff18329ddbf9f05a9ac53bf06f71d) _(prelude)_ Add / remove items by @joshka in [#1149](https://github.com/ratatui-org/ratatui/pull/1149) [**breaking**]
+- [7b45f74](https://github.com/ratatui/ratatui/commit/7b45f74b719ff18329ddbf9f05a9ac53bf06f71d) _(prelude)_ Add / remove items by @joshka in [#1149](https://github.com/ratatui/ratatui/pull/1149) [**breaking**]
 
   ```text
   his PR removes the items from the prelude that don't form a coherent
@@ -781,13 +783,13 @@ The following items have been added to the prelude:
   to interact with the layout system. These are newer items that were
   added in the last few releases, which should be used more liberally.
 
-- [cd64367](https://github.com/ratatui-org/ratatui/commit/cd64367e244a1588206f653fd79678ce62a86a2f) _(symbols)_ Add tests for line symbols by @joshka in [#1186](https://github.com/ratatui-org/ratatui/pull/1186)
+- [cd64367](https://github.com/ratatui/ratatui/commit/cd64367e244a1588206f653fd79678ce62a86a2f) _(symbols)_ Add tests for line symbols by @joshka in [#1186](https://github.com/ratatui/ratatui/pull/1186)
 
-- [8cfc316](https://github.com/ratatui-org/ratatui/commit/8cfc316bccb48e88660d14cd18c0df2264c4d6ce) _(uncategorized)_ Alphabetize examples in Cargo.toml by @joshka in [#1145](https://github.com/ratatui-org/ratatui/pull/1145)
+- [8cfc316](https://github.com/ratatui/ratatui/commit/8cfc316bccb48e88660d14cd18c0df2264c4d6ce) _(uncategorized)_ Alphabetize examples in Cargo.toml by @joshka in [#1145](https://github.com/ratatui/ratatui/pull/1145)
 
 ### Build
 
-- [70df102](https://github.com/ratatui-org/ratatui/commit/70df102de0154cdfbd6508659cf6ed649f820bc8) _(bench)_ Improve benchmark consistency by @EdJoPaTo in [#1126](https://github.com/ratatui-org/ratatui/pull/1126)
+- [70df102](https://github.com/ratatui/ratatui/commit/70df102de0154cdfbd6508659cf6ed649f820bc8) _(bench)_ Improve benchmark consistency by @EdJoPaTo in [#1126](https://github.com/ratatui/ratatui/pull/1126)
 
   ```text
   Codegen units are optimized on their own. Per default bench / release
@@ -801,14 +803,14 @@ The following items have been added to the prelude:
 
 ### New Contributors
 
-- @thscharler made their first contribution in [#1177](https://github.com/ratatui-org/ratatui/pull/1177)
-- @matta made their first contribution in [#1132](https://github.com/ratatui-org/ratatui/pull/1132)
-- @nowNick made their first contribution in [#565](https://github.com/ratatui-org/ratatui/pull/565)
-- @enricozb made their first contribution in [#991](https://github.com/ratatui-org/ratatui/pull/991)
+- @thscharler made their first contribution in [#1177](https://github.com/ratatui/ratatui/pull/1177)
+- @matta made their first contribution in [#1132](https://github.com/ratatui/ratatui/pull/1132)
+- @nowNick made their first contribution in [#565](https://github.com/ratatui/ratatui/pull/565)
+- @enricozb made their first contribution in [#991](https://github.com/ratatui/ratatui/pull/991)
 
-**Full Changelog**: https://github.com/ratatui-org/ratatui/compare/v0.26.3...v0.27.0
+**Full Changelog**: <https://github.com/ratatui/ratatui/compare/v0.26.3...v0.27.0>
 
-## [0.26.3](https://github.com/ratatui-org/ratatui/releases/tag/v0.26.3) - 2024-05-19
+## [0.26.3](https://github.com/ratatui/ratatui/releases/tag/v0.26.3) - 2024-05-19
 
 We are happy to announce a brand new [**Ratatui Forum**](https://forum.ratatui.rs) 🐭 for Rust & TUI enthusiasts.
 
@@ -818,17 +820,18 @@ This is a patch release that fixes the unicode truncation bug, adds performance 
 
 ### Features
 
-- [97ee102](https://github.com/ratatui-org/ratatui/commit/97ee102f179eed4f309d575495f0e4c8359b4f04) *(buffer)* Track_caller for index_of by @EdJoPaTo in [#1046](https://github.com/ratatui-org/ratatui/pull/1046)
+- [97ee102](https://github.com/ratatui/ratatui/commit/97ee102f179eed4f309d575495f0e4c8359b4f04) _(buffer)_ Track_caller for index_of by @EdJoPaTo in [#1046](https://github.com/ratatui/ratatui/pull/1046)
 **
+
   ````text
   The caller put in the wrong x/y -> the caller is the cause.
   ````
 
-- [bf09234](https://github.com/ratatui-org/ratatui/commit/bf0923473c5cb7f2cff24b010f0072b5ce2f8cf2) *(table)* Make TableState::new const by @EdJoPaTo in [#1040](https://github.com/ratatui-org/ratatui/pull/1040)
+- [bf09234](https://github.com/ratatui/ratatui/commit/bf0923473c5cb7f2cff24b010f0072b5ce2f8cf2) _(table)_ Make TableState::new const by @EdJoPaTo in [#1040](https://github.com/ratatui/ratatui/pull/1040)
 
-- [eb281df](https://github.com/ratatui-org/ratatui/commit/eb281df97482c2aab66875dc27a49a316a4d7fd7) *(uncategorized)* Use inner Display implementation by @EdJoPaTo in [#1097](https://github.com/ratatui-org/ratatui/pull/1097)
+- [eb281df](https://github.com/ratatui/ratatui/commit/eb281df97482c2aab66875dc27a49a316a4d7fd7) _(uncategorized)_ Use inner Display implementation by @EdJoPaTo in [#1097](https://github.com/ratatui/ratatui/pull/1097)
 
-- [ec763af](https://github.com/ratatui-org/ratatui/commit/ec763af8512df731799c8f30c38c37252068a4c4) *(uncategorized)* Make Stylize's `.bg(color)` generic by @kdheepak in [#1099](https://github.com/ratatui-org/ratatui/pull/1099)
+- [ec763af](https://github.com/ratatui/ratatui/commit/ec763af8512df731799c8f30c38c37252068a4c4) _(uncategorized)_ Make Stylize's `.bg(color)` generic by @kdheepak in [#1099](https://github.com/ratatui/ratatui/pull/1099)
 
   ````text
   This PR makes `.bg(color)` generic accepting anything that can be
@@ -836,20 +839,20 @@ This is a patch release that fixes the unicode truncation bug, adds performance 
   trait
   ````
 
-- [4d1784f](https://github.com/ratatui-org/ratatui/commit/4d1784f2de104b88e998216addaae96ab018f44f) *(uncategorized)* Re-export ParseColorError as style::ParseColorError by @joshka in [#1086](https://github.com/ratatui-org/ratatui/pull/1086)
+- [4d1784f](https://github.com/ratatui/ratatui/commit/4d1784f2de104b88e998216addaae96ab018f44f) _(uncategorized)_ Re-export ParseColorError as style::ParseColorError by @joshka in [#1086](https://github.com/ratatui/ratatui/pull/1086)
 
-  Fixes:https://github.com/ratatui-org/ratatui/issues/1085
+  Fixes:<https://github.com/ratatui/ratatui/issues/1085>
 
 ### Bug Fixes
 
-- [366cbae](https://github.com/ratatui-org/ratatui/commit/366cbae09fb2bf5b5d7f489de1ff15f930569f05) *(buffer)* Fix Debug panic and fix formatting of overridden parts by @EdJoPaTo in [#1098](https://github.com/ratatui-org/ratatui/pull/1098)
+- [366cbae](https://github.com/ratatui/ratatui/commit/366cbae09fb2bf5b5d7f489de1ff15f930569f05) _(buffer)_ Fix Debug panic and fix formatting of overridden parts by @EdJoPaTo in [#1098](https://github.com/ratatui/ratatui/pull/1098)
 
   ````text
   Fix panic in `Debug for Buffer` when `width == 0`.
   Also corrects the output when symbols are overridden.
   ````
 
-- [4392759](https://github.com/ratatui-org/ratatui/commit/43927595012254b33a3901e0d2e5d28164ad04f0) *(examples)* Changed user_input example to work with multi-byte unicode chars by @OkieOth in [#1069](https://github.com/ratatui-org/ratatui/pull/1069)
+- [4392759](https://github.com/ratatui/ratatui/commit/43927595012254b33a3901e0d2e5d28164ad04f0) _(examples)_ Changed user_input example to work with multi-byte unicode chars by @OkieOth in [#1069](https://github.com/ratatui/ratatui/pull/1069)
 
   ````text
   This is the proposed solution for issue #1068. It solves the bug in the
@@ -860,7 +863,7 @@ This is a patch release that fixes the unicode truncation bug, adds performance 
 
 ---------
 
-- [20fc0dd](https://github.com/ratatui-org/ratatui/commit/20fc0ddfca97a863c9ec7537bcf283d3d49baab4) *(examples)* Fix key handling in constraints by @psobolik in [#1066](https://github.com/ratatui-org/ratatui/pull/1066)
+- [20fc0dd](https://github.com/ratatui/ratatui/commit/20fc0ddfca97a863c9ec7537bcf283d3d49baab4) _(examples)_ Fix key handling in constraints by @psobolik in [#1066](https://github.com/ratatui/ratatui/pull/1066)
 
   ````text
   Add check for `KeyEventKind::Press` to constraints example's event
@@ -872,9 +875,9 @@ This is a patch release that fixes the unicode truncation bug, adds performance 
 
 ---------
 
-- [f4637d4](https://github.com/ratatui-org/ratatui/commit/f4637d40c35e068fd60d17c9a42b9114667c9861) *(reflow)* Allow wrapping at zero width whitespace by @kxxt in [#1074](https://github.com/ratatui-org/ratatui/pull/1074)
+- [f4637d4](https://github.com/ratatui/ratatui/commit/f4637d40c35e068fd60d17c9a42b9114667c9861) _(reflow)_ Allow wrapping at zero width whitespace by @kxxt in [#1074](https://github.com/ratatui/ratatui/pull/1074)
 
-- [699c2d7](https://github.com/ratatui-org/ratatui/commit/699c2d7c8d0e8c2023cf75350b66535a7b48a102) *(uncategorized)* Unicode truncation bug by @joshka in [#1089](https://github.com/ratatui-org/ratatui/pull/1089)
+- [699c2d7](https://github.com/ratatui/ratatui/commit/699c2d7c8d0e8c2023cf75350b66535a7b48a102) _(uncategorized)_ Unicode truncation bug by @joshka in [#1089](https://github.com/ratatui/ratatui/pull/1089)
 
   ````text
   - Rewrote the line / span rendering code to take into account how
@@ -884,22 +887,22 @@ This is a patch release that fixes the unicode truncation bug, adds performance 
   - Adds a benchmark to ensure perf
   ````
 
-  Fixes:https://github.com/ratatui-org/ratatui/issues/1032
+  Fixes:<https://github.com/ratatui/ratatui/issues/1032>
 
-- [b30411d](https://github.com/ratatui-org/ratatui/commit/b30411d1c71cb7b43b7232226514caa54a56c25f) *(uncategorized)* Termwiz underline color test by @joshka in [#1094](https://github.com/ratatui-org/ratatui/pull/1094)
+- [b30411d](https://github.com/ratatui/ratatui/commit/b30411d1c71cb7b43b7232226514caa54a56c25f) _(uncategorized)_ Termwiz underline color test by @joshka in [#1094](https://github.com/ratatui/ratatui/pull/1094)
 
   ````text
   Fixes code that doesn't compile in the termwiz tests when
   underline-color feature is enabled.
   ````
 
-- [5f1e119](https://github.com/ratatui-org/ratatui/commit/5f1e119563043e97e5c2c5e7dd48ccd75e17791e) *(uncategorized)* Correct feature flag typo for termwiz by @joshka in [#1088](https://github.com/ratatui-org/ratatui/pull/1088)
+- [5f1e119](https://github.com/ratatui/ratatui/commit/5f1e119563043e97e5c2c5e7dd48ccd75e17791e) _(uncategorized)_ Correct feature flag typo for termwiz by @joshka in [#1088](https://github.com/ratatui/ratatui/pull/1088)
 
   ````text
   underline-color was incorrectly spelt as underline_color
   ````
 
-- [0a16496](https://github.com/ratatui-org/ratatui/commit/0a164965ea2b163433871717cee4fd774a23ee5a) *(uncategorized)* Use `to_string` to serialize Color by @SleepySwords in [#934](https://github.com/ratatui-org/ratatui/pull/934)
+- [0a16496](https://github.com/ratatui/ratatui/commit/0a164965ea2b163433871717cee4fd774a23ee5a) _(uncategorized)_ Use `to_string` to serialize Color by @SleepySwords in [#934](https://github.com/ratatui/ratatui/pull/934)
 
   ````text
   Since deserialize now uses `FromStr` to deserialize color, serializing
@@ -921,7 +924,7 @@ Other color variants remain the same.
 
 ### Refactor
 
-- [2cfe82a](https://github.com/ratatui-org/ratatui/commit/2cfe82a47eb34baa25f474db7be364de7b95374a) *(buffer)* Deprecate assert_buffer_eq! in favor of assert_eq! by @EdJoPaTo in [#1007](https://github.com/ratatui-org/ratatui/pull/1007)
+- [2cfe82a](https://github.com/ratatui/ratatui/commit/2cfe82a47eb34baa25f474db7be364de7b95374a) _(buffer)_ Deprecate assert_buffer_eq! in favor of assert_eq! by @EdJoPaTo in [#1007](https://github.com/ratatui/ratatui/pull/1007)
 
   ````text
   - Simplify `assert_buffer_eq!` logic.
@@ -948,9 +951,9 @@ Other color variants remain the same.
   changes to the library code.
   ````
 
-- [baedc39](https://github.com/ratatui-org/ratatui/commit/baedc39494ea70292b1d247934420a20d0544b7e) *(buffer)* Simplify set_stringn logic by @EdJoPaTo in [#1083](https://github.com/ratatui-org/ratatui/pull/1083)
+- [baedc39](https://github.com/ratatui/ratatui/commit/baedc39494ea70292b1d247934420a20d0544b7e) _(buffer)_ Simplify set_stringn logic by @EdJoPaTo in [#1083](https://github.com/ratatui/ratatui/pull/1083)
 
-- [9bd89c2](https://github.com/ratatui-org/ratatui/commit/9bd89c218afb1f3999dce1bfe6edea5b7442966d) *(clippy)* Enable breaking lint checks by @EdJoPaTo in [#988](https://github.com/ratatui-org/ratatui/pull/988)
+- [9bd89c2](https://github.com/ratatui/ratatui/commit/9bd89c218afb1f3999dce1bfe6edea5b7442966d) _(clippy)_ Enable breaking lint checks by @EdJoPaTo in [#988](https://github.com/ratatui/ratatui/pull/988)
 
   ````text
   We need to make sure to not change existing methods without a notice.
@@ -962,43 +965,43 @@ Other color variants remain the same.
   It's not breaking because the old method is still there.
   ````
 
-- [bef5bcf](https://github.com/ratatui-org/ratatui/commit/bef5bcf750375a78b11ae06f217091b2463e842f) *(example)* Remove pointless new method by @EdJoPaTo in [#1038](https://github.com/ratatui-org/ratatui/pull/1038)
+- [bef5bcf](https://github.com/ratatui/ratatui/commit/bef5bcf750375a78b11ae06f217091b2463e842f) _(example)_ Remove pointless new method by @EdJoPaTo in [#1038](https://github.com/ratatui/ratatui/pull/1038)
 
   ````text
   Use `App::default()` directly.
   ````
 
-- [f3172c5](https://github.com/ratatui-org/ratatui/commit/f3172c59d4dae6ce4909251976a39c21d88f1907) *(gauge)* Fix internal typo by @EdJoPaTo in [#1048](https://github.com/ratatui-org/ratatui/pull/1048)
+- [f3172c5](https://github.com/ratatui/ratatui/commit/f3172c59d4dae6ce4909251976a39c21d88f1907) _(gauge)_ Fix internal typo by @EdJoPaTo in [#1048](https://github.com/ratatui/ratatui/pull/1048)
 
 ### Documentation
 
-- [da1ade7](https://github.com/ratatui-org/ratatui/commit/da1ade7b2e4d8909ea0001483780d2c907349fd6) *(github)* Update code owners about past maintainers by @orhun in [#1073](https://github.com/ratatui-org/ratatui/pull/1073)
+- [da1ade7](https://github.com/ratatui/ratatui/commit/da1ade7b2e4d8909ea0001483780d2c907349fd6) _(github)_ Update code owners about past maintainers by @orhun in [#1073](https://github.com/ratatui/ratatui/pull/1073)
 
   ````text
   As per suggestion in
-  https://github.com/ratatui-org/ratatui/pull/1067#issuecomment-2079766990
+  https://github.com/ratatui/ratatui/pull/1067#issuecomment-2079766990
 
   It's good for historical purposes!
   ````
 
-- [3687f78](https://github.com/ratatui-org/ratatui/commit/3687f78f6a06bd175eda3e19819f6dc68012fb59) *(github)* Update code owners by @orhun in [#1067](https://github.com/ratatui-org/ratatui/pull/1067)
+- [3687f78](https://github.com/ratatui/ratatui/commit/3687f78f6a06bd175eda3e19819f6dc68012fb59) _(github)_ Update code owners by @orhun in [#1067](https://github.com/ratatui/ratatui/pull/1067)
 
   ````text
   Removes the team members that are not able to review PRs recently (with
   their approval ofc)
   ````
 
-- [839cca2](https://github.com/ratatui-org/ratatui/commit/839cca20bf3f109352ea43f1119e13c879e04b95) *(table)* Fix typo in docs for highlight_symbol by @kdheepak in [#1108](https://github.com/ratatui-org/ratatui/pull/1108)
+- [839cca2](https://github.com/ratatui/ratatui/commit/839cca20bf3f109352ea43f1119e13c879e04b95) _(table)_ Fix typo in docs for highlight_symbol by @kdheepak in [#1108](https://github.com/ratatui/ratatui/pull/1108)
 
-- [f945a0b](https://github.com/ratatui-org/ratatui/commit/f945a0bcff644c1fa2ad3caaa87cf2b640beaf46) *(test)* Fix typo in TestBackend documentation by @orhun in [#1107](https://github.com/ratatui-org/ratatui/pull/1107)
+- [f945a0b](https://github.com/ratatui/ratatui/commit/f945a0bcff644c1fa2ad3caaa87cf2b640beaf46) _(test)_ Fix typo in TestBackend documentation by @orhun in [#1107](https://github.com/ratatui/ratatui/pull/1107)
 
-- [828d17a](https://github.com/ratatui-org/ratatui/commit/828d17a3f5f449255d7981bb462bf48382c7cb2e) *(uncategorized)* Add minimal example by @joshka in [#1114](https://github.com/ratatui-org/ratatui/pull/1114)
+- [828d17a](https://github.com/ratatui/ratatui/commit/828d17a3f5f449255d7981bb462bf48382c7cb2e) _(uncategorized)_ Add minimal example by @joshka in [#1114](https://github.com/ratatui/ratatui/pull/1114)
 
-- [e95230b](https://github.com/ratatui-org/ratatui/commit/e95230beda9f86dfb7a9bc1c1167e5a91a2748c3) *(uncategorized)* Add note about scrollbar state content length by @Utagai in [#1077](https://github.com/ratatui-org/ratatui/pull/1077)
+- [e95230b](https://github.com/ratatui/ratatui/commit/e95230beda9f86dfb7a9bc1c1167e5a91a2748c3) _(uncategorized)_ Add note about scrollbar state content length by @Utagai in [#1077](https://github.com/ratatui/ratatui/pull/1077)
 
 ### Performance
 
-- [366c2a0](https://github.com/ratatui-org/ratatui/commit/366c2a0e6d17810b26ba37918e72c2f784176d2c) *(block)* Use Block::bordered by @EdJoPaTo in [#1041](https://github.com/ratatui-org/ratatui/pull/1041)
+- [366c2a0](https://github.com/ratatui/ratatui/commit/366c2a0e6d17810b26ba37918e72c2f784176d2c) _(block)_ Use Block::bordered by @EdJoPaTo in [#1041](https://github.com/ratatui/ratatui/pull/1041)
 
   `Block::bordered()` is shorter than
 
@@ -1006,7 +1009,7 @@ Other color variants remain the same.
 (`Borders`) and in case `Block::default()` was used before can even be
 `const`.
 
-- [2e71c18](https://github.com/ratatui-org/ratatui/commit/2e71c1874e2de6d9f2bd21622246e55484a9fc62) *(buffer)* Simplify Buffer::filled with macro by @EdJoPaTo in [#1036](https://github.com/ratatui-org/ratatui/pull/1036)
+- [2e71c18](https://github.com/ratatui/ratatui/commit/2e71c1874e2de6d9f2bd21622246e55484a9fc62) _(buffer)_ Simplify Buffer::filled with macro by @EdJoPaTo in [#1036](https://github.com/ratatui/ratatui/pull/1036)
 
   ````text
   The `vec![]` macro is highly optimized by the Rust team and shorter.
@@ -1017,18 +1020,18 @@ Other color variants remain the same.
   not performance relevant on every render.
   ````
 
-- [81b9633](https://github.com/ratatui-org/ratatui/commit/81b96338ea41f9e5fbb0868808a0b450f31eef41) *(calendar)* Use const fn by @EdJoPaTo in [#1039](https://github.com/ratatui-org/ratatui/pull/1039)
+- [81b9633](https://github.com/ratatui/ratatui/commit/81b96338ea41f9e5fbb0868808a0b450f31eef41) _(calendar)_ Use const fn by @EdJoPaTo in [#1039](https://github.com/ratatui/ratatui/pull/1039)
 
   ````text
   Also, do the comparison without `as u8`. Stays the same at runtime and
   is cleaner code.
   ````
 
-- [c442dfd](https://github.com/ratatui-org/ratatui/commit/c442dfd1ad4896e7abeeaac1754b94bae1f8d014) *(canvas)* Change map data to const instead of static by @EdJoPaTo in [#1037](https://github.com/ratatui-org/ratatui/pull/1037)
+- [c442dfd](https://github.com/ratatui/ratatui/commit/c442dfd1ad4896e7abeeaac1754b94bae1f8d014) _(canvas)_ Change map data to const instead of static by @EdJoPaTo in [#1037](https://github.com/ratatui/ratatui/pull/1037)
 
-- [1706b0a](https://github.com/ratatui-org/ratatui/commit/1706b0a3e434c51dfed9af88470f47162b615c33) *(crossterm)* Speed up combined fg and bg color changes by up to 20% by @joshka in [#1072](https://github.com/ratatui-org/ratatui/pull/1072)
+- [1706b0a](https://github.com/ratatui/ratatui/commit/1706b0a3e434c51dfed9af88470f47162b615c33) _(crossterm)_ Speed up combined fg and bg color changes by up to 20% by @joshka in [#1072](https://github.com/ratatui/ratatui/pull/1072)
 
-- [1a4bb1c](https://github.com/ratatui-org/ratatui/commit/1a4bb1cbb8dc98ab3c9ecfce225a591b0f7a36bc) *(layout)* Avoid allocating memory when using split ergonomic utils by @tranzystorekk in [#1105](https://github.com/ratatui-org/ratatui/pull/1105)
+- [1a4bb1c](https://github.com/ratatui/ratatui/commit/1a4bb1cbb8dc98ab3c9ecfce225a591b0f7a36bc) _(layout)_ Avoid allocating memory when using split ergonomic utils by @tranzystorekk in [#1105](https://github.com/ratatui/ratatui/pull/1105)
 
   ````text
   Don't create intermediate vec in `Layout::areas` and
@@ -1037,22 +1040,22 @@ Other color variants remain the same.
 
 ### Styling
 
-- [aa4260f](https://github.com/ratatui-org/ratatui/commit/aa4260f92c869ed77123fab700f9f20b059bbe07) *(uncategorized)* Use std::fmt instead of importing Debug and Display by @joshka in [#1087](https://github.com/ratatui-org/ratatui/pull/1087)
+- [aa4260f](https://github.com/ratatui/ratatui/commit/aa4260f92c869ed77123fab700f9f20b059bbe07) _(uncategorized)_ Use std::fmt instead of importing Debug and Display by @joshka in [#1087](https://github.com/ratatui/ratatui/pull/1087)
 
   ````text
   This is a small universal style change to avoid making this change a
   part of other PRs.
 
-  [rationale](https://github.com/ratatui-org/ratatui/pull/1083#discussion_r1588466060)
+  [rationale](https://github.com/ratatui/ratatui/pull/1083#discussion_r1588466060)
   ````
 
 ### Testing
 
-- [3cc29bd](https://github.com/ratatui-org/ratatui/commit/3cc29bdada096283f1fa89d0a610fa6fd5425f9b) *(block)* Use rstest to simplify test cases by @EdJoPaTo in [#1095](https://github.com/ratatui-org/ratatui/pull/1095)
+- [3cc29bd](https://github.com/ratatui/ratatui/commit/3cc29bdada096283f1fa89d0a610fa6fd5425f9b) _(block)_ Use rstest to simplify test cases by @EdJoPaTo in [#1095](https://github.com/ratatui/ratatui/pull/1095)
 
 ### Miscellaneous Tasks
 
-- [5fbb77a](https://github.com/ratatui-org/ratatui/commit/5fbb77ad205ccff763d71899c2f5a34560d25b92) *(readme)* Use terminal theme for badges by @TadoTheMiner in [#1026](https://github.com/ratatui-org/ratatui/pull/1026)
+- [5fbb77a](https://github.com/ratatui/ratatui/commit/5fbb77ad205ccff763d71899c2f5a34560d25b92) _(readme)_ Use terminal theme for badges by @TadoTheMiner in [#1026](https://github.com/ratatui/ratatui/pull/1026)
 
   ````text
   The badges in the readme were all the default theme. Giving them
@@ -1060,21 +1063,21 @@ Other color variants remain the same.
   colors from the VHS repo.
   ````
 
-- [bef2bc1](https://github.com/ratatui-org/ratatui/commit/bef2bc1e7c012ecbf357ac54a5262304646b292d) *(cargo)* Add homepage to Cargo.toml by @joshka in [#1080](https://github.com/ratatui-org/ratatui/pull/1080)
+- [bef2bc1](https://github.com/ratatui/ratatui/commit/bef2bc1e7c012ecbf357ac54a5262304646b292d) _(cargo)_ Add homepage to Cargo.toml by @joshka in [#1080](https://github.com/ratatui/ratatui/pull/1080)
 
-- [76e5fe5](https://github.com/ratatui-org/ratatui/commit/76e5fe5a9a1934aa7cce8f0d48c1c9035ac0bf41) *(uncategorized)* Revert "Make Stylize's `.bg(color)` generic" by @kdheepak in [#1102](https://github.com/ratatui-org/ratatui/pull/1102)
+- [76e5fe5](https://github.com/ratatui/ratatui/commit/76e5fe5a9a1934aa7cce8f0d48c1c9035ac0bf41) _(uncategorized)_ Revert "Make Stylize's `.bg(color)` generic" by @kdheepak in [#1102](https://github.com/ratatui/ratatui/pull/1102)
 
   ````text
   This reverts commit ec763af8512df731799c8f30c38c37252068a4c4 from #1099
   ````
 
-- [64eb391](https://github.com/ratatui-org/ratatui/commit/64eb3913a4776db290baeb4179e00d2686d42934) *(uncategorized)* Fixup cargo lint for windows targets by @joshka in [#1071](https://github.com/ratatui-org/ratatui/pull/1071)
+- [64eb391](https://github.com/ratatui/ratatui/commit/64eb3913a4776db290baeb4179e00d2686d42934) _(uncategorized)_ Fixup cargo lint for windows targets by @joshka in [#1071](https://github.com/ratatui/ratatui/pull/1071)
 
   ````text
   Crossterm brings in multiple versions of the same dep
   ````
 
-- [326a461](https://github.com/ratatui-org/ratatui/commit/326a461f9a345ba853d57afefc8d77ba0b0b5a14) *(uncategorized)* Add package categories field by @mcskware in [#1035](https://github.com/ratatui-org/ratatui/pull/1035)
+- [326a461](https://github.com/ratatui/ratatui/commit/326a461f9a345ba853d57afefc8d77ba0b0b5a14) _(uncategorized)_ Add package categories field by @mcskware in [#1035](https://github.com/ratatui/ratatui/pull/1035)
 
   ````text
   Add the package categories field in Cargo.toml, with value
@@ -1083,7 +1086,7 @@ Other color variants remain the same.
   [`clippy::cargo_common_metadata`](https://rust-lang.github.io/rust-clippy/master/index.html#/cargo_common_metadata).
 
   As per discussion in [Cargo package categories
-  suggestions](https://github.com/ratatui-org/ratatui/discussions/1034),
+  suggestions](https://github.com/ratatui/ratatui/discussions/1034),
   this lint is not suggested to be run by default in CI, but rather as an
   occasional one-off as part of the larger
   [`clippy::cargo`](https://doc.rust-lang.org/stable/clippy/lints.html#cargo)
@@ -1092,15 +1095,15 @@ Other color variants remain the same.
 
 ### Build
 
-- [4955380](https://github.com/ratatui-org/ratatui/commit/4955380932ab4d657be15dd6c65f48334795c785) *(uncategorized)* Remove pre-push hooks by @joshka in [#1115](https://github.com/ratatui-org/ratatui/pull/1115)
+- [4955380](https://github.com/ratatui/ratatui/commit/4955380932ab4d657be15dd6c65f48334795c785) _(uncategorized)_ Remove pre-push hooks by @joshka in [#1115](https://github.com/ratatui/ratatui/pull/1115)
 
-- [28e81c0](https://github.com/ratatui-org/ratatui/commit/28e81c0714d55f0103d9f075609bcf7e5f551fb1) *(uncategorized)* Add underline-color to all features flag in makefile by @joshka in [#1100](https://github.com/ratatui-org/ratatui/pull/1100)
+- [28e81c0](https://github.com/ratatui/ratatui/commit/28e81c0714d55f0103d9f075609bcf7e5f551fb1) _(uncategorized)_ Add underline-color to all features flag in makefile by @joshka in [#1100](https://github.com/ratatui/ratatui/pull/1100)
 
-- [c75aa19](https://github.com/ratatui-org/ratatui/commit/c75aa1990f5c1e7e86de0fafc9ce0c1b1dcac3ea) *(uncategorized)* Add clippy::cargo lint by @joshka in [#1053](https://github.com/ratatui-org/ratatui/pull/1053)
+- [c75aa19](https://github.com/ratatui/ratatui/commit/c75aa1990f5c1e7e86de0fafc9ce0c1b1dcac3ea) _(uncategorized)_ Add clippy::cargo lint by @joshka in [#1053](https://github.com/ratatui/ratatui/pull/1053)
 
   ````text
-  Followup to https://github.com/ratatui-org/ratatui/pull/1035 and
-  https://github.com/ratatui-org/ratatui/discussions/1034
+  Followup to https://github.com/ratatui/ratatui/pull/1035 and
+  https://github.com/ratatui/ratatui/discussions/1034
 
   It's reasonable to enable this and deal with breakage by fixing any
   specific issues that arise.
@@ -1108,16 +1111,16 @@ Other color variants remain the same.
 
 ### New Contributors
 
-* @Utagai made their first contribution in [#1077](https://github.com/ratatui-org/ratatui/pull/1077)
-* @kxxt made their first contribution in [#1074](https://github.com/ratatui-org/ratatui/pull/1074)
-* @OkieOth made their first contribution in [#1069](https://github.com/ratatui-org/ratatui/pull/1069)
-* @psobolik made their first contribution in [#1066](https://github.com/ratatui-org/ratatui/pull/1066)
-* @SleepySwords made their first contribution in [#934](https://github.com/ratatui-org/ratatui/pull/934)
-* @mcskware made their first contribution in [#1035](https://github.com/ratatui-org/ratatui/pull/1035)
+- @Utagai made their first contribution in [#1077](https://github.com/ratatui/ratatui/pull/1077)
+- @kxxt made their first contribution in [#1074](https://github.com/ratatui/ratatui/pull/1074)
+- @OkieOth made their first contribution in [#1069](https://github.com/ratatui/ratatui/pull/1069)
+- @psobolik made their first contribution in [#1066](https://github.com/ratatui/ratatui/pull/1066)
+- @SleepySwords made their first contribution in [#934](https://github.com/ratatui/ratatui/pull/934)
+- @mcskware made their first contribution in [#1035](https://github.com/ratatui/ratatui/pull/1035)
 
-**Full Changelog**: https://github.com/ratatui-org/ratatui/compare/v0.26.2...v0.26.3
+**Full Changelog**: <https://github.com/ratatui/ratatui/compare/v0.26.2...v0.26.3>
 
-## [0.26.2](https://github.com/ratatui-org/ratatui/releases/tag/v0.26.2) - 2024-04-15
+## [0.26.2](https://github.com/ratatui/ratatui/releases/tag/v0.26.2) - 2024-04-15
 
 This is a patch release that fixes bugs and adds enhancements, including new iterator constructors, List scroll padding, and various rendering improvements. ✨
 
@@ -1125,11 +1128,11 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
 
 ### Features
 
-- [11b452d](https://github.com/ratatui-org/ratatui/commit/11b452d56fe590188ee7a53fa2dde95513b1a4c7)
-  *(layout)* Mark various functions as const by @EdJoPaTo in [#951](https://github.com/ratatui-org/ratatui/pull/951)
+- [11b452d](https://github.com/ratatui/ratatui/commit/11b452d56fe590188ee7a53fa2dde95513b1a4c7)
+  _(layout)_ Mark various functions as const by @EdJoPaTo in [#951](https://github.com/ratatui/ratatui/pull/951)
 
-- [1cff511](https://github.com/ratatui-org/ratatui/commit/1cff51193466f5a94d202b6233d56889eccf6d7b)
-  *(line)* Impl Styled for Line by @joshka in [#968](https://github.com/ratatui-org/ratatui/pull/968)
+- [1cff511](https://github.com/ratatui/ratatui/commit/1cff51193466f5a94d202b6233d56889eccf6d7b)
+  _(line)_ Impl Styled for Line by @joshka in [#968](https://github.com/ratatui/ratatui/pull/968)
 
   ````text
   This adds `FromIterator` impls for `Line` and `Text` that allow creating
@@ -1148,8 +1151,8 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
   ```
   ````
 
-- [654949b](https://github.com/ratatui-org/ratatui/commit/654949bb00b4522130642f9ad50ab4d9095d921b)
-  *(list)* Add Scroll Padding to Lists by @CameronBarnes in [#958](https://github.com/ratatui-org/ratatui/pull/958)
+- [654949b](https://github.com/ratatui/ratatui/commit/654949bb00b4522130642f9ad50ab4d9095d921b)
+  _(list)_ Add Scroll Padding to Lists by @CameronBarnes in [#958](https://github.com/ratatui/ratatui/pull/958)
 
   ````text
   Introduces scroll padding, which allows the api user to request that a certain number of ListItems be kept visible above and below the currently selected item while scrolling.
@@ -1159,10 +1162,10 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
   ```
   ````
 
-  Fixes:https://github.com/ratatui-org/ratatui/pull/955
+  Fixes:<https://github.com/ratatui/ratatui/pull/955>
 
-- [26af650](https://github.com/ratatui-org/ratatui/commit/26af65043ee9f165459dec228d12eaeed9997d92)
-  *(text)* Add push methods for text and line by @joshka in [#998](https://github.com/ratatui-org/ratatui/pull/998)
+- [26af650](https://github.com/ratatui/ratatui/commit/26af65043ee9f165459dec228d12eaeed9997d92)
+  _(text)_ Add push methods for text and line by @joshka in [#998](https://github.com/ratatui/ratatui/pull/998)
 
   ````text
   Adds the following methods to the `Text` and `Line` structs:
@@ -1175,8 +1178,8 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
   construction of text objects.
   ````
 
-- [b5bdde0](https://github.com/ratatui-org/ratatui/commit/b5bdde079e0e1eda98b9b1bbbba011b770e5b167)
-  *(text)* Add `FromIterator` impls for `Line` and `Text` by @joshka in [#967](https://github.com/ratatui-org/ratatui/pull/967)
+- [b5bdde0](https://github.com/ratatui/ratatui/commit/b5bdde079e0e1eda98b9b1bbbba011b770e5b167)
+  _(text)_ Add `FromIterator` impls for `Line` and `Text` by @joshka in [#967](https://github.com/ratatui/ratatui/pull/967)
 
   ````text
   This adds `FromIterator` impls for `Line` and `Text` that allow creating
@@ -1195,8 +1198,8 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
   ```
   ````
 
-- [12f67e8](https://github.com/ratatui-org/ratatui/commit/12f67e810fad0f907546408192a2380b590ff7bd)
-  *(uncategorized)* Impl Widget for `&str` and `String` by @kdheepak in [#952](https://github.com/ratatui-org/ratatui/pull/952)
+- [12f67e8](https://github.com/ratatui/ratatui/commit/12f67e810fad0f907546408192a2380b590ff7bd)
+  _(uncategorized)_ Impl Widget for `&str` and `String` by @kdheepak in [#952](https://github.com/ratatui/ratatui/pull/952)
 
   ````text
   Currently, `f.render_widget("hello world".bold(), area)` works but
@@ -1215,8 +1218,8 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
 
 ### Bug Fixes
 
-- [0207160](https://github.com/ratatui-org/ratatui/commit/02071607848c51250b4663722c52e19c8ce1c5e2)
-  *(line)* Line truncation respects alignment by @TadoTheMiner in [#987](https://github.com/ratatui-org/ratatui/pull/987)
+- [0207160](https://github.com/ratatui/ratatui/commit/02071607848c51250b4663722c52e19c8ce1c5e2)
+  _(line)_ Line truncation respects alignment by @TadoTheMiner in [#987](https://github.com/ratatui/ratatui/pull/987)
 
   ````text
   When rendering a `Line`, the line will be truncated:
@@ -1228,10 +1231,10 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
   left, right, centered lines respectively.
   ````
 
-  Fixes:https://github.com/ratatui-org/ratatui/issues/932
+  Fixes:<https://github.com/ratatui/ratatui/issues/932>
 
-- [c56f49b](https://github.com/ratatui-org/ratatui/commit/c56f49b9fb1c7f1c8c97749119e85f81882ca9a9)
-  *(list)* Saturating_sub to fix highlight_symbol overflow by @mrjackwills in [#949](https://github.com/ratatui-org/ratatui/pull/949)
+- [c56f49b](https://github.com/ratatui/ratatui/commit/c56f49b9fb1c7f1c8c97749119e85f81882ca9a9)
+  _(list)_ Saturating_sub to fix highlight_symbol overflow by @mrjackwills in [#949](https://github.com/ratatui/ratatui/pull/949)
 
   ````text
   An overflow (pedantically an underflow) can occur if the
@@ -1239,19 +1242,19 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
   less than that char length.
   ````
 
-- [b7778e5](https://github.com/ratatui-org/ratatui/commit/b7778e5cd15d0d4b28f7bbb8b3c62950748e333a)
-  *(paragraph)* Unit test typo by @joshka in [#1022](https://github.com/ratatui-org/ratatui/pull/1022)
+- [b7778e5](https://github.com/ratatui/ratatui/commit/b7778e5cd15d0d4b28f7bbb8b3c62950748e333a)
+  _(paragraph)_ Unit test typo by @joshka in [#1022](https://github.com/ratatui/ratatui/pull/1022)
 
-- [943c043](https://github.com/ratatui-org/ratatui/commit/943c0431d968a82b23a2f31527f32e57f86f8a7c)
-  *(scrollbar)* Dont render on 0 length track by @EdJoPaTo in [#964](https://github.com/ratatui-org/ratatui/pull/964)
+- [943c043](https://github.com/ratatui/ratatui/commit/943c0431d968a82b23a2f31527f32e57f86f8a7c)
+  _(scrollbar)_ Dont render on 0 length track by @EdJoPaTo in [#964](https://github.com/ratatui/ratatui/pull/964)
 
   ````text
   Fixes a panic when `track_length - 1` is used. (clamp panics on `-1.0`
   being smaller than `0.0`)
   ````
 
-- [742a5ea](https://github.com/ratatui-org/ratatui/commit/742a5ead066bec14047f6ab7ffa3ac8307eea715)
-  *(text)* Fix panic when rendering out of bounds by @joshka in [#997](https://github.com/ratatui-org/ratatui/pull/997)
+- [742a5ea](https://github.com/ratatui/ratatui/commit/742a5ead066bec14047f6ab7ffa3ac8307eea715)
+  _(text)_ Fix panic when rendering out of bounds by @joshka in [#997](https://github.com/ratatui/ratatui/pull/997)
 
   ````text
   Previously it was possible to cause a panic when rendering to an area
@@ -1259,17 +1262,17 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
   to the buffer.
   ````
 
-- [f6c4e44](https://github.com/ratatui-org/ratatui/commit/f6c4e447e65fe10f4fc7fcc9e9c4312acad41096)
-  *(uncategorized)* Ensure that paragraph correctly renders styled text by @joshka in [#992](https://github.com/ratatui-org/ratatui/pull/992)
+- [f6c4e44](https://github.com/ratatui/ratatui/commit/f6c4e447e65fe10f4fc7fcc9e9c4312acad41096)
+  _(uncategorized)_ Ensure that paragraph correctly renders styled text by @joshka in [#992](https://github.com/ratatui/ratatui/pull/992)
 
   ````text
   Paragraph was ignoring the new `Text::style` field added in 0.26.0
   ````
 
-  Fixes:https://github.com/ratatui-org/ratatui/issues/990
+  Fixes:<https://github.com/ratatui/ratatui/issues/990>
 
-- [35e971f](https://github.com/ratatui-org/ratatui/commit/35e971f7ebb0deadc613b561b15511abd48bdb54)
-  *(uncategorized)* Scrollbar thumb not visible on long lists by @ThomasMiz in [#959](https://github.com/ratatui-org/ratatui/pull/959)
+- [35e971f](https://github.com/ratatui/ratatui/commit/35e971f7ebb0deadc613b561b15511abd48bdb54)
+  _(uncategorized)_ Scrollbar thumb not visible on long lists by @ThomasMiz in [#959](https://github.com/ratatui/ratatui/pull/959)
 
   ````text
   When displaying somewhat-long lists, the `Scrollbar` widget sometimes did not display a thumb character, and only the track will be visible.
@@ -1277,14 +1280,14 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
 
 ### Refactor
 
-- [6fd5f63](https://github.com/ratatui-org/ratatui/commit/6fd5f631bbd58156d9fcae196040bb0248097819)
-  *(lint)* Prefer idiomatic for loops by @EdJoPaTo
+- [6fd5f63](https://github.com/ratatui/ratatui/commit/6fd5f631bbd58156d9fcae196040bb0248097819)
+  _(lint)_ Prefer idiomatic for loops by @EdJoPaTo
 
-- [37b957c](https://github.com/ratatui-org/ratatui/commit/37b957c7e167a7ecda07b8a60cee5de71efcc55e)
-  *(lints)* Add lints to scrollbar by @EdJoPaTo
+- [37b957c](https://github.com/ratatui/ratatui/commit/37b957c7e167a7ecda07b8a60cee5de71efcc55e)
+  _(lints)_ Add lints to scrollbar by @EdJoPaTo
 
-- [c12bcfe](https://github.com/ratatui-org/ratatui/commit/c12bcfefa26529610886040bd96f2b6762436b15)
-  *(non-src)* Apply pedantic lints by @EdJoPaTo in [#976](https://github.com/ratatui-org/ratatui/pull/976)
+- [c12bcfe](https://github.com/ratatui/ratatui/commit/c12bcfefa26529610886040bd96f2b6762436b15)
+  _(non-src)_ Apply pedantic lints by @EdJoPaTo in [#976](https://github.com/ratatui/ratatui/pull/976)
 
   ````text
   Fixes many not yet enabled lints (mostly pedantic) on everything that is
@@ -1296,13 +1299,13 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
   diff of #974 even more.
 
   Also see
-  https://github.com/ratatui-org/ratatui/pull/974#discussion_r1506458743
+  https://github.com/ratatui/ratatui/pull/974#discussion_r1506458743
 
   ---------
   ````
 
-- [8719608](https://github.com/ratatui-org/ratatui/commit/8719608bdaf32ba92bdfdd60569cf73f7070a618)
-  *(span)* Rename to_aligned_line into into_aligned_line by @EdJoPaTo in [#993](https://github.com/ratatui-org/ratatui/pull/993)
+- [8719608](https://github.com/ratatui/ratatui/commit/8719608bdaf32ba92bdfdd60569cf73f7070a618)
+  _(span)_ Rename to_aligned_line into into_aligned_line by @EdJoPaTo in [#993](https://github.com/ratatui/ratatui/pull/993)
 
   ````text
   With the Rust method naming conventions these methods are into methods
@@ -1324,42 +1327,42 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
   ```
   ````
 
-- [b831c56](https://github.com/ratatui-org/ratatui/commit/b831c5688c6f1fbfa6ae2bcd70d803a54fcf0196)
-  *(widget-ref)* Clippy::needless_pass_by_value by @EdJoPaTo
+- [b831c56](https://github.com/ratatui/ratatui/commit/b831c5688c6f1fbfa6ae2bcd70d803a54fcf0196)
+  _(widget-ref)_ Clippy::needless_pass_by_value by @EdJoPaTo
 
-- [359204c](https://github.com/ratatui-org/ratatui/commit/359204c9298cc26ea21807d886d596de0329bacc)
-  *(uncategorized)* Simplify to io::Result by @EdJoPaTo in [#1016](https://github.com/ratatui-org/ratatui/pull/1016)
+- [359204c](https://github.com/ratatui/ratatui/commit/359204c9298cc26ea21807d886d596de0329bacc)
+  _(uncategorized)_ Simplify to io::Result by @EdJoPaTo in [#1016](https://github.com/ratatui/ratatui/pull/1016)
 
   ````text
   Simplifies the code, logic stays exactly the same.
   ````
 
-- [8e68db9](https://github.com/ratatui-org/ratatui/commit/8e68db9e2f57fcbf7cb5140006bbbd4dd80bf907)
-  *(uncategorized)* Remove pointless default on internal structs by @EdJoPaTo in [#980](https://github.com/ratatui-org/ratatui/pull/980)
+- [8e68db9](https://github.com/ratatui/ratatui/commit/8e68db9e2f57fcbf7cb5140006bbbd4dd80bf907)
+  _(uncategorized)_ Remove pointless default on internal structs by @EdJoPaTo in [#980](https://github.com/ratatui/ratatui/pull/980)
 
   See #978
 
 Also remove other derives. They are unused and just slow down
 compilation.
 
-- [3be189e](https://github.com/ratatui-org/ratatui/commit/3be189e3c6ebd418d13138ff32bc4a749dc840cf)
-  *(uncategorized)* Clippy::thread_local_initializer_can_be_made_const by @EdJoPaTo
+- [3be189e](https://github.com/ratatui/ratatui/commit/3be189e3c6ebd418d13138ff32bc4a749dc840cf)
+  _(uncategorized)_ Clippy::thread_local_initializer_can_be_made_const by @EdJoPaTo
 
   ````text
   enabled by default on nightly
   ````
 
-- [5c4efac](https://github.com/ratatui-org/ratatui/commit/5c4efacd1d70bb295d90ffaa73853dc206c187fb)
-  *(uncategorized)* Clippy::map_err_ignore by @EdJoPaTo
+- [5c4efac](https://github.com/ratatui/ratatui/commit/5c4efacd1d70bb295d90ffaa73853dc206c187fb)
+  _(uncategorized)_ Clippy::map_err_ignore by @EdJoPaTo
 
-- [bbb6d65](https://github.com/ratatui-org/ratatui/commit/bbb6d65e063df9a74ab6487b2216183c1fdd7230)
-  *(uncategorized)* Clippy::else_if_without_else by @EdJoPaTo
+- [bbb6d65](https://github.com/ratatui/ratatui/commit/bbb6d65e063df9a74ab6487b2216183c1fdd7230)
+  _(uncategorized)_ Clippy::else_if_without_else by @EdJoPaTo
 
-- [fdb14dc](https://github.com/ratatui-org/ratatui/commit/fdb14dc7cd69788e2ed20709e767f7631b11ffa2)
-  *(uncategorized)* Clippy::redundant_type_annotations by @EdJoPaTo
+- [fdb14dc](https://github.com/ratatui/ratatui/commit/fdb14dc7cd69788e2ed20709e767f7631b11ffa2)
+  _(uncategorized)_ Clippy::redundant_type_annotations by @EdJoPaTo
 
-- [9b3b23a](https://github.com/ratatui-org/ratatui/commit/9b3b23ac14518a1ef23065d4a5da0fb047b18213)
-  *(uncategorized)* Remove literal suffix by @EdJoPaTo
+- [9b3b23a](https://github.com/ratatui/ratatui/commit/9b3b23ac14518a1ef23065d4a5da0fb047b18213)
+  _(uncategorized)_ Remove literal suffix by @EdJoPaTo
 
   ````text
   it's not needed and can just be assumed
@@ -1367,121 +1370,121 @@ compilation.
 
   related:clippy::(un)separated_literal_suffix
 
-- [58b6e0b](https://github.com/ratatui-org/ratatui/commit/58b6e0be0f4db3d90005e130e4b84cd865179785)
-  *(uncategorized)* Clippy::should_panic_without_expect by @EdJoPaTo
+- [58b6e0b](https://github.com/ratatui/ratatui/commit/58b6e0be0f4db3d90005e130e4b84cd865179785)
+  _(uncategorized)_ Clippy::should_panic_without_expect by @EdJoPaTo
 
-- [c870a41](https://github.com/ratatui-org/ratatui/commit/c870a41057ac0c14c2e72e762b37689dc32e7b23)
-  *(uncategorized)* Clippy::many_single_char_names by @EdJoPaTo
+- [c870a41](https://github.com/ratatui/ratatui/commit/c870a41057ac0c14c2e72e762b37689dc32e7b23)
+  _(uncategorized)_ Clippy::many_single_char_names by @EdJoPaTo
 
-- [a6036ad](https://github.com/ratatui-org/ratatui/commit/a6036ad78911653407f607f5efa556a055d3dce9)
-  *(uncategorized)* Clippy::similar_names by @EdJoPaTo
+- [a6036ad](https://github.com/ratatui/ratatui/commit/a6036ad78911653407f607f5efa556a055d3dce9)
+  _(uncategorized)_ Clippy::similar_names by @EdJoPaTo
 
-- [060d26b](https://github.com/ratatui-org/ratatui/commit/060d26b6dc6e1027dbf46ae98b0ebba83701f941)
-  *(uncategorized)* Clippy::match_same_arms by @EdJoPaTo
+- [060d26b](https://github.com/ratatui/ratatui/commit/060d26b6dc6e1027dbf46ae98b0ebba83701f941)
+  _(uncategorized)_ Clippy::match_same_arms by @EdJoPaTo
 
-- [fcbea9e](https://github.com/ratatui-org/ratatui/commit/fcbea9ee68591344a29a7b2e83f1c8c878857aeb)
-  *(uncategorized)* Clippy::uninlined_format_args by @EdJoPaTo
+- [fcbea9e](https://github.com/ratatui/ratatui/commit/fcbea9ee68591344a29a7b2e83f1c8c878857aeb)
+  _(uncategorized)_ Clippy::uninlined_format_args by @EdJoPaTo
 
-- [14b24e7](https://github.com/ratatui-org/ratatui/commit/14b24e75858af48f39d5880e7f6c9adeac1b1da9)
-  *(uncategorized)* Clippy::if_not_else by @EdJoPaTo
+- [14b24e7](https://github.com/ratatui/ratatui/commit/14b24e75858af48f39d5880e7f6c9adeac1b1da9)
+  _(uncategorized)_ Clippy::if_not_else by @EdJoPaTo
 
-- [5ed1f43](https://github.com/ratatui-org/ratatui/commit/5ed1f43c627053f25d9ee711677ebec6cb8fcd85)
-  *(uncategorized)* Clippy::redundant_closure_for_method_calls by @EdJoPaTo
+- [5ed1f43](https://github.com/ratatui/ratatui/commit/5ed1f43c627053f25d9ee711677ebec6cb8fcd85)
+  _(uncategorized)_ Clippy::redundant_closure_for_method_calls by @EdJoPaTo
 
-- [c8c7924](https://github.com/ratatui-org/ratatui/commit/c8c7924e0ca84351f5ed5c54e79611ce16d4dc37)
-  *(uncategorized)* Clippy::too_many_lines by @EdJoPaTo
+- [c8c7924](https://github.com/ratatui/ratatui/commit/c8c7924e0ca84351f5ed5c54e79611ce16d4dc37)
+  _(uncategorized)_ Clippy::too_many_lines by @EdJoPaTo
 
-- [e3afe7c](https://github.com/ratatui-org/ratatui/commit/e3afe7c8a14c1cffd7de50782a7acf0f95f41673)
-  *(uncategorized)* Clippy::unreadable_literal by @EdJoPaTo
+- [e3afe7c](https://github.com/ratatui/ratatui/commit/e3afe7c8a14c1cffd7de50782a7acf0f95f41673)
+  _(uncategorized)_ Clippy::unreadable_literal by @EdJoPaTo
 
-- [a1f54de](https://github.com/ratatui-org/ratatui/commit/a1f54de7d60fa6c57be29bf8f02a675e58b7b9c2)
-  *(uncategorized)* Clippy::bool_to_int_with_if by @EdJoPaTo
+- [a1f54de](https://github.com/ratatui/ratatui/commit/a1f54de7d60fa6c57be29bf8f02a675e58b7b9c2)
+  _(uncategorized)_ Clippy::bool_to_int_with_if by @EdJoPaTo
 
-- [b8ea190](https://github.com/ratatui-org/ratatui/commit/b8ea190bf2cde8c18e2ac8276d2eb57d219db263)
-  *(uncategorized)* Clippy::cast_lossless by @EdJoPaTo
+- [b8ea190](https://github.com/ratatui/ratatui/commit/b8ea190bf2cde8c18e2ac8276d2eb57d219db263)
+  _(uncategorized)_ Clippy::cast_lossless by @EdJoPaTo
 
-- [0de5238](https://github.com/ratatui-org/ratatui/commit/0de5238ed3613f2d663f5e9628ca7b2aa205ed02)
-  *(uncategorized)* Dead_code by @EdJoPaTo
+- [0de5238](https://github.com/ratatui/ratatui/commit/0de5238ed3613f2d663f5e9628ca7b2aa205ed02)
+  _(uncategorized)_ Dead_code by @EdJoPaTo
 
   ````text
   enabled by default, only detected by nightly yet
   ````
 
-- [df5dddf](https://github.com/ratatui-org/ratatui/commit/df5dddfbc9c679d15a5a90ea79bb1f8946d5cb9c)
-  *(uncategorized)* Unused_imports by @EdJoPaTo
+- [df5dddf](https://github.com/ratatui/ratatui/commit/df5dddfbc9c679d15a5a90ea79bb1f8946d5cb9c)
+  _(uncategorized)_ Unused_imports by @EdJoPaTo
 
   ````text
   enabled by default, only detected on nightly yet
   ````
 
-- [f1398ae](https://github.com/ratatui-org/ratatui/commit/f1398ae6cb1abd32106923d64844b482c7ba6f82)
-  *(uncategorized)* Clippy::useless_vec by @EdJoPaTo
+- [f1398ae](https://github.com/ratatui/ratatui/commit/f1398ae6cb1abd32106923d64844b482c7ba6f82)
+  _(uncategorized)_ Clippy::useless_vec by @EdJoPaTo
 
   ````text
   Lint enabled by default but only nightly finds this yet
   ````
 
-- [525848f](https://github.com/ratatui-org/ratatui/commit/525848ff4e066526d402fecf1d5b9c63cff1f22a)
-  *(uncategorized)* Manually apply clippy::use_self for impl with lifetimes by @EdJoPaTo
+- [525848f](https://github.com/ratatui/ratatui/commit/525848ff4e066526d402fecf1d5b9c63cff1f22a)
+  _(uncategorized)_ Manually apply clippy::use_self for impl with lifetimes by @EdJoPaTo
 
-- [660c718](https://github.com/ratatui-org/ratatui/commit/660c7183c7a10dc453d80dfb651d9534536960b9)
-  *(uncategorized)* Clippy::empty_line_after_doc_comments by @EdJoPaTo
+- [660c718](https://github.com/ratatui/ratatui/commit/660c7183c7a10dc453d80dfb651d9534536960b9)
+  _(uncategorized)_ Clippy::empty_line_after_doc_comments by @EdJoPaTo
 
-- [ab951fa](https://github.com/ratatui-org/ratatui/commit/ab951fae8166c9321728ba942b48552dfe4d9c55)
-  *(uncategorized)* Clippy::return_self_not_must_use by @EdJoPaTo
+- [ab951fa](https://github.com/ratatui/ratatui/commit/ab951fae8166c9321728ba942b48552dfe4d9c55)
+  _(uncategorized)_ Clippy::return_self_not_must_use by @EdJoPaTo
 
-- [3cd4369](https://github.com/ratatui-org/ratatui/commit/3cd436917649a93b4b80d0c4a0343284e0585522)
-  *(uncategorized)* Clippy::doc_markdown by @EdJoPaTo
+- [3cd4369](https://github.com/ratatui/ratatui/commit/3cd436917649a93b4b80d0c4a0343284e0585522)
+  _(uncategorized)_ Clippy::doc_markdown by @EdJoPaTo
 
-- [9bc014d](https://github.com/ratatui-org/ratatui/commit/9bc014d7f16efdb70fcd6b6b786fe74eac7b9bdf)
-  *(uncategorized)* Clippy::items_after_statements by @EdJoPaTo
+- [9bc014d](https://github.com/ratatui/ratatui/commit/9bc014d7f16efdb70fcd6b6b786fe74eac7b9bdf)
+  _(uncategorized)_ Clippy::items_after_statements by @EdJoPaTo
 
-- [36a0cd5](https://github.com/ratatui-org/ratatui/commit/36a0cd56e5645533a1d6c2720536fa10a56b0d40)
-  *(uncategorized)* Clippy::deref_by_slicing by @EdJoPaTo
+- [36a0cd5](https://github.com/ratatui/ratatui/commit/36a0cd56e5645533a1d6c2720536fa10a56b0d40)
+  _(uncategorized)_ Clippy::deref_by_slicing by @EdJoPaTo
 
-- [f7f6692](https://github.com/ratatui-org/ratatui/commit/f7f66928a8833532a3bc97292665640285e7aafa)
-  *(uncategorized)* Clippy::equatable_if_let by @EdJoPaTo
+- [f7f6692](https://github.com/ratatui/ratatui/commit/f7f66928a8833532a3bc97292665640285e7aafa)
+  _(uncategorized)_ Clippy::equatable_if_let by @EdJoPaTo
 
-- [01418eb](https://github.com/ratatui-org/ratatui/commit/01418eb7c2e1874cb4070828c485d81ea171b18d)
-  *(uncategorized)* Clippy::default_trait_access by @EdJoPaTo
+- [01418eb](https://github.com/ratatui/ratatui/commit/01418eb7c2e1874cb4070828c485d81ea171b18d)
+  _(uncategorized)_ Clippy::default_trait_access by @EdJoPaTo
 
-- [8536760](https://github.com/ratatui-org/ratatui/commit/8536760e7802a498f7c6d9fe8fb4c7920a1c6e71)
-  *(uncategorized)* Clippy::inefficient_to_string by @EdJoPaTo
+- [8536760](https://github.com/ratatui/ratatui/commit/8536760e7802a498f7c6d9fe8fb4c7920a1c6e71)
+  _(uncategorized)_ Clippy::inefficient_to_string by @EdJoPaTo
 
-- [a558b19](https://github.com/ratatui-org/ratatui/commit/a558b19c9a7b90a1ed3f309301f49f0b483e02ec)
-  *(uncategorized)* Clippy::implicit_clone by @EdJoPaTo
+- [a558b19](https://github.com/ratatui/ratatui/commit/a558b19c9a7b90a1ed3f309301f49f0b483e02ec)
+  _(uncategorized)_ Clippy::implicit_clone by @EdJoPaTo
 
-- [5b00e3a](https://github.com/ratatui-org/ratatui/commit/5b00e3aae98cb5c20c10bec944948a75ac83f956)
-  *(uncategorized)* Clippy::use_self by @EdJoPaTo
+- [5b00e3a](https://github.com/ratatui/ratatui/commit/5b00e3aae98cb5c20c10bec944948a75ac83f956)
+  _(uncategorized)_ Clippy::use_self by @EdJoPaTo
 
-- [27680c0](https://github.com/ratatui-org/ratatui/commit/27680c05ce1670f026ad23c446ada321c1c755f0)
-  *(uncategorized)* Clippy::semicolon_if_nothing_returned by @EdJoPaTo
+- [27680c0](https://github.com/ratatui/ratatui/commit/27680c05ce1670f026ad23c446ada321c1c755f0)
+  _(uncategorized)_ Clippy::semicolon_if_nothing_returned by @EdJoPaTo
 
 ### Documentation
 
-- [14461c3](https://github.com/ratatui-org/ratatui/commit/14461c3a3554c95905ebca433fc3d4dae1e1acda)
-  *(breaking-changes)* Typos and markdownlint by @EdJoPaTo in [#1009](https://github.com/ratatui-org/ratatui/pull/1009)
+- [14461c3](https://github.com/ratatui/ratatui/commit/14461c3a3554c95905ebca433fc3d4dae1e1acda)
+  _(breaking-changes)_ Typos and markdownlint by @EdJoPaTo in [#1009](https://github.com/ratatui/ratatui/pull/1009)
 
-- [d0067c8](https://github.com/ratatui-org/ratatui/commit/d0067c8815d5244d319934d58a9366c8ad36b3e5)
-  *(license)* Update copyright years by @orhun in [#962](https://github.com/ratatui-org/ratatui/pull/962)
+- [d0067c8](https://github.com/ratatui/ratatui/commit/d0067c8815d5244d319934d58a9366c8ad36b3e5)
+  _(license)_ Update copyright years by @orhun in [#962](https://github.com/ratatui/ratatui/pull/962)
 
-- [88bfb5a](https://github.com/ratatui-org/ratatui/commit/88bfb5a43027cf3410ad560772c5bfdbaa3d58b7)
-  *(text)* Update Text and Line docs by @joshka in [#969](https://github.com/ratatui-org/ratatui/pull/969)
+- [88bfb5a](https://github.com/ratatui/ratatui/commit/88bfb5a43027cf3410ad560772c5bfdbaa3d58b7)
+  _(text)_ Update Text and Line docs by @joshka in [#969](https://github.com/ratatui/ratatui/pull/969)
 
-- [3b002fd](https://github.com/ratatui-org/ratatui/commit/3b002fdcab964ce3f65f55dc8053d9678ae247a3)
-  *(uncategorized)* Update incompatible code warning in examples readme by @joshka in [#1013](https://github.com/ratatui-org/ratatui/pull/1013)
+- [3b002fd](https://github.com/ratatui/ratatui/commit/3b002fdcab964ce3f65f55dc8053d9678ae247a3)
+  _(uncategorized)_ Update incompatible code warning in examples readme by @joshka in [#1013](https://github.com/ratatui/ratatui/pull/1013)
 
 ### Performance
 
-- [e02f476](https://github.com/ratatui-org/ratatui/commit/e02f4768ce2ee30473200fe98e2687e42acb9c33)
-  *(borders)* Allow border!() in const by @EdJoPaTo in [#977](https://github.com/ratatui-org/ratatui/pull/977)
+- [e02f476](https://github.com/ratatui/ratatui/commit/e02f4768ce2ee30473200fe98e2687e42acb9c33)
+  _(borders)_ Allow border!() in const by @EdJoPaTo in [#977](https://github.com/ratatui/ratatui/pull/977)
 
   ````text
   This allows more compiler optimizations when the macro is used.
   ````
 
-- [541f0f9](https://github.com/ratatui-org/ratatui/commit/541f0f99538762a07d68a71b2989ecc6ff6f71ef)
-  *(cell)* Use const CompactString::new_inline by @EdJoPaTo in [#979](https://github.com/ratatui-org/ratatui/pull/979)
+- [541f0f9](https://github.com/ratatui/ratatui/commit/541f0f99538762a07d68a71b2989ecc6ff6f71ef)
+  _(cell)_ Use const CompactString::new_inline by @EdJoPaTo in [#979](https://github.com/ratatui/ratatui/pull/979)
 
   ````text
   Some minor find when messing around trying to `const` all the things.
@@ -1490,41 +1493,41 @@ compilation.
   when their contents are.
   ````
 
-- [65e7923](https://github.com/ratatui-org/ratatui/commit/65e792375396c3160d76964ef0dfc4fb1e53be41)
-  *(scrollbar)* Const creation by @EdJoPaTo in [#963](https://github.com/ratatui-org/ratatui/pull/963)
+- [65e7923](https://github.com/ratatui/ratatui/commit/65e792375396c3160d76964ef0dfc4fb1e53be41)
+  _(scrollbar)_ Const creation by @EdJoPaTo in [#963](https://github.com/ratatui/ratatui/pull/963)
 
   ````text
   A bunch of `const fn` allow for more performance and `Default` now uses the `const` new implementations.
   ````
 
-- [8195f52](https://github.com/ratatui-org/ratatui/commit/8195f526cb4b321f337dcbe9e689cc7f6eb84065)
-  *(uncategorized)* Clippy::needless_pass_by_value by @EdJoPaTo
+- [8195f52](https://github.com/ratatui/ratatui/commit/8195f526cb4b321f337dcbe9e689cc7f6eb84065)
+  _(uncategorized)_ Clippy::needless_pass_by_value by @EdJoPaTo
 
-- [183c07e](https://github.com/ratatui-org/ratatui/commit/183c07ef436cbb8fb0bec418042b44b4fedd836f)
-  *(uncategorized)* Clippy::trivially_copy_pass_by_ref by @EdJoPaTo
+- [183c07e](https://github.com/ratatui/ratatui/commit/183c07ef436cbb8fb0bec418042b44b4fedd836f)
+  _(uncategorized)_ Clippy::trivially_copy_pass_by_ref by @EdJoPaTo
 
-- [a13867f](https://github.com/ratatui-org/ratatui/commit/a13867ffceb2f8f57f4540049754c2f916fd3efc)
-  *(uncategorized)* Clippy::cloned_instead_of_copied by @EdJoPaTo
+- [a13867f](https://github.com/ratatui/ratatui/commit/a13867ffceb2f8f57f4540049754c2f916fd3efc)
+  _(uncategorized)_ Clippy::cloned_instead_of_copied by @EdJoPaTo
 
-- [3834374](https://github.com/ratatui-org/ratatui/commit/3834374652b46c5ddbfedcf8dea2086fd762f884)
-  *(uncategorized)* Clippy::missing_const_for_fn by @EdJoPaTo
+- [3834374](https://github.com/ratatui/ratatui/commit/3834374652b46c5ddbfedcf8dea2086fd762f884)
+  _(uncategorized)_ Clippy::missing_const_for_fn by @EdJoPaTo
 
 ### Miscellaneous Tasks
 
-- [125ee92](https://github.com/ratatui-org/ratatui/commit/125ee929ee9009b97a270e2e105a3f1167ab13d7)
-  *(docs)* Fix: fix typos in crate documentation by @orhun in [#1002](https://github.com/ratatui-org/ratatui/pull/1002)
+- [125ee92](https://github.com/ratatui/ratatui/commit/125ee929ee9009b97a270e2e105a3f1167ab13d7)
+  _(docs)_ Fix: fix typos in crate documentation by @orhun in [#1002](https://github.com/ratatui/ratatui/pull/1002)
 
-- [38c17e0](https://github.com/ratatui-org/ratatui/commit/38c17e091cf3f4de2d196ecdd6a40129019eafc4)
-  *(editorconfig)* Set and apply some defaults by @EdJoPaTo
+- [38c17e0](https://github.com/ratatui/ratatui/commit/38c17e091cf3f4de2d196ecdd6a40129019eafc4)
+  _(editorconfig)_ Set and apply some defaults by @EdJoPaTo
 
-- [07da90a](https://github.com/ratatui-org/ratatui/commit/07da90a7182035b24f870bcbf0a0ffaad75eb48b)
-  *(funding)* Add eth address for receiving funds from drips.network by @BenJam in [#994](https://github.com/ratatui-org/ratatui/pull/994)
+- [07da90a](https://github.com/ratatui/ratatui/commit/07da90a7182035b24f870bcbf0a0ffaad75eb48b)
+  _(funding)_ Add eth address for receiving funds from drips.network by @BenJam in [#994](https://github.com/ratatui/ratatui/pull/994)
 
-- [078e97e](https://github.com/ratatui-org/ratatui/commit/078e97e4ff65c02afa7c884914ecd38a6e959b58)
-  *(github)* Add EdJoPaTo as a maintainer by @orhun in [#986](https://github.com/ratatui-org/ratatui/pull/986)
+- [078e97e](https://github.com/ratatui/ratatui/commit/078e97e4ff65c02afa7c884914ecd38a6e959b58)
+  _(github)_ Add EdJoPaTo as a maintainer by @orhun in [#986](https://github.com/ratatui/ratatui/pull/986)
 
-- [b0314c5](https://github.com/ratatui-org/ratatui/commit/b0314c5731b32f51f5b6ca71a5194c6d7f265972)
-  *(uncategorized)* Remove conventional commit check for PR by @Valentin271 in [#950](https://github.com/ratatui-org/ratatui/pull/950)
+- [b0314c5](https://github.com/ratatui/ratatui/commit/b0314c5731b32f51f5b6ca71a5194c6d7f265972)
+  _(uncategorized)_ Remove conventional commit check for PR by @Valentin271 in [#950](https://github.com/ratatui/ratatui/pull/950)
 
   ````text
   This removes conventional commit check for PRs.
@@ -1538,19 +1541,19 @@ compilation.
 
 ### Build
 
-- [6e6ba27](https://github.com/ratatui-org/ratatui/commit/6e6ba27a122560bcf47b0efd20b7095f1bfd8714)
-  *(lint)* Warn on pedantic and allow the rest by @EdJoPaTo
+- [6e6ba27](https://github.com/ratatui/ratatui/commit/6e6ba27a122560bcf47b0efd20b7095f1bfd8714)
+  _(lint)_ Warn on pedantic and allow the rest by @EdJoPaTo
 
-- [c4ce7e8](https://github.com/ratatui-org/ratatui/commit/c4ce7e8ff6f00875e1ead5b68052f0db737bd44d)
-  *(uncategorized)* Enable more satisfied lints by @EdJoPaTo
+- [c4ce7e8](https://github.com/ratatui/ratatui/commit/c4ce7e8ff6f00875e1ead5b68052f0db737bd44d)
+  _(uncategorized)_ Enable more satisfied lints by @EdJoPaTo
 
   ````text
   These lints dont generate warnings and therefore dont need refactoring.
   I think they are useful in the future.
   ````
 
-- [a4e84a6](https://github.com/ratatui-org/ratatui/commit/a4e84a6a7f6f5b80903799028f30e2a4438f2807)
-  *(uncategorized)* Increase msrv to 1.74.0 by @EdJoPaTo [**breaking**]
+- [a4e84a6](https://github.com/ratatui/ratatui/commit/a4e84a6a7f6f5b80903799028f30e2a4438f2807)
+  _(uncategorized)_ Increase msrv to 1.74.0 by @EdJoPaTo [**breaking**]
 
   ````text
   configure lints in Cargo.toml requires 1.74.0
@@ -1560,21 +1563,21 @@ compilation.
 
 ### New Contributors
 
-* @TadoTheMiner made their first contribution in [#987](https://github.com/ratatui-org/ratatui/pull/987)
-* @BenJam made their first contribution in [#994](https://github.com/ratatui-org/ratatui/pull/994)
-* @CameronBarnes made their first contribution in [#958](https://github.com/ratatui-org/ratatui/pull/958)
-* @ThomasMiz made their first contribution in [#959](https://github.com/ratatui-org/ratatui/pull/959)
+- @TadoTheMiner made their first contribution in [#987](https://github.com/ratatui/ratatui/pull/987)
+- @BenJam made their first contribution in [#994](https://github.com/ratatui/ratatui/pull/994)
+- @CameronBarnes made their first contribution in [#958](https://github.com/ratatui/ratatui/pull/958)
+- @ThomasMiz made their first contribution in [#959](https://github.com/ratatui/ratatui/pull/959)
 
-**Full Changelog**: https://github.com/ratatui-org/ratatui/compare/v0.26.1...0.26.2
+**Full Changelog**: <https://github.com/ratatui/ratatui/compare/v0.26.1...0.26.2>
 
-## [0.26.1](https://github.com/ratatui-org/ratatui/releases/tag/v0.26.1) - 2024-02-12
+## [0.26.1](https://github.com/ratatui/ratatui/releases/tag/v0.26.1) - 2024-02-12
 
 This is a patch release that fixes bugs and adds enhancements, including new iterators, title options for blocks, and various rendering improvements. ✨
 
 ### Features
 
-- [74a0511](https://github.com/ratatui-org/ratatui/commit/74a051147a4059990c31e08d96a8469d8220537b)
-  *(rect)* Add Rect::positions iterator ([#928](https://github.com/ratatui-org/ratatui/issues/928))
+- [74a0511](https://github.com/ratatui/ratatui/commit/74a051147a4059990c31e08d96a8469d8220537b)
+  _(rect)_ Add Rect::positions iterator ([#928](https://github.com/ratatui/ratatui/issues/928))
 
   ````text
   Useful for performing some action on all the cells in a particular area.
@@ -1589,8 +1592,8 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
   ```
   ````
 
-- [9182f47](https://github.com/ratatui-org/ratatui/commit/9182f47026d1630cb749163b6f8b8987474312ae)
-  *(uncategorized)* Add Block::title_top and Block::title_top_bottom ([#940](https://github.com/ratatui-org/ratatui/issues/940))
+- [9182f47](https://github.com/ratatui/ratatui/commit/9182f47026d1630cb749163b6f8b8987474312ae)
+  _(uncategorized)_ Add Block::title_top and Block::title_top_bottom ([#940](https://github.com/ratatui/ratatui/issues/940))
 
   ````text
   This adds the ability to add titles to the top and bottom of a block
@@ -1616,13 +1619,13 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
   "└D─────E─────F┘",
   ```
 
-  Addresses part of https://github.com/ratatui-org/ratatui/issues/738
+  Addresses part of https://github.com/ratatui/ratatui/issues/738
   ````
 
 ### Bug Fixes
 
-- [2202059](https://github.com/ratatui-org/ratatui/commit/220205925911ed4377358d2a28ffca9373f11bda)
-  *(block)* Fix crash on empty right aligned title ([#933](https://github.com/ratatui-org/ratatui/issues/933))
+- [2202059](https://github.com/ratatui/ratatui/commit/220205925911ed4377358d2a28ffca9373f11bda)
+  _(block)_ Fix crash on empty right aligned title ([#933](https://github.com/ratatui/ratatui/issues/933))
 
   ````text
   - Simplified implementation of the rendering for block.
@@ -1630,14 +1633,14 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
     odd in length will now be rendered one character to the left compared
     to before. This aligns with other places that we render centered text
     and is a more consistent behavior. See
-    https://github.com/ratatui-org/ratatui/pull/807#discussion_r1455645954
+    https://github.com/ratatui/ratatui/pull/807#discussion_r1455645954
     for another example of this.
   ````
 
-  Fixes: https://github.com/ratatui-org/ratatui/pull/929
+  Fixes: <https://github.com/ratatui/ratatui/pull/929>
 
-- [14c67fb](https://github.com/ratatui-org/ratatui/commit/14c67fbb52101d10b2d2e26898c408ab8dd3ec2d)
-  *(list)* Highlight symbol when using a  multi-bytes char ([#924](https://github.com/ratatui-org/ratatui/issues/924))
+- [14c67fb](https://github.com/ratatui/ratatui/commit/14c67fbb52101d10b2d2e26898c408ab8dd3ec2d)
+  _(list)_ Highlight symbol when using a  multi-bytes char ([#924](https://github.com/ratatui/ratatui/issues/924))
 
   ````text
   ratatui v0.26.0 brought a regression in the List widget, in which the
@@ -1645,15 +1648,15 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
   the highlight symbol was a multi-char character, e.g. `▶`.
   ````
 
-- [0dcdbea](https://github.com/ratatui-org/ratatui/commit/0dcdbea083aace6d531c0d505837e0911f400675)
-  *(paragraph)* Render Line::styled correctly inside a paragraph ([#930](https://github.com/ratatui-org/ratatui/issues/930))
+- [0dcdbea](https://github.com/ratatui/ratatui/commit/0dcdbea083aace6d531c0d505837e0911f400675)
+  _(paragraph)_ Render Line::styled correctly inside a paragraph ([#930](https://github.com/ratatui/ratatui/issues/930))
 
   ````text
   Renders the styled graphemes of the line instead of the contained spans.
   ````
 
-- [fae5862](https://github.com/ratatui-org/ratatui/commit/fae5862c6e0947ee1488a7e4775413dbead67c8b)
-  *(uncategorized)* Ensure that buffer::set_line sets the line style ([#926](https://github.com/ratatui-org/ratatui/issues/926))
+- [fae5862](https://github.com/ratatui/ratatui/commit/fae5862c6e0947ee1488a7e4775413dbead67c8b)
+  _(uncategorized)_ Ensure that buffer::set_line sets the line style ([#926](https://github.com/ratatui/ratatui/issues/926))
 
   ````text
   Fixes a regression in 0.26 where buffer::set_line was no longer setting
@@ -1663,54 +1666,54 @@ This is a patch release that fixes bugs and adds enhancements, including new ite
   Also adds a configuration for just running unit tests to bacon.toml.
   ````
 
-- [fbb5dfa](https://github.com/ratatui-org/ratatui/commit/fbb5dfaaa903efde0e63114c393dc3063d5f56fd)
-  *(uncategorized)* Scrollbar rendering when no track symbols are provided ([#911](https://github.com/ratatui-org/ratatui/issues/911))
+- [fbb5dfa](https://github.com/ratatui/ratatui/commit/fbb5dfaaa903efde0e63114c393dc3063d5f56fd)
+  _(uncategorized)_ Scrollbar rendering when no track symbols are provided ([#911](https://github.com/ratatui/ratatui/issues/911))
 
 ### Refactor
 
-- [c3fb258](https://github.com/ratatui-org/ratatui/commit/c3fb25898f3e3ffe485ee69631b680679874d2cb)
-  *(rect)* Move iters to module and add docs ([#927](https://github.com/ratatui-org/ratatui/issues/927))
+- [c3fb258](https://github.com/ratatui/ratatui/commit/c3fb25898f3e3ffe485ee69631b680679874d2cb)
+  _(rect)_ Move iters to module and add docs ([#927](https://github.com/ratatui/ratatui/issues/927))
 
-- [e51ca6e](https://github.com/ratatui-org/ratatui/commit/e51ca6e0d2705e6e0a96aeee78f1e80fcaaf34fc)
-  *(uncategorized)* Finish tidying up table ([#942](https://github.com/ratatui-org/ratatui/issues/942))
+- [e51ca6e](https://github.com/ratatui/ratatui/commit/e51ca6e0d2705e6e0a96aeee78f1e80fcaaf34fc)
+  _(uncategorized)_ Finish tidying up table ([#942](https://github.com/ratatui/ratatui/issues/942))
 
-- [91040c0](https://github.com/ratatui-org/ratatui/commit/91040c0865043b8d5e7387509523a41345ed5af3)
-  *(uncategorized)* Rearrange block structure ([#939](https://github.com/ratatui-org/ratatui/issues/939))
+- [91040c0](https://github.com/ratatui/ratatui/commit/91040c0865043b8d5e7387509523a41345ed5af3)
+  _(uncategorized)_ Rearrange block structure ([#939](https://github.com/ratatui/ratatui/issues/939))
 
 ### Documentation
 
-- [61a8278](https://github.com/ratatui-org/ratatui/commit/61a827821dff2bd733377cfc143266edce1dbeec)
-  *(canvas)* Add documentation to canvas module ([#913](https://github.com/ratatui-org/ratatui/issues/913))
+- [61a8278](https://github.com/ratatui/ratatui/commit/61a827821dff2bd733377cfc143266edce1dbeec)
+  _(canvas)_ Add documentation to canvas module ([#913](https://github.com/ratatui/ratatui/issues/913))
 
   ````text
   Document the whole `canvas` module. With this, the whole `widgets`
   module is documented.
   ````
 
-- [d2d91f7](https://github.com/ratatui-org/ratatui/commit/d2d91f754c87458c6d07863eca20f3ea8ae319ce)
-  *(changelog)* Add sponsors section ([#908](https://github.com/ratatui-org/ratatui/issues/908))
+- [d2d91f7](https://github.com/ratatui/ratatui/commit/d2d91f754c87458c6d07863eca20f3ea8ae319ce)
+  _(changelog)_ Add sponsors section ([#908](https://github.com/ratatui/ratatui/issues/908))
 
-- [410d08b](https://github.com/ratatui-org/ratatui/commit/410d08b2b5812d7e29302adc0e8ddf18eb7d1d26)
-  *(uncategorized)* Add link to FOSDEM 2024 talk ([#944](https://github.com/ratatui-org/ratatui/issues/944))
+- [410d08b](https://github.com/ratatui/ratatui/commit/410d08b2b5812d7e29302adc0e8ddf18eb7d1d26)
+  _(uncategorized)_ Add link to FOSDEM 2024 talk ([#944](https://github.com/ratatui/ratatui/issues/944))
 
-- [1f208ff](https://github.com/ratatui-org/ratatui/commit/1f208ffd0368b4d269854dc0c550686dcd2d1de0)
-  *(uncategorized)* Add GitHub Sponsors badge ([#943](https://github.com/ratatui-org/ratatui/issues/943))
+- [1f208ff](https://github.com/ratatui/ratatui/commit/1f208ffd0368b4d269854dc0c550686dcd2d1de0)
+  _(uncategorized)_ Add GitHub Sponsors badge ([#943](https://github.com/ratatui/ratatui/issues/943))
 
 ### Performance
 
-- [0963463](https://github.com/ratatui-org/ratatui/commit/096346350e19c5de9a4d74bba64796997e9f40da)
-  *(uncategorized)* Use drain instead of remove in chart examples ([#922](https://github.com/ratatui-org/ratatui/issues/922))
+- [0963463](https://github.com/ratatui/ratatui/commit/096346350e19c5de9a4d74bba64796997e9f40da)
+  _(uncategorized)_ Use drain instead of remove in chart examples ([#922](https://github.com/ratatui/ratatui/issues/922))
 
 ### Miscellaneous Tasks
 
-- [a4892ad](https://github.com/ratatui-org/ratatui/commit/a4892ad444739d7a760bc45bbd954e728c66b2d2)
-  *(uncategorized)* Fix typo in docsrs example ([#946](https://github.com/ratatui-org/ratatui/issues/946))
+- [a4892ad](https://github.com/ratatui/ratatui/commit/a4892ad444739d7a760bc45bbd954e728c66b2d2)
+  _(uncategorized)_ Fix typo in docsrs example ([#946](https://github.com/ratatui/ratatui/issues/946))
 
-- [18870ce](https://github.com/ratatui-org/ratatui/commit/18870ce99063a492674de061441b2cce5dc54c60)
-  *(uncategorized)* Fix the method name for setting the Line style ([#947](https://github.com/ratatui-org/ratatui/issues/947))
+- [18870ce](https://github.com/ratatui/ratatui/commit/18870ce99063a492674de061441b2cce5dc54c60)
+  _(uncategorized)_ Fix the method name for setting the Line style ([#947](https://github.com/ratatui/ratatui/issues/947))
 
-- [8fb4630](https://github.com/ratatui-org/ratatui/commit/8fb46301a00b5d065f9b890496f914d3fdc17495)
-  *(uncategorized)* Remove github action bot that makes comments nudging commit signing ([#937](https://github.com/ratatui-org/ratatui/issues/937))
+- [8fb4630](https://github.com/ratatui/ratatui/commit/8fb46301a00b5d065f9b890496f914d3fdc17495)
+  _(uncategorized)_ Remove github action bot that makes comments nudging commit signing ([#937](https://github.com/ratatui/ratatui/issues/937))
 
   ````text
   We can consider reverting this commit once this PR is merged:
@@ -1723,10 +1726,10 @@ Thank you so much to everyone that contributed to this release!
 
 Here is the list of contributors who have contributed to `ratatui` for the first time!
 
-* @mo8it
-* @m4rch3n1ng
+- @mo8it
+- @m4rch3n1ng
 
-## [0.26.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.26.0) - 2024-02-02
+## [0.26.0](https://github.com/ratatui/ratatui/releases/tag/v0.26.0) - 2024-02-02
 
 We are excited to announce the new version of `ratatui` - a Rust library that's all about cooking up TUIs 🐭
 
@@ -1734,22 +1737,22 @@ In this version, we have primarily focused on simplifications and quality-of-lif
 
 ✨ **Release highlights**: <https://ratatui.rs/highlights/v026/>
 
-⚠️ List of breaking changes can be found [here](https://github.com/ratatui-org/ratatui/blob/main/BREAKING-CHANGES.md).
+⚠️ List of breaking changes can be found [here](https://github.com/ratatui/ratatui/blob/main/BREAKING-CHANGES.md).
 
-💖 Consider sponsoring us at <https://github.com/sponsors/ratatui-org>!
+💖 Consider sponsoring us at <https://github.com/sponsors/ratatui>!
 
 ### Features
 
-- [79ceb9f](https://github.com/ratatui-org/ratatui/commit/79ceb9f7b6ce7d7079fd7a1e1de8b160086206d0)
-  _(line)_ Add alignment convenience functions ([#856](https://github.com/ratatui-org/ratatui/issues/856))
+- [79ceb9f](https://github.com/ratatui/ratatui/commit/79ceb9f7b6ce7d7079fd7a1e1de8b160086206d0)
+  _(line)_ Add alignment convenience functions ([#856](https://github.com/ratatui/ratatui/issues/856))
 
   ```text
   This adds convenience functions `left_aligned()`, `centered()` and
   `right_aligned()` plus unit tests. Updated example code.
   ```
 
-- [0df9354](https://github.com/ratatui-org/ratatui/commit/0df935473f59d9bcf16ea5092878e59ee129d876)
-  _(padding)_ Add new constructors for padding ([#828](https://github.com/ratatui-org/ratatui/issues/828))
+- [0df9354](https://github.com/ratatui/ratatui/commit/0df935473f59d9bcf16ea5092878e59ee129d876)
+  _(padding)_ Add new constructors for padding ([#828](https://github.com/ratatui/ratatui/issues/828))
 
   ````text
   Adds `proportional`, `symmetric`, `left`, `right`, `top`, and `bottom`
@@ -1762,18 +1765,18 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   ```
   ````
 
-  Fixes:https://github.com/ratatui-org/ratatui/issues/798
+  Fixes:<https://github.com/ratatui/ratatui/issues/798>
 
-- [d726e92](https://github.com/ratatui-org/ratatui/commit/d726e928d2004d2a99caeeb00b95ce27dbc04bc0)
-  _(paragraph)_ Add alignment convenience functions ([#866](https://github.com/ratatui-org/ratatui/issues/866))
+- [d726e92](https://github.com/ratatui/ratatui/commit/d726e928d2004d2a99caeeb00b95ce27dbc04bc0)
+  _(paragraph)_ Add alignment convenience functions ([#866](https://github.com/ratatui/ratatui/issues/866))
 
   ```text
   Added convenience functions left_aligned(), centered() and
   right_aligned() plus unit tests. Updated example code.
   ```
 
-- [c1ed5c3](https://github.com/ratatui-org/ratatui/commit/c1ed5c3637dc4574612ac2029249ba700e9192b5)
-  _(span)_ Add alignment functions ([#873](https://github.com/ratatui-org/ratatui/issues/873))
+- [c1ed5c3](https://github.com/ratatui/ratatui/commit/c1ed5c3637dc4574612ac2029249ba700e9192b5)
+  _(span)_ Add alignment functions ([#873](https://github.com/ratatui/ratatui/issues/873))
 
   ```text
   Implemented functions that convert Span into a
@@ -1782,16 +1785,16 @@ In this version, we have primarily focused on simplifications and quality-of-lif
 
   Closes #853
 
-- [b80264d](https://github.com/ratatui-org/ratatui/commit/b80264de877e7ca240cea15716379622d822bc08)
-  _(text)_ Add alignment convenience functions ([#862](https://github.com/ratatui-org/ratatui/issues/862))
+- [b80264d](https://github.com/ratatui/ratatui/commit/b80264de877e7ca240cea15716379622d822bc08)
+  _(text)_ Add alignment convenience functions ([#862](https://github.com/ratatui/ratatui/issues/862))
 
   ```text
   Adds convenience functions `left_aligned()`, `centered()` and
   `right_aligned()` plus unit tests.
   ```
 
-- [23f6938](https://github.com/ratatui-org/ratatui/commit/23f6938498a7c31916a091d5b79c9d95a0575344)
-  _(block)_ Add `Block::bordered` ([#736](https://github.com/ratatui-org/ratatui/issues/736))
+- [23f6938](https://github.com/ratatui/ratatui/commit/23f6938498a7c31916a091d5b79c9d95a0575344)
+  _(block)_ Add `Block::bordered` ([#736](https://github.com/ratatui/ratatui/issues/736))
 
   ````text
   This avoid creating a block with no borders and then settings Borders::ALL. i.e.
@@ -1802,8 +1805,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   ```
   ````
 
-- [ffd5fc7](https://github.com/ratatui-org/ratatui/commit/ffd5fc79fcaf8bfff1a49c55f8d4b503a9e6dfed)
-  _(color)_ Add Color::from_u32 constructor ([#785](https://github.com/ratatui-org/ratatui/issues/785))
+- [ffd5fc7](https://github.com/ratatui/ratatui/commit/ffd5fc79fcaf8bfff1a49c55f8d4b503a9e6dfed)
+  _(color)_ Add Color::from_u32 constructor ([#785](https://github.com/ratatui/ratatui/issues/785))
 
   ````text
   Convert a u32 in the format 0x00RRGGBB to a Color.
@@ -1814,8 +1817,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   ```
   ````
 
-- [4f2db82](https://github.com/ratatui-org/ratatui/commit/4f2db82a774a3faea7db9659f30684e9635c24b2)
-  _(color)_ Use the FromStr implementation for deserialization ([#705](https://github.com/ratatui-org/ratatui/issues/705))
+- [4f2db82](https://github.com/ratatui/ratatui/commit/4f2db82a774a3faea7db9659f30684e9635c24b2)
+  _(color)_ Use the FromStr implementation for deserialization ([#705](https://github.com/ratatui/ratatui/issues/705))
 
   ```text
   The deserialize implementation for Color used to support only the enum
@@ -1824,16 +1827,16 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   light-red, #00ff00, etc.)
   ```
 
-- [1cbe1f5](https://github.com/ratatui-org/ratatui/commit/1cbe1f52abb7ab1cd5bd05030e7857ee1762f44a)
-  _(constraints)_ Rename `Constraint::Proportional` to `Constraint::Fill` ([#880](https://github.com/ratatui-org/ratatui/issues/880))
+- [1cbe1f5](https://github.com/ratatui/ratatui/commit/1cbe1f52abb7ab1cd5bd05030e7857ee1762f44a)
+  _(constraints)_ Rename `Constraint::Proportional` to `Constraint::Fill` ([#880](https://github.com/ratatui/ratatui/issues/880))
 
   `Constraint::Fill` is a more intuitive name for the behavior, and it is
   shorter.
 
   Resolves #859
 
-- [dfd6db9](https://github.com/ratatui-org/ratatui/commit/dfd6db988faa7a45cbe99b01024c086c4fcf7577)
-  _(demo2)_ Add destroy mode to celebrate commit 1000! ([#809](https://github.com/ratatui-org/ratatui/issues/809))
+- [dfd6db9](https://github.com/ratatui/ratatui/commit/dfd6db988faa7a45cbe99b01024c086c4fcf7577)
+  _(demo2)_ Add destroy mode to celebrate commit 1000! ([#809](https://github.com/ratatui/ratatui/issues/809))
 
   ````text
   ```shell
@@ -1843,13 +1846,13 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   Press `d` to activate destroy mode and Enjoy!
 
   ![Destroy
-  Demo2](https://github.com/ratatui-org/ratatui/blob/1d39444e3dea6f309cf9035be2417ac711c1abc9/examples/demo2-destroy.gif?raw=true)
+  Demo2](https://github.com/ratatui/ratatui/blob/1d39444e3dea6f309cf9035be2417ac711c1abc9/examples/demo2-destroy.gif?raw=true)
 
   Vendors a copy of tui-big-text to allow us to use it in the demo.
   ````
 
-- [540fd2d](https://github.com/ratatui-org/ratatui/commit/540fd2df036648674a2f6d37f7b12326d5978bbd)
-  _(layout)_ Change `Flex::default()` ([#881](https://github.com/ratatui-org/ratatui/issues/881)) [**breaking**]
+- [540fd2d](https://github.com/ratatui/ratatui/commit/540fd2df036648674a2f6d37f7b12326d5978bbd)
+  _(layout)_ Change `Flex::default()` ([#881](https://github.com/ratatui/ratatui/issues/881)) [**breaking**]
 
   ````text
   This PR makes a number of simplifications to the layout and constraint
@@ -1913,24 +1916,24 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   constraints. I imagine most users will be happier out of the box with
   the new Table default.
 
-  Resolves https://github.com/ratatui-org/ratatui/issues/843
+  Resolves https://github.com/ratatui/ratatui/issues/843
 
   Thanks to @joshka for the direction
   ````
 
-- [bbcfa55](https://github.com/ratatui-org/ratatui/commit/bbcfa55a88c1916598ea0442217ac7f6a99ea96f)
-  _(layout)_ Add Rect::contains method ([#882](https://github.com/ratatui-org/ratatui/issues/882))
+- [bbcfa55](https://github.com/ratatui/ratatui/commit/bbcfa55a88c1916598ea0442217ac7f6a99ea96f)
+  _(layout)_ Add Rect::contains method ([#882](https://github.com/ratatui/ratatui/issues/882))
 
   ```text
   This is useful for performing hit tests (i.e. did the user click in an
   area).
   ```
 
-- [736605e](https://github.com/ratatui-org/ratatui/commit/736605ec88aac4877b19dd66ded97b26d933407f)
-  _(layout)_ Add default impl for Position ([#869](https://github.com/ratatui-org/ratatui/issues/869))
+- [736605e](https://github.com/ratatui/ratatui/commit/736605ec88aac4877b19dd66ded97b26d933407f)
+  _(layout)_ Add default impl for Position ([#869](https://github.com/ratatui/ratatui/issues/869))
 
-- [1e75596](https://github.com/ratatui-org/ratatui/commit/1e755967c53e9a1803cc7fcc46ad0946c78f0eda)
-  _(layout)_ Increase default cache size to 500 ([#850](https://github.com/ratatui-org/ratatui/issues/850))
+- [1e75596](https://github.com/ratatui/ratatui/commit/1e755967c53e9a1803cc7fcc46ad0946c78f0eda)
+  _(layout)_ Increase default cache size to 500 ([#850](https://github.com/ratatui/ratatui/issues/850))
 
   ```text
   This is a somewhat arbitrary size for the layout cache based on adding
@@ -1942,10 +1945,10 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   `Layout::init_cache()`.
   ```
 
-  Fixes:https://github.com/ratatui-org/ratatui/issues/820
+  Fixes:<https://github.com/ratatui/ratatui/issues/820>
 
-- [2819eea](https://github.com/ratatui-org/ratatui/commit/2819eea82bfde48562b830b4ef1c998dacae8b69)
-  _(layout)_ Add Position struct ([#790](https://github.com/ratatui-org/ratatui/issues/790))
+- [2819eea](https://github.com/ratatui/ratatui/commit/2819eea82bfde48562b830b4ef1c998dacae8b69)
+  _(layout)_ Add Position struct ([#790](https://github.com/ratatui/ratatui/issues/790))
 
   ```text
   This stores the x and y coordinates (columns and rows)
@@ -1955,8 +1958,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   - add Rect::as_position
   ```
 
-- [1561d64](https://github.com/ratatui-org/ratatui/commit/1561d64c80e6498f90807a1607d84a1405d3e0bb)
-  _(layout)_ Add Rect -> Size conversion methods ([#789](https://github.com/ratatui-org/ratatui/issues/789))
+- [1561d64](https://github.com/ratatui/ratatui/commit/1561d64c80e6498f90807a1607d84a1405d3e0bb)
+  _(layout)_ Add Rect -> Size conversion methods ([#789](https://github.com/ratatui/ratatui/issues/789))
 
   ```text
   - add Size::new() constructor
@@ -1965,8 +1968,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   - document and add tests for Size
   ```
 
-- [f13fd73](https://github.com/ratatui-org/ratatui/commit/f13fd73d9ec108af723a9cd11f4262f2b09c9d25)
-  _(layout)_ Add `Rect::clamp()` method ([#749](https://github.com/ratatui-org/ratatui/issues/749))
+- [f13fd73](https://github.com/ratatui/ratatui/commit/f13fd73d9ec108af723a9cd11f4262f2b09c9d25)
+  _(layout)_ Add `Rect::clamp()` method ([#749](https://github.com/ratatui/ratatui/issues/749))
 
   ````text
   * feat(layout): add a Rect::clamp() method
@@ -2006,8 +2009,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   * fix: move rstest to dev deps
   ````
 
-- [98bcf1c](https://github.com/ratatui-org/ratatui/commit/98bcf1c0a57a340229684345497b2d378979de04)
-  _(layout)_ Add Rect::split method ([#729](https://github.com/ratatui-org/ratatui/issues/729))
+- [98bcf1c](https://github.com/ratatui/ratatui/commit/98bcf1c0a57a340229684345497b2d378979de04)
+  _(layout)_ Add Rect::split method ([#729](https://github.com/ratatui/ratatui/issues/729))
 
   ````text
   This method splits a Rect and returns a fixed-size array of the
@@ -2021,8 +2024,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   ```
   ````
 
-- [0494ee5](https://github.com/ratatui-org/ratatui/commit/0494ee52f1f0070f1ccf4532f7301fd59d4a5c10)
-  _(layout)_ Accept Into<Constraint> for constructors ([#744](https://github.com/ratatui-org/ratatui/issues/744))
+- [0494ee5](https://github.com/ratatui/ratatui/commit/0494ee52f1f0070f1ccf4532f7301fd59d4a5c10)
+  _(layout)_ Accept Into<Constraint> for constructors ([#744](https://github.com/ratatui/ratatui/issues/744))
 
   ````text
   This allows Layout constructors to accept any type that implements
@@ -2038,8 +2041,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   ```
   ````
 
-- [7ab12ed](https://github.com/ratatui-org/ratatui/commit/7ab12ed8ce8f6cdb0712d132b4dfc4cccfda08da)
-  _(layout)_ Add horizontal and vertical constructors ([#728](https://github.com/ratatui-org/ratatui/issues/728))
+- [7ab12ed](https://github.com/ratatui/ratatui/commit/7ab12ed8ce8f6cdb0712d132b4dfc4cccfda08da)
+  _(layout)_ Add horizontal and vertical constructors ([#728](https://github.com/ratatui/ratatui/issues/728))
 
   ````text
   * feat(layout): add vertical and horizontal constructors
@@ -2063,8 +2066,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   ```
   ````
 
-- [4278b40](https://github.com/ratatui-org/ratatui/commit/4278b4088d2ab1d94aa5d73d7a0c321a46dbd9de)
-  _(line)_ Implement iterators for Line ([#896](https://github.com/ratatui-org/ratatui/issues/896))
+- [4278b40](https://github.com/ratatui/ratatui/commit/4278b4088d2ab1d94aa5d73d7a0c321a46dbd9de)
+  _(line)_ Implement iterators for Line ([#896](https://github.com/ratatui/ratatui/issues/896))
 
   ```text
   This allows iterating over the `Span`s of a line using `for` loops and
@@ -2075,8 +2078,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   - update call sites to iterate over `Line` rather than `Line::spans`
   ```
 
-- [5d410c6](https://github.com/ratatui-org/ratatui/commit/5d410c6895de49e77c7e0d1884be63d797724448)
-  _(line)_ Implement Widget for Line ([#715](https://github.com/ratatui-org/ratatui/issues/715))
+- [5d410c6](https://github.com/ratatui/ratatui/commit/5d410c6895de49e77c7e0d1884be63d797724448)
+  _(line)_ Implement Widget for Line ([#715](https://github.com/ratatui/ratatui/issues/715))
 
   ````text
   This allows us to use Line as a child of other widgets, and to use
@@ -2089,8 +2092,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   ```
   ````
 
-- [c977293](https://github.com/ratatui-org/ratatui/commit/c977293f14b019ee520379bf5eaafb44cef04a01)
-  _(line)_ Add style field, setters and docs ([#708](https://github.com/ratatui-org/ratatui/issues/708)) [**breaking**]
+- [c977293](https://github.com/ratatui/ratatui/commit/c977293f14b019ee520379bf5eaafb44cef04a01)
+  _(line)_ Add style field, setters and docs ([#708](https://github.com/ratatui/ratatui/issues/708)) [**breaking**]
 
   ```text
   - The `Line` struct now stores the style of the line rather than each
@@ -2102,15 +2105,15 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   BREAKING CHANGE:`Line::style` is now a field of `Line` instead of being
   stored in each `Span`.
 
-- [bbf2f90](https://github.com/ratatui-org/ratatui/commit/bbf2f906fbe7e593fdeb5dd7530d3479788f77a5)
-  _(rect.rs)_ Implement Rows and Columns iterators in Rect ([#765](https://github.com/ratatui-org/ratatui/issues/765))
+- [bbf2f90](https://github.com/ratatui/ratatui/commit/bbf2f906fbe7e593fdeb5dd7530d3479788f77a5)
+  _(rect.rs)_ Implement Rows and Columns iterators in Rect ([#765](https://github.com/ratatui/ratatui/issues/765))
 
   ```text
   This enables iterating over rows and columns of a Rect. In tern being able to use that with other iterators and simplify looping over cells.
   ```
 
-- [fe06f0c](https://github.com/ratatui-org/ratatui/commit/fe06f0c7b06e50cd5d7916dab9ccb5e28f5a6511)
-  _(serde)_ Support TableState, ListState, and ScrollbarState ([#723](https://github.com/ratatui-org/ratatui/issues/723))
+- [fe06f0c](https://github.com/ratatui/ratatui/commit/fe06f0c7b06e50cd5d7916dab9ccb5e28f5a6511)
+  _(serde)_ Support TableState, ListState, and ScrollbarState ([#723](https://github.com/ratatui/ratatui/issues/723))
 
   ````text
   TableState, ListState, and ScrollbarState can now be serialized and deserialized
@@ -2131,8 +2134,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   ```
   ````
 
-- [37c1836](https://github.com/ratatui-org/ratatui/commit/37c183636b573e7637af5fbab9ae5c6f2d3fec6b)
-  _(span)_ Implement Widget on Span ([#709](https://github.com/ratatui-org/ratatui/issues/709))
+- [37c1836](https://github.com/ratatui/ratatui/commit/37c183636b573e7637af5fbab9ae5c6f2d3fec6b)
+  _(span)_ Implement Widget on Span ([#709](https://github.com/ratatui/ratatui/issues/709))
 
   ````text
   This allows us to use Span as a child of other widgets, and to use
@@ -2147,8 +2150,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   ```
   ````
 
-- [e1e85aa](https://github.com/ratatui-org/ratatui/commit/e1e85aa7af2a7624b12a0ad7f0aa2413b409475d)
-  _(style)_ Add material design color palette ([#786](https://github.com/ratatui-org/ratatui/issues/786))
+- [e1e85aa](https://github.com/ratatui/ratatui/commit/e1e85aa7af2a7624b12a0ad7f0aa2413b409475d)
+  _(style)_ Add material design color palette ([#786](https://github.com/ratatui/ratatui/issues/786))
 
   ````text
   The `ratatui::style::palette::material` module contains the Google 2014
@@ -2163,8 +2166,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   ```
   ````
 
-- [bf67850](https://github.com/ratatui-org/ratatui/commit/bf678507395a528befcf5c5e3180368cb8f4b826)
-  _(style)_ Add tailwind color palette ([#787](https://github.com/ratatui-org/ratatui/issues/787))
+- [bf67850](https://github.com/ratatui/ratatui/commit/bf678507395a528befcf5c5e3180368cb8f4b826)
+  _(style)_ Add tailwind color palette ([#787](https://github.com/ratatui/ratatui/issues/787))
 
   ````text
   The `ratatui::style::palette::tailwind` module contains the default
@@ -2180,11 +2183,11 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   ```
   ````
 
-- [27e9216](https://github.com/ratatui-org/ratatui/commit/27e9216cea7f25fcf172fe0a8f11e7cca222b055)
-  _(table)_ Remove allow deprecated attribute used previously for segment_size ✨ ([#875](https://github.com/ratatui-org/ratatui/issues/875))
+- [27e9216](https://github.com/ratatui/ratatui/commit/27e9216cea7f25fcf172fe0a8f11e7cca222b055)
+  _(table)_ Remove allow deprecated attribute used previously for segment_size ✨ ([#875](https://github.com/ratatui/ratatui/issues/875))
 
-- [a489d85](https://github.com/ratatui-org/ratatui/commit/a489d85f2dda561ea18f1431f6e44f0335549eca)
-  _(table)_ Deprecate SegmentSize on table ([#842](https://github.com/ratatui-org/ratatui/issues/842))
+- [a489d85](https://github.com/ratatui/ratatui/commit/a489d85f2dda561ea18f1431f6e44f0335549eca)
+  _(table)_ Deprecate SegmentSize on table ([#842](https://github.com/ratatui/ratatui/issues/842))
 
   ```text
   This adds for table:
@@ -2195,8 +2198,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   - Updated tests
   ```
 
-- [c69ca47](https://github.com/ratatui-org/ratatui/commit/c69ca47922619332f76488f5d9e70541b496fe1c)
-  _(table)_ Collect iterator of `Row` into `Table` ([#774](https://github.com/ratatui-org/ratatui/issues/774)) [**breaking**]
+- [c69ca47](https://github.com/ratatui/ratatui/commit/c69ca47922619332f76488f5d9e70541b496fe1c)
+  _(table)_ Collect iterator of `Row` into `Table` ([#774](https://github.com/ratatui/ratatui/issues/774)) [**breaking**]
 
   ```text
   Any iterator whose item is convertible into `Row` can now be
@@ -2211,8 +2214,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   will no longer compile, as the type of `vec![]` can no longer be
   inferred.
 
-- [2faa879](https://github.com/ratatui-org/ratatui/commit/2faa879658a439d233edc4ac886fb42c17ff971a)
-  _(table)_ Accept Text for highlight_symbol ([#781](https://github.com/ratatui-org/ratatui/issues/781))
+- [2faa879](https://github.com/ratatui/ratatui/commit/2faa879658a439d233edc4ac886fb42c17ff971a)
+  _(table)_ Accept Text for highlight_symbol ([#781](https://github.com/ratatui/ratatui/issues/781))
 
   ````text
   This allows for multi-line symbols to be used as the highlight symbol.
@@ -2228,8 +2231,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   ```
   ````
 
-- [e64e194](https://github.com/ratatui-org/ratatui/commit/e64e194b6bc5f89c68fe73d430e63c264af6ca4f)
-  _(table)_ Implement FromIterator for widgets::Row ([#755](https://github.com/ratatui-org/ratatui/issues/755))
+- [e64e194](https://github.com/ratatui/ratatui/commit/e64e194b6bc5f89c68fe73d430e63c264af6ca4f)
+  _(table)_ Implement FromIterator for widgets::Row ([#755](https://github.com/ratatui/ratatui/issues/755))
 
   ```text
   The `Row::new` constructor accepts a single argument that implements
@@ -2239,8 +2242,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   entire iterator chain in `Row::new`.
   ```
 
-- [803a72d](https://github.com/ratatui-org/ratatui/commit/803a72df27190e273556e089e42036bfc001f003)
-  _(table)_ Accept Into<Constraint> for widths ([#745](https://github.com/ratatui-org/ratatui/issues/745))
+- [803a72d](https://github.com/ratatui/ratatui/commit/803a72df27190e273556e089e42036bfc001f003)
+  _(table)_ Accept Into<Constraint> for widths ([#745](https://github.com/ratatui/ratatui/issues/745))
 
   ````text
   This allows Table constructors to accept any type that implements
@@ -2254,15 +2257,15 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   ```
   ````
 
-- [f025d2b](https://github.com/ratatui-org/ratatui/commit/f025d2bfa26eac11ef5c2a63943a4e177abfc800)
-  _(table)_ Add Table::footer and Row::top_margin methods ([#722](https://github.com/ratatui-org/ratatui/issues/722))
+- [f025d2b](https://github.com/ratatui/ratatui/commit/f025d2bfa26eac11ef5c2a63943a4e177abfc800)
+  _(table)_ Add Table::footer and Row::top_margin methods ([#722](https://github.com/ratatui/ratatui/issues/722))
 
   ```text
   * feat(table): Add a Table::footer method
   ```
 
-- [f29c73f](https://github.com/ratatui-org/ratatui/commit/f29c73fb1cf746aea0adfaed4a8b959e0466b830)
-  _(tabs)_ Accept Iterators of `Line` in constructors ([#776](https://github.com/ratatui-org/ratatui/issues/776)) [**breaking**]
+- [f29c73f](https://github.com/ratatui/ratatui/commit/f29c73fb1cf746aea0adfaed4a8b959e0466b830)
+  _(tabs)_ Accept Iterators of `Line` in constructors ([#776](https://github.com/ratatui/ratatui/issues/776)) [**breaking**]
 
   ```text
   Any iterator whose item is convertible into `Line` can now be
@@ -2280,8 +2283,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   because the return type of `.collect()` can no longer be inferred to
   be a `Vec<_>`.
 
-- [b459228](https://github.com/ratatui-org/ratatui/commit/b459228e26b9429b8a09084d76251361f7f5bfd3)
-  _(termwiz)_ Add `From` termwiz style impls ([#726](https://github.com/ratatui-org/ratatui/issues/726))
+- [b459228](https://github.com/ratatui/ratatui/commit/b459228e26b9429b8a09084d76251361f7f5bfd3)
+  _(termwiz)_ Add `From` termwiz style impls ([#726](https://github.com/ratatui/ratatui/issues/726))
 
   ```text
   Important note: this also fixes a wrong mapping between ratatui's gray
@@ -2289,8 +2292,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   `termwiz::color::AnsiColor::Silver`
   ```
 
-- [9ba7354](https://github.com/ratatui-org/ratatui/commit/9ba7354335a106607fe0670e1205a038ec54aa1b)
-  _(text)_ Implement iterators for Text ([#900](https://github.com/ratatui-org/ratatui/issues/900))
+- [9ba7354](https://github.com/ratatui/ratatui/commit/9ba7354335a106607fe0670e1205a038ec54aa1b)
+  _(text)_ Implement iterators for Text ([#900](https://github.com/ratatui/ratatui/issues/900))
 
   ```text
   This allows iterating over the `Lines`s of a text using `for` loops and
@@ -2301,8 +2304,8 @@ In this version, we have primarily focused on simplifications and quality-of-lif
   - update call sites to iterate over `Text` rather than `Text::lines`
   ```
 
-- [68d5783](https://github.com/ratatui-org/ratatui/commit/68d5783a6912c644b922b7030facff4b1172a434)
-  _(text)_ Add style and alignment ([#807](https://github.com/ratatui-org/ratatui/issues/807))
+- [68d5783](https://github.com/ratatui/ratatui/commit/68d5783a6912c644b922b7030facff4b1172a434)
+  _(text)_ Add style and alignment ([#807](https://github.com/ratatui/ratatui/issues/807))
 
   Fixes #758, fixes #801
 
@@ -2315,8 +2318,8 @@ This PR adds:
 All places that use `Text` have been updated and support its new
 features expect paragraph which still has a custom implementation.
 
-- [815757f](https://github.com/ratatui-org/ratatui/commit/815757fcbbc147050f8ce9418a4e91fd871d011f)
-  _(widgets)_ Implement Widget for Widget refs ([#833](https://github.com/ratatui-org/ratatui/issues/833))
+- [815757f](https://github.com/ratatui/ratatui/commit/815757fcbbc147050f8ce9418a4e91fd871d011f)
+  _(widgets)_ Implement Widget for Widget refs ([#833](https://github.com/ratatui/ratatui/issues/833))
 
   ````text
   Many widgets can be rendered without changing their state.
@@ -2342,18 +2345,18 @@ features expect paragraph which still has a custom implementation.
   Other widgets will be implemented in follow up commits.
   ````
 
-  Fixes:https://github.com/ratatui-org/ratatui/discussions/164
-  Replaces PRs: https://github.com/ratatui-org/ratatui/pull/122 and
+  Fixes:<https://github.com/ratatui/ratatui/discussions/164>
+  Replaces PRs: <https://github.com/ratatui/ratatui/pull/122> and
 
-  https://github.com/ratatui-org/ratatui/pull/16
+  <https://github.com/ratatui/ratatui/pull/16>
 
-  Enables:https://github.com/ratatui-org/ratatui/issues/132
+  Enables:<https://github.com/ratatui/ratatui/issues/132>
   Validated as a viable working solution by:
 
-  https://github.com/ratatui-org/ratatui/pull/836
+  <https://github.com/ratatui/ratatui/pull/836>
 
-- [eb79256](https://github.com/ratatui-org/ratatui/commit/eb79256ceea151130c6b80930b51098b9ad43f5b)
-  _(widgets)_ Collect iterator of `ListItem` into `List` ([#775](https://github.com/ratatui-org/ratatui/issues/775))
+- [eb79256](https://github.com/ratatui/ratatui/commit/eb79256ceea151130c6b80930b51098b9ad43f5b)
+  _(widgets)_ Collect iterator of `ListItem` into `List` ([#775](https://github.com/ratatui/ratatui/issues/775))
 
   ````text
   Any iterator whose item is convertible into `ListItem` can now be
@@ -2364,8 +2367,8 @@ features expect paragraph which still has a custom implementation.
   ```
   ````
 
-- [c8dd879](https://github.com/ratatui-org/ratatui/commit/c8dd87918d44fff6d4c3c78e1fc821a3275db1ae)
-  _(uncategorized)_ Add WidgetRef and StatefulWidgetRef traits ([#903](https://github.com/ratatui-org/ratatui/issues/903))
+- [c8dd879](https://github.com/ratatui/ratatui/commit/c8dd87918d44fff6d4c3c78e1fc821a3275db1ae)
+  _(uncategorized)_ Add WidgetRef and StatefulWidgetRef traits ([#903](https://github.com/ratatui/ratatui/issues/903))
 
   ````text
   The Widget trait consumes self, which makes it impossible to use in a
@@ -2416,8 +2419,8 @@ features expect paragraph which still has a custom implementation.
   ```
   ````
 
-- [87bf1dd](https://github.com/ratatui-org/ratatui/commit/87bf1dd9dfb8bf2e6c08c488d4a38dac21e14304)
-  _(uncategorized)_ Replace Rect::split with Layout::areas and spacers ([#904](https://github.com/ratatui-org/ratatui/issues/904))
+- [87bf1dd](https://github.com/ratatui/ratatui/commit/87bf1dd9dfb8bf2e6c08c488d4a38dac21e14304)
+  _(uncategorized)_ Replace Rect::split with Layout::areas and spacers ([#904](https://github.com/ratatui/ratatui/issues/904))
 
   ```text
   In a recent commit we added Rec::split, but this feels more ergonomic as
@@ -2425,8 +2428,8 @@ features expect paragraph which still has a custom implementation.
   the areas.
   ```
 
-- [dab08b9](https://github.com/ratatui-org/ratatui/commit/dab08b99b6a2a4c8ced6f780af7a37a0f3c34f6b)
-  _(uncategorized)_ Show space constrained UIs conditionally ([#895](https://github.com/ratatui-org/ratatui/issues/895))
+- [dab08b9](https://github.com/ratatui/ratatui/commit/dab08b99b6a2a4c8ced6f780af7a37a0f3c34f6b)
+  _(uncategorized)_ Show space constrained UIs conditionally ([#895](https://github.com/ratatui/ratatui/issues/895))
 
   ```text
   With this PR the constraint explorer demo only shows space constrained
@@ -2435,26 +2438,26 @@ features expect paragraph which still has a custom implementation.
   Smallest (15 row height):
 
   <img width="759" alt="image"
-  src="https://github.com/ratatui-org/ratatui/assets/1813121/37a4a027-6c6d-4feb-8104-d732aee298ac">
+  src="https://github.com/ratatui/ratatui/assets/1813121/37a4a027-6c6d-4feb-8104-d732aee298ac">
 
   Small (20 row height):
 
   <img width="759" alt="image"
-  src="https://github.com/ratatui-org/ratatui/assets/1813121/f76e025f-0061-4f09-9c91-2f7b00fcfb9e">
+  src="https://github.com/ratatui/ratatui/assets/1813121/f76e025f-0061-4f09-9c91-2f7b00fcfb9e">
 
   Medium (30 row height):
 
   <img width="758" alt="image"
-  src="https://github.com/ratatui-org/ratatui/assets/1813121/81b070da-1bfb-40c5-9fbc-c1ab44ce422e">
+  src="https://github.com/ratatui/ratatui/assets/1813121/81b070da-1bfb-40c5-9fbc-c1ab44ce422e">
 
   Full (40 row height):
 
   <img width="760" alt="image"
-  src="https://github.com/ratatui-org/ratatui/assets/1813121/7bb8a8c4-1a77-4bbc-a346-c8b5c198c6d3">
+  src="https://github.com/ratatui/ratatui/assets/1813121/7bb8a8c4-1a77-4bbc-a346-c8b5c198c6d3">
   ```
 
-- [2a12f7b](https://github.com/ratatui-org/ratatui/commit/2a12f7bddf0b286e63439c2d1fa894dcfbfde6c0)
-  _(uncategorized)_ Impl Widget for &BarChart ([#897](https://github.com/ratatui-org/ratatui/issues/897))
+- [2a12f7b](https://github.com/ratatui/ratatui/commit/2a12f7bddf0b286e63439c2d1fa894dcfbfde6c0)
+  _(uncategorized)_ Impl Widget for &BarChart ([#897](https://github.com/ratatui/ratatui/issues/897))
 
   ```text
   BarChart had some internal mutations that needed to be removed to
@@ -2462,14 +2465,14 @@ features expect paragraph which still has a custom implementation.
   other widgets.
   ```
 
-- [9ec43ef](https://github.com/ratatui-org/ratatui/commit/9ec43eff1c7a62631fab99e4874ccd15fe7b210a)
-  _(uncategorized)_ Constraint Explorer example ([#893](https://github.com/ratatui-org/ratatui/issues/893))
+- [9ec43ef](https://github.com/ratatui/ratatui/commit/9ec43eff1c7a62631fab99e4874ccd15fe7b210a)
+  _(uncategorized)_ Constraint Explorer example ([#893](https://github.com/ratatui/ratatui/issues/893))
 
   ```text
   Here's a constraint explorer demo put together with @joshka
   ```
 
-  https://github.com/ratatui-org/ratatui/assets/1813121/08d7d8f6-d013-44b4-8331-f4eee3589cce
+  <https://github.com/ratatui/ratatui/assets/1813121/08d7d8f6-d013-44b4-8331-f4eee3589cce>
 
 It allows users to interactive explore how the constraints behave with
 respect to each other and compare that across flex modes. It allows
@@ -2479,24 +2482,24 @@ decrement the values, add and remove constraints, and add spacing
 It is also a good example for how to structure a simple TUI with several
 Ratatui code patterns that are useful for refactoring.
 
-Fixes:https://github.com/ratatui-org/ratatui/issues/792
+Fixes:<https://github.com/ratatui/ratatui/issues/792>
 
 ---
 
-- [4ee4e6d](https://github.com/ratatui-org/ratatui/commit/4ee4e6d78a136b5a1e4942f25b9afe34f7dd5d0c)
-  _(uncategorized)_ Make spacing work in `Flex::SpaceAround` and `Flex::SpaceBetween` ([#892](https://github.com/ratatui-org/ratatui/issues/892))
+- [4ee4e6d](https://github.com/ratatui/ratatui/commit/4ee4e6d78a136b5a1e4942f25b9afe34f7dd5d0c)
+  _(uncategorized)_ Make spacing work in `Flex::SpaceAround` and `Flex::SpaceBetween` ([#892](https://github.com/ratatui/ratatui/issues/892))
 
   ```text
   This PR implements user provided spacing gaps for `SpaceAround` and
   `SpaceBetween`.
   ```
 
-  https://github.com/ratatui-org/ratatui/assets/1813121/2e260708-e8a7-48ef-aec7-9cf84b655e91
+  <https://github.com/ratatui/ratatui/assets/1813121/2e260708-e8a7-48ef-aec7-9cf84b655e91>
 
 Now user provided spacing gaps always take priority in all `Flex` modes.
 
-- [dd5ca3a](https://github.com/ratatui-org/ratatui/commit/dd5ca3a0c83bc1efc281133707eec04864567e69)
-  _(uncategorized)_ Better weights for constraints ([#889](https://github.com/ratatui-org/ratatui/issues/889))
+- [dd5ca3a](https://github.com/ratatui/ratatui/commit/dd5ca3a0c83bc1efc281133707eec04864567e69)
+  _(uncategorized)_ Better weights for constraints ([#889](https://github.com/ratatui/ratatui/issues/889))
 
   ````text
   This PR is a split of reworking the weights from #888
@@ -2519,24 +2522,24 @@ Now user provided spacing gaps always take priority in all `Flex` modes.
   ```
   ````
 
-- [aeec163](https://github.com/ratatui-org/ratatui/commit/aeec16369bdf26dc96af46cc580df191078464ae)
-  _(uncategorized)_ Change rounding to make tests stable ([#888](https://github.com/ratatui-org/ratatui/issues/888))
+- [aeec163](https://github.com/ratatui/ratatui/commit/aeec16369bdf26dc96af46cc580df191078464ae)
+  _(uncategorized)_ Change rounding to make tests stable ([#888](https://github.com/ratatui/ratatui/issues/888))
 
   ```text
   This fixes some unstable tests
   ```
 
-- [be4fdaa](https://github.com/ratatui-org/ratatui/commit/be4fdaa0c7c863daa50c0109cd5f96005365029d)
-  _(uncategorized)_ Change priority of constraints and add `split_with_spacers` ✨ ([#788](https://github.com/ratatui-org/ratatui/issues/788))
+- [be4fdaa](https://github.com/ratatui/ratatui/commit/be4fdaa0c7c863daa50c0109cd5f96005365029d)
+  _(uncategorized)_ Change priority of constraints and add `split_with_spacers` ✨ ([#788](https://github.com/ratatui/ratatui/issues/788))
 
   ```text
-  Follow up to https://github.com/ratatui-org/ratatui/pull/783
+  Follow up to https://github.com/ratatui/ratatui/pull/783
 
   This PR introduces different priorities for each kind of constraint.
   This PR also adds tests that specifies this behavior. This PR resolves a
   number of broken tests.
 
-  Fixes https://github.com/ratatui-org/ratatui/issues/827
+  Fixes https://github.com/ratatui/ratatui/issues/827
 
   With this PR, the layout algorithm will do the following in order:
 
@@ -2558,14 +2561,14 @@ Now user provided spacing gaps always take priority in all `Flex` modes.
   idea). Here's a screenshot with the modified flex example:
 
   <img width="569" alt="image"
-  src="https://github.com/ratatui-org/ratatui/assets/1813121/46c8901d-882c-43b0-ba87-b1d455099d8f">
+  src="https://github.com/ratatui/ratatui/assets/1813121/46c8901d-882c-43b0-ba87-b1d455099d8f">
 
   This PR introduces a `strengths` module that has "default" weights that
   give stable solutions as well as predictable behavior.
   ```
 
-- [d713201](https://github.com/ratatui-org/ratatui/commit/d7132011f921cb87593914bd7d2e24ac676ec911)
-  _(uncategorized)_ Add `Color::from_hsl` ✨ ([#772](https://github.com/ratatui-org/ratatui/issues/772))
+- [d713201](https://github.com/ratatui/ratatui/commit/d7132011f921cb87593914bd7d2e24ac676ec911)
+  _(uncategorized)_ Add `Color::from_hsl` ✨ ([#772](https://github.com/ratatui/ratatui/issues/772))
 
   ````text
   This PR adds `Color::from_hsl` that returns a valid `Color::Rgb`.
@@ -2586,8 +2589,8 @@ Now user provided spacing gaps always take priority in all `Flex` modes.
 
   Related #763
 
-- [405a125](https://github.com/ratatui-org/ratatui/commit/405a125c8235b983993e3774361821b67a340aa0)
-  _(uncategorized)_ Add wide and tall proportional border set ([#848](https://github.com/ratatui-org/ratatui/issues/848))
+- [405a125](https://github.com/ratatui/ratatui/commit/405a125c8235b983993e3774361821b67a340aa0)
+  _(uncategorized)_ Add wide and tall proportional border set ([#848](https://github.com/ratatui/ratatui/issues/848))
 
   ```text
   Adds `PROPORTIONAL_WIDE` and `PROPORTIONAL_TALL` border sets.
@@ -2611,10 +2614,10 @@ Now user provided spacing gaps always take priority in all `Flex` modes.
 █▄▄█
 ```
 
-Fixes:https://github.com/ratatui-org/ratatui/issues/834
+Fixes:<https://github.com/ratatui/ratatui/issues/834>
 
-- [9df6ceb](https://github.com/ratatui-org/ratatui/commit/9df6cebb58e97ac795868fa0af96a8aaf9c794c0)
-  _(uncategorized)_ Table column calculation uses layout spacing ✨ ([#824](https://github.com/ratatui-org/ratatui/issues/824))
+- [9df6ceb](https://github.com/ratatui/ratatui/commit/9df6cebb58e97ac795868fa0af96a8aaf9c794c0)
+  _(uncategorized)_ Table column calculation uses layout spacing ✨ ([#824](https://github.com/ratatui/ratatui/issues/824))
 
   ```text
   This uses the new `spacing` feature of the `Layout` struct to allocate
@@ -2632,8 +2635,8 @@ Fixes:https://github.com/ratatui-org/ratatui/issues/834
   ---------
   ```
 
-- [f299463](https://github.com/ratatui-org/ratatui/commit/f299463847e8aa4b61619e5a5c02c5855d8fdb7b)
-  _(uncategorized)_ Add one eighth wide and tall border sets ✨ ([#831](https://github.com/ratatui-org/ratatui/issues/831))
+- [f299463](https://github.com/ratatui/ratatui/commit/f299463847e8aa4b61619e5a5c02c5855d8fdb7b)
+  _(uncategorized)_ Add one eighth wide and tall border sets ✨ ([#831](https://github.com/ratatui/ratatui/issues/831))
 
   ````text
   This PR adds the
@@ -2644,10 +2647,10 @@ Fixes:https://github.com/ratatui-org/ratatui/issues/834
   mcgugan wide, bottom is mcgugan tall):
 
   <img width="759" alt="image"
-  src="https://github.com/ratatui-org/ratatui/assets/1813121/756bb50e-f8c3-4eec-abe8-ce358058a526">
+  src="https://github.com/ratatui/ratatui/assets/1813121/756bb50e-f8c3-4eec-abe8-ce358058a526">
 
   <img width="759" alt="image"
-  src="https://github.com/ratatui-org/ratatui/assets/1813121/583485ef-9eb2-4b45-ab88-90bd7cb14c54">
+  src="https://github.com/ratatui/ratatui/assets/1813121/583485ef-9eb2-4b45-ab88-90bd7cb14c54">
 
   As of this PR, `MCGUGAN_WIDE` has to be styled manually, like so:
 
@@ -2678,17 +2681,17 @@ Fixes:https://github.com/ratatui-org/ratatui/issues/834
   ```
   ````
 
-- [ae6a2b0](https://github.com/ratatui-org/ratatui/commit/ae6a2b0007ee7195de14d36420e2e30853fbb2f4)
-  _(uncategorized)_ Add spacing feature to flex example ✨ ([#830](https://github.com/ratatui-org/ratatui/issues/830))
+- [ae6a2b0](https://github.com/ratatui/ratatui/commit/ae6a2b0007ee7195de14d36420e2e30853fbb2f4)
+  _(uncategorized)_ Add spacing feature to flex example ✨ ([#830](https://github.com/ratatui/ratatui/issues/830))
 
   ```text
   This adds the `spacing` using `+` and `-` to the flex example
   ```
 
-- [cddf4b2](https://github.com/ratatui-org/ratatui/commit/cddf4b2930f573fafad64a4ddd7fe5753f7540e2)
-  _(uncategorized)_ Implement Display for Text, Line, Span ([#826](https://github.com/ratatui-org/ratatui/issues/826))
+- [cddf4b2](https://github.com/ratatui/ratatui/commit/cddf4b2930f573fafad64a4ddd7fe5753f7540e2)
+  _(uncategorized)_ Implement Display for Text, Line, Span ([#826](https://github.com/ratatui/ratatui/issues/826))
 
-  Issue:https://github.com/ratatui-org/ratatui/issues/816
+  Issue:<https://github.com/ratatui/ratatui/issues/816>
 
 This PR adds:
 
@@ -2696,8 +2699,8 @@ This PR adds:
 
 Display implementation displays actual content while ignoring style.
 
-- [5131c81](https://github.com/ratatui-org/ratatui/commit/5131c813ce5de078be0458c9a067bca2d6b38921)
-  _(uncategorized)_ Add layout spacing ✨ ([#821](https://github.com/ratatui-org/ratatui/issues/821))
+- [5131c81](https://github.com/ratatui/ratatui/commit/5131c813ce5de078be0458c9a067bca2d6b38921)
+  _(uncategorized)_ Add layout spacing ✨ ([#821](https://github.com/ratatui/ratatui/issues/821))
 
   ```text
   This adds a `spacing` feature for layouts.
@@ -2705,7 +2708,7 @@ Display implementation displays actual content while ignoring style.
   Spacing can be added between items of a layout.
   ```
 
-- [de97a1f](https://github.com/ratatui-org/ratatui/commit/de97a1f1da4fd146034f7c8f20264f4d558cc1a0)
+- [de97a1f](https://github.com/ratatui/ratatui/commit/de97a1f1da4fd146034f7c8f20264f4d558cc1a0)
   _(uncategorized)_ Add flex to layout ✨
 
   ```text
@@ -2721,7 +2724,7 @@ Display implementation displays actual content while ignoring style.
   - SpaceAround
   - SpaceBetween
 
-  <img width="380" alt="image" src="https://github.com/ratatui-org/ratatui/assets/1813121/b744518c-eae7-4e35-bbc4-fe3c95193cde">
+  <img width="380" alt="image" src="https://github.com/ratatui/ratatui/assets/1813121/b744518c-eae7-4e35-bbc4-fe3c95193cde">
 
   It also adds two more variants, to make this backward compatible and to
   make it replace `SegmentSize`:
@@ -2741,19 +2744,19 @@ Display implementation displays actual content while ignoring style.
   test it visually, shared below:
   ```
 
-  https://github.com/ratatui-org/ratatui/assets/1813121/c8716c59-493f-4631-add5-feecf4bd4e06
+  <https://github.com/ratatui/ratatui/assets/1813121/c8716c59-493f-4631-add5-feecf4bd4e06>
 
-- [9a3815b](https://github.com/ratatui-org/ratatui/commit/9a3815b66d8b6e4ff9f6475666f5742701e256bb)
-  _(uncategorized)_ Add Constraint::Fixed and Constraint::Proportional ✨ ([#783](https://github.com/ratatui-org/ratatui/issues/783))
+- [9a3815b](https://github.com/ratatui/ratatui/commit/9a3815b66d8b6e4ff9f6475666f5742701e256bb)
+  _(uncategorized)_ Add Constraint::Fixed and Constraint::Proportional ✨ ([#783](https://github.com/ratatui/ratatui/issues/783))
 
-- [425a651](https://github.com/ratatui-org/ratatui/commit/425a65140b61695169c996784974488ad2fd16ea)
-  _(uncategorized)_ Add comprehensive tests for Length interacting with other constraints ✨ ([#802](https://github.com/ratatui-org/ratatui/issues/802))
+- [425a651](https://github.com/ratatui/ratatui/commit/425a65140b61695169c996784974488ad2fd16ea)
+  _(uncategorized)_ Add comprehensive tests for Length interacting with other constraints ✨ ([#802](https://github.com/ratatui/ratatui/issues/802))
 
-- [c50ff08](https://github.com/ratatui-org/ratatui/commit/c50ff08a630ae59c9aac10f69fe3ce67c2db449c)
-  _(uncategorized)_ Add frame count ✨ ([#766](https://github.com/ratatui-org/ratatui/issues/766))
+- [c50ff08](https://github.com/ratatui/ratatui/commit/c50ff08a630ae59c9aac10f69fe3ce67c2db449c)
+  _(uncategorized)_ Add frame count ✨ ([#766](https://github.com/ratatui/ratatui/issues/766))
 
-- [8f56fab](https://github.com/ratatui-org/ratatui/commit/8f56fabcdd34cb3938736f3302902a7fead64ee5)
-  _(uncategorized)_ Accept Color and Modifier for all Styles ([#720](https://github.com/ratatui-org/ratatui/issues/720)) [**breaking**]
+- [8f56fab](https://github.com/ratatui/ratatui/commit/8f56fabcdd34cb3938736f3302902a7fead64ee5)
+  _(uncategorized)_ Accept Color and Modifier for all Styles ([#720](https://github.com/ratatui/ratatui/issues/720)) [**breaking**]
 
   ````text
   * feat: accept Color and Modifier for all Styles
@@ -2776,7 +2779,7 @@ Display implementation displays actual content while ignoring style.
 
 `````
 
-Fixes https://github.com/ratatui-org/ratatui/issues/694
+Fixes https://github.com/ratatui/ratatui/issues/694
 
   BREAKING CHANGE:All style related methods now accept `S: Into<Style>`
 instead of `Style`. This means that if you are already passing an
@@ -2794,45 +2797,45 @@ Adds conversions for various Color and Modifier combinations
 
 ### Bug Fixes
 
-- [ee54493](https://github.com/ratatui-org/ratatui/commit/ee544931633ada25d84daa95e4e3a0b17801cb8b)
-  *(buffer)* Don't panic in set_style ([#714](https://github.com/ratatui-org/ratatui/issues/714))
+- [ee54493](https://github.com/ratatui/ratatui/commit/ee544931633ada25d84daa95e4e3a0b17801cb8b)
+  *(buffer)* Don't panic in set_style ([#714](https://github.com/ratatui/ratatui/issues/714))
 
   ````text
   This fixes a panic in set_style when the area to be styled is
   outside the buffer's bounds.
 `````
 
-- [c959bd2](https://github.com/ratatui-org/ratatui/commit/c959bd2881244a4ad9609403d8a84860f290b859)
-  _(calendar)_ CalendarEventStore panic ([#822](https://github.com/ratatui-org/ratatui/issues/822))
+- [c959bd2](https://github.com/ratatui/ratatui/commit/c959bd2881244a4ad9609403d8a84860f290b859)
+  _(calendar)_ CalendarEventStore panic ([#822](https://github.com/ratatui/ratatui/issues/822))
 
   `CalendarEventStore::today()` panics if the system's UTC offset cannot
   be determined. In this circumstance, it's better to use `now_utc`
   instead.
 
-- [0614190](https://github.com/ratatui-org/ratatui/commit/06141900b4f049dd2c76bfccb49b4d51ae854bb0)
-  _(cd)_ Fix grepping the last release ([#762](https://github.com/ratatui-org/ratatui/issues/762))
+- [0614190](https://github.com/ratatui/ratatui/commit/06141900b4f049dd2c76bfccb49b4d51ae854bb0)
+  _(cd)_ Fix grepping the last release ([#762](https://github.com/ratatui/ratatui/issues/762))
 
-- [a67815e](https://github.com/ratatui-org/ratatui/commit/a67815e1388806d87d387ff17af0dfab48412011)
-  _(chart)_ Exclude unnamed datasets from legend ([#753](https://github.com/ratatui-org/ratatui/issues/753))
+- [a67815e](https://github.com/ratatui/ratatui/commit/a67815e1388806d87d387ff17af0dfab48412011)
+  _(chart)_ Exclude unnamed datasets from legend ([#753](https://github.com/ratatui/ratatui/issues/753))
 
   ```text
   A dataset with no name won't display an empty line anymore in the legend.
   If no dataset have name, then no legend is ever displayed.
   ```
 
-- [3e7810a](https://github.com/ratatui-org/ratatui/commit/3e7810a2ab2bbd09027ecd832aa295c5e71d9eda)
-  _(example)_ Increase layout cache size ([#815](https://github.com/ratatui-org/ratatui/issues/815))
+- [3e7810a](https://github.com/ratatui/ratatui/commit/3e7810a2ab2bbd09027ecd832aa295c5e71d9eda)
+  _(example)_ Increase layout cache size ([#815](https://github.com/ratatui/ratatui/issues/815))
 
   ```text
   This was causing very bad performances especially on scrolling.
   It's also a good usage demonstration.
   ```
 
-- [50b81c9](https://github.com/ratatui-org/ratatui/commit/50b81c9d4ea6a357cc964baff0b267dcfe6087c6)
-  _(examples/scrollbar)_ Title wasn't displayed because of background reset ([#795](https://github.com/ratatui-org/ratatui/issues/795))
+- [50b81c9](https://github.com/ratatui/ratatui/commit/50b81c9d4ea6a357cc964baff0b267dcfe6087c6)
+  _(examples/scrollbar)_ Title wasn't displayed because of background reset ([#795](https://github.com/ratatui/ratatui/issues/795))
 
-- [b3a57f3](https://github.com/ratatui-org/ratatui/commit/b3a57f3dff1e56fe431235b839c4bd0ee0fec594)
-  _(list)_ Modify List and List example to support saving offsets. ([#667](https://github.com/ratatui-org/ratatui/issues/667))
+- [b3a57f3](https://github.com/ratatui/ratatui/commit/b3a57f3dff1e56fe431235b839c4bd0ee0fec594)
+  _(list)_ Modify List and List example to support saving offsets. ([#667](https://github.com/ratatui/ratatui/issues/667))
 
   ```text
   The current `List` example will unselect and reset the position of a
@@ -2843,18 +2846,18 @@ Adds conversions for various Color and Modifier combinations
   `unselect()`s a `StatefulList`.
   ```
 
-- [6645d2e](https://github.com/ratatui-org/ratatui/commit/6645d2e0585a4e2d1d64fa730c09077b2d215545)
-  _(table)_ Ensure that default and new() match ([#751](https://github.com/ratatui-org/ratatui/issues/751)) [**breaking**]
+- [6645d2e](https://github.com/ratatui/ratatui/commit/6645d2e0585a4e2d1d64fa730c09077b2d215545)
+  _(table)_ Ensure that default and new() match ([#751](https://github.com/ratatui/ratatui/issues/751)) [**breaking**]
 
   ```text
-  In https://github.com/ratatui-org/ratatui/pull/660 we introduced the
+  In https://github.com/ratatui/ratatui/pull/660 we introduced the
   segment_size field to the Table struct. However, we forgot to update
   the default() implementation to match the new() implementation. This
   meant that the default() implementation picked up SegmentSize::default()
   instead of SegmentSize::None.
 
   Additionally the introduction of Table::default() in an earlier PR,
-  https://github.com/ratatui-org/ratatui/pull/339, was also missing the
+  https://github.com/ratatui/ratatui/pull/339, was also missing the
   default for the column_spacing field (1).
 
   This commit fixes the default() implementation to match the new()
@@ -2868,8 +2871,8 @@ Adds conversions for various Color and Modifier combinations
   SegmentSize::None. This will affect the rendering of a small amount of
   apps.
 
-- [b0ed658](https://github.com/ratatui-org/ratatui/commit/b0ed658970e8a94f25948c80d511102c197a8f6a)
-  _(table)_ Render missing widths as equal ([#710](https://github.com/ratatui-org/ratatui/issues/710))
+- [b0ed658](https://github.com/ratatui/ratatui/commit/b0ed658970e8a94f25948c80d511102c197a8f6a)
+  _(table)_ Render missing widths as equal ([#710](https://github.com/ratatui/ratatui/issues/710))
 
   ```text
   Previously, if `.widths` was not called before rendering a `Table`, no
@@ -2879,27 +2882,27 @@ Adds conversions for various Color and Modifier combinations
 
   Fixes #510.
 
-- [f71bf18](https://github.com/ratatui-org/ratatui/commit/f71bf182975526aa2eca9ee710361f39db2d666d)
-  _(uncategorized)_ Bug with flex stretch with spacing and proportional constraints ([#829](https://github.com/ratatui-org/ratatui/issues/829))
+- [f71bf18](https://github.com/ratatui/ratatui/commit/f71bf182975526aa2eca9ee710361f39db2d666d)
+  _(uncategorized)_ Bug with flex stretch with spacing and proportional constraints ([#829](https://github.com/ratatui/ratatui/issues/829))
 
   ```text
   This PR fixes a bug with layouts when using spacing on proportional
   constraints.
   ```
 
-- [cc6737b](https://github.com/ratatui-org/ratatui/commit/cc6737b8bc09d254413adc1cbf2bc62d2f93792d)
-  _(uncategorized)_ Make SpaceBetween with one element Stretch 🐛 ([#813](https://github.com/ratatui-org/ratatui/issues/813))
+- [cc6737b](https://github.com/ratatui/ratatui/commit/cc6737b8bc09d254413adc1cbf2bc62d2f93792d)
+  _(uncategorized)_ Make SpaceBetween with one element Stretch 🐛 ([#813](https://github.com/ratatui/ratatui/issues/813))
 
   ```text
   When there's just one element, `SpaceBetween` should do the same thing
   as `Stretch`.
   ```
 
-- [7a8af8d](https://github.com/ratatui-org/ratatui/commit/7a8af8da6ba83c7a3f31d03b29c51de6b03ced64)
-  _(uncategorized)_ Update templates links ([#808](https://github.com/ratatui-org/ratatui/issues/808))
+- [7a8af8d](https://github.com/ratatui/ratatui/commit/7a8af8da6ba83c7a3f31d03b29c51de6b03ced64)
+  _(uncategorized)_ Update templates links ([#808](https://github.com/ratatui/ratatui/issues/808))
 
-- [f2eab71](https://github.com/ratatui-org/ratatui/commit/f2eab71ccf11a206c253bf4efeafc744f103b116)
-  _(uncategorized)_ Broken tests in table.rs ([#784](https://github.com/ratatui-org/ratatui/issues/784))
+- [f2eab71](https://github.com/ratatui/ratatui/commit/f2eab71ccf11a206c253bf4efeafc744f103b116)
+  _(uncategorized)_ Broken tests in table.rs ([#784](https://github.com/ratatui/ratatui/issues/784))
 
   ```text
   * fix: broken tests in table.rs
@@ -2907,37 +2910,37 @@ Adds conversions for various Color and Modifier combinations
   * fix: Use default instead of raw
   ```
 
-- [8dd177a](https://github.com/ratatui-org/ratatui/commit/8dd177a0513230bfddc89aa315dfb49d1c7b070c)
-  _(uncategorized)_ Fix PR write permission to upload unsigned commit comment ([#770](https://github.com/ratatui-org/ratatui/issues/770))
+- [8dd177a](https://github.com/ratatui/ratatui/commit/8dd177a0513230bfddc89aa315dfb49d1c7b070c)
+  _(uncategorized)_ Fix PR write permission to upload unsigned commit comment ([#770](https://github.com/ratatui/ratatui/issues/770))
 
 ### Refactor
 
-- [cf86123](https://github.com/ratatui-org/ratatui/commit/cf861232c7c2369fa44010374432ba0a4814b6f8)
-  _(scrollbar)_ Rewrite scrollbar implementation ([#847](https://github.com/ratatui-org/ratatui/issues/847))
+- [cf86123](https://github.com/ratatui/ratatui/commit/cf861232c7c2369fa44010374432ba0a4814b6f8)
+  _(scrollbar)_ Rewrite scrollbar implementation ([#847](https://github.com/ratatui/ratatui/issues/847))
 
   ```text
   Implementation was simplified and calculates the size of the thumb a
   bit more proportionally to the content that is visible.
   ```
 
-- [fd4703c](https://github.com/ratatui-org/ratatui/commit/fd4703c0869eca22a51d9a33f7bb54bfd051c565)
-  _(block)_ Move padding and title into separate files ([#837](https://github.com/ratatui-org/ratatui/issues/837))
+- [fd4703c](https://github.com/ratatui/ratatui/commit/fd4703c0869eca22a51d9a33f7bb54bfd051c565)
+  _(block)_ Move padding and title into separate files ([#837](https://github.com/ratatui/ratatui/issues/837))
 
-- [bc274e2](https://github.com/ratatui-org/ratatui/commit/bc274e2bd9cfee1133dfbcca3c95374560706537)
-  _(block)_ Remove deprecated `title_on_bottom` ([#757](https://github.com/ratatui-org/ratatui/issues/757)) [**breaking**]
+- [bc274e2](https://github.com/ratatui/ratatui/commit/bc274e2bd9cfee1133dfbcca3c95374560706537)
+  _(block)_ Remove deprecated `title_on_bottom` ([#757](https://github.com/ratatui/ratatui/issues/757)) [**breaking**]
 
   `Block::title_on_bottom` was deprecated in v0.22. Use `Block::title` and `Title::position` instead.
 
-- [a62632a](https://github.com/ratatui-org/ratatui/commit/a62632a947a950f7ab303e67eb910b01f4ee256d)
-  _(buffer)_ Split buffer module into files ([#721](https://github.com/ratatui-org/ratatui/issues/721))
+- [a62632a](https://github.com/ratatui/ratatui/commit/a62632a947a950f7ab303e67eb910b01f4ee256d)
+  _(buffer)_ Split buffer module into files ([#721](https://github.com/ratatui/ratatui/issues/721))
 
-- [e0aa6c5](https://github.com/ratatui-org/ratatui/commit/e0aa6c5e1f254c7222afee7a8acf1652025b1949)
-  _(chart)_ Replace deprecated apply ([#812](https://github.com/ratatui-org/ratatui/issues/812))
+- [e0aa6c5](https://github.com/ratatui/ratatui/commit/e0aa6c5e1f254c7222afee7a8acf1652025b1949)
+  _(chart)_ Replace deprecated apply ([#812](https://github.com/ratatui/ratatui/issues/812))
 
   Fixes #793
 
-- [7f42ec9](https://github.com/ratatui-org/ratatui/commit/7f42ec97139da1897583d1d04610fa24e3c53fa2)
-  _(colors_rgb)_ Impl widget on mutable refs ([#865](https://github.com/ratatui-org/ratatui/issues/865))
+- [7f42ec9](https://github.com/ratatui/ratatui/commit/7f42ec97139da1897583d1d04610fa24e3c53fa2)
+  _(colors_rgb)_ Impl widget on mutable refs ([#865](https://github.com/ratatui/ratatui/issues/865))
 
   ```text
   This commit refactors the colors_rgb example to implement the Widget
@@ -2951,12 +2954,12 @@ Adds conversions for various Color and Modifier combinations
   installing the error hooks.
   ```
 
-- [813f707](https://github.com/ratatui-org/ratatui/commit/813f707892d77177b5f7bfe910ff0d312f17eb83)
-  _(example)_ Improve constraints and flex examples ([#817](https://github.com/ratatui-org/ratatui/issues/817))
+- [813f707](https://github.com/ratatui/ratatui/commit/813f707892d77177b5f7bfe910ff0d312f17eb83)
+  _(example)_ Improve constraints and flex examples ([#817](https://github.com/ratatui/ratatui/issues/817))
 
   ```text
   This PR is a follow up to
-  https://github.com/ratatui-org/ratatui/pull/811.
+  https://github.com/ratatui/ratatui/pull/811.
 
   It improves the UI of the layouts by
 
@@ -2970,27 +2973,27 @@ Adds conversions for various Color and Modifier combinations
   to name a few. Here are some example gifs of the outcome:
 
 
-  ![constraints](https://github.com/ratatui-org/ratatui/assets/381361/8eed34cf-e959-472f-961b-d439bfe3324e)
+  ![constraints](https://github.com/ratatui/ratatui/assets/381361/8eed34cf-e959-472f-961b-d439bfe3324e)
 
 
-  ![flex](https://github.com/ratatui-org/ratatui/assets/381361/3195a56c-9cb6-4525-bc1c-b969c0d6a812)
+  ![flex](https://github.com/ratatui/ratatui/assets/381361/3195a56c-9cb6-4525-bc1c-b969c0d6a812)
 
   ---------
   ```
 
-- [bb5444f](https://github.com/ratatui-org/ratatui/commit/bb5444f618f8baf7be9c9ba9f0cad829160d9392)
-  _(example)_ Add scroll to flex example ([#811](https://github.com/ratatui-org/ratatui/issues/811))
+- [bb5444f](https://github.com/ratatui/ratatui/commit/bb5444f618f8baf7be9c9ba9f0cad829160d9392)
+  _(example)_ Add scroll to flex example ([#811](https://github.com/ratatui/ratatui/issues/811))
 
   ```text
   This commit adds `scroll` to the flex example. It also adds more examples to showcase how constraints interact. It improves the UI to make it easier to understand and short terminal friendly.
 
-  <img width="380" alt="image" src="https://github.com/ratatui-org/ratatui/assets/1813121/30541efc-ecbe-4e28-b4ef-4d5f1dc63fec"/>
+  <img width="380" alt="image" src="https://github.com/ratatui/ratatui/assets/1813121/30541efc-ecbe-4e28-b4ef-4d5f1dc63fec"/>
 
   ---------
   ```
 
-- [6d15b25](https://github.com/ratatui-org/ratatui/commit/6d15b2570ff1a7c5dc2f6888efb313fb38f55f2a)
-  _(layout)_ Move the remaining types ([#743](https://github.com/ratatui-org/ratatui/issues/743))
+- [6d15b25](https://github.com/ratatui/ratatui/commit/6d15b2570ff1a7c5dc2f6888efb313fb38f55f2a)
+  _(layout)_ Move the remaining types ([#743](https://github.com/ratatui/ratatui/issues/743))
 
   ```text
   - alignment -> layout/alignment.rs
@@ -2999,20 +3002,20 @@ Adds conversions for various Color and Modifier combinations
   - size -> layout/size.rs
   ```
 
-- [659460e](https://github.com/ratatui-org/ratatui/commit/659460e19cc4109a36f416f79e583066730ca199)
-  _(layout)_ Move SegmentSize to layout/segment_size.rs ([#742](https://github.com/ratatui-org/ratatui/issues/742))
+- [659460e](https://github.com/ratatui/ratatui/commit/659460e19cc4109a36f416f79e583066730ca199)
+  _(layout)_ Move SegmentSize to layout/segment_size.rs ([#742](https://github.com/ratatui/ratatui/issues/742))
 
-- [ba036cd](https://github.com/ratatui-org/ratatui/commit/ba036cd57966ff9e7e2f871580095fda1df158ee)
-  _(layout)_ Move Layout to layout/layout.rs ([#741](https://github.com/ratatui-org/ratatui/issues/741))
+- [ba036cd](https://github.com/ratatui/ratatui/commit/ba036cd57966ff9e7e2f871580095fda1df158ee)
+  _(layout)_ Move Layout to layout/layout.rs ([#741](https://github.com/ratatui/ratatui/issues/741))
 
-- [8724aeb](https://github.com/ratatui-org/ratatui/commit/8724aeb9e74f4756a15681740ce7825cb094b42a)
-  _(layout)_ Move Margin to margin.rs ([#740](https://github.com/ratatui-org/ratatui/issues/740))
+- [8724aeb](https://github.com/ratatui/ratatui/commit/8724aeb9e74f4756a15681740ce7825cb094b42a)
+  _(layout)_ Move Margin to margin.rs ([#740](https://github.com/ratatui/ratatui/issues/740))
 
-- [9574198](https://github.com/ratatui-org/ratatui/commit/95741989588547cec12aaa27fbb5bc7cf2600426)
-  _(line)_ Reorder methods for natural reading order ([#713](https://github.com/ratatui-org/ratatui/issues/713))
+- [9574198](https://github.com/ratatui/ratatui/commit/95741989588547cec12aaa27fbb5bc7cf2600426)
+  _(line)_ Reorder methods for natural reading order ([#713](https://github.com/ratatui/ratatui/issues/713))
 
-- [6364533](https://github.com/ratatui-org/ratatui/commit/63645333d681c13502047e20d67612d9113d4375)
-  _(table)_ Split table into multiple files ([#718](https://github.com/ratatui-org/ratatui/issues/718))
+- [6364533](https://github.com/ratatui/ratatui/commit/63645333d681c13502047e20d67612d9113d4375)
+  _(table)_ Split table into multiple files ([#718](https://github.com/ratatui/ratatui/issues/718))
 
   ```text
   At close to 2000 lines of code, the table widget was getting a bit
@@ -3022,21 +3025,21 @@ Adds conversions for various Color and Modifier combinations
   Also refactors the table rendering code to be easier to maintain.
   ```
 
-- [5aba988](https://github.com/ratatui-org/ratatui/commit/5aba988fac6d0a2437192f5127c36bd272de5c78)
-  _(terminal)_ Extract types to files ([#760](https://github.com/ratatui-org/ratatui/issues/760))
+- [5aba988](https://github.com/ratatui/ratatui/commit/5aba988fac6d0a2437192f5127c36bd272de5c78)
+  _(terminal)_ Extract types to files ([#760](https://github.com/ratatui/ratatui/issues/760))
 
   ```text
   Fields on Frame that were private are now pub(crate).
   ```
 
-- [4d262d2](https://github.com/ratatui-org/ratatui/commit/4d262d21cbfba12da92a754fad533403df20701d)
-  _(widget)_ Move borders to widgets/borders.rs ([#832](https://github.com/ratatui-org/ratatui/issues/832))
+- [4d262d2](https://github.com/ratatui/ratatui/commit/4d262d21cbfba12da92a754fad533403df20701d)
+  _(widget)_ Move borders to widgets/borders.rs ([#832](https://github.com/ratatui/ratatui/issues/832))
 
-- [5254795](https://github.com/ratatui-org/ratatui/commit/525479546acebff7faec165f45028001a01525fe)
-  _(uncategorized)_ Make layout tests a bit easier to understand ([#890](https://github.com/ratatui-org/ratatui/issues/890))
+- [5254795](https://github.com/ratatui/ratatui/commit/525479546acebff7faec165f45028001a01525fe)
+  _(uncategorized)_ Make layout tests a bit easier to understand ([#890](https://github.com/ratatui/ratatui/issues/890))
 
-- [bd6b91c](https://github.com/ratatui-org/ratatui/commit/bd6b91c958a8ac2eb5b0e62432d65294403e5af3)
-  _(uncategorized)_ Make `patch_style` & `reset_style` chainable ([#754](https://github.com/ratatui-org/ratatui/issues/754)) [**breaking**]
+- [bd6b91c](https://github.com/ratatui/ratatui/commit/bd6b91c958a8ac2eb5b0e62432d65294403e5af3)
+  _(uncategorized)_ Make `patch_style` & `reset_style` chainable ([#754](https://github.com/ratatui/ratatui/issues/754)) [**breaking**]
 
   ```text
   Previously, `patch_style` and `reset_style` in `Text`, `Line` and `Span`
@@ -3045,29 +3048,29 @@ Adds conversions for various Color and Modifier combinations
    ownership of `Self` and return it.
   ```
 
-- [da6c299](https://github.com/ratatui-org/ratatui/commit/da6c299804850a1b7747ca1472c9a904bcd956ea)
-  _(uncategorized)_ Extract layout::Constraint to file ([#739](https://github.com/ratatui-org/ratatui/issues/739))
+- [da6c299](https://github.com/ratatui/ratatui/commit/da6c299804850a1b7747ca1472c9a904bcd956ea)
+  _(uncategorized)_ Extract layout::Constraint to file ([#739](https://github.com/ratatui/ratatui/issues/739))
 
 ### Documentation
 
-- [6ecaeed](https://github.com/ratatui-org/ratatui/commit/6ecaeed5497b15c4fa12c15048776b884e46b985)
-  _(text)_ Add overview of the relevant methods ([#857](https://github.com/ratatui-org/ratatui/issues/857))
+- [6ecaeed](https://github.com/ratatui/ratatui/commit/6ecaeed5497b15c4fa12c15048776b884e46b985)
+  _(text)_ Add overview of the relevant methods ([#857](https://github.com/ratatui/ratatui/issues/857))
 
   ```text
   Add an overview of the relevant methods under `Constructor Methods`, `Setter Methods`, and `Other Methods` subtitles.
   ```
 
-- [50374b2](https://github.com/ratatui-org/ratatui/commit/50374b2456808af8e14715c86bd773d7cfee2627)
-  _(backend)_ Fix broken book link ([#733](https://github.com/ratatui-org/ratatui/issues/733))
+- [50374b2](https://github.com/ratatui/ratatui/commit/50374b2456808af8e14715c86bd773d7cfee2627)
+  _(backend)_ Fix broken book link ([#733](https://github.com/ratatui/ratatui/issues/733))
 
-- [e1cc849](https://github.com/ratatui-org/ratatui/commit/e1cc8495544513bc0d9a26f8d2fe446d9b6b1091)
-  _(breaking)_ Fix typo ([#702](https://github.com/ratatui-org/ratatui/issues/702))
+- [e1cc849](https://github.com/ratatui/ratatui/commit/e1cc8495544513bc0d9a26f8d2fe446d9b6b1091)
+  _(breaking)_ Fix typo ([#702](https://github.com/ratatui/ratatui/issues/702))
 
-- [49df5d4](https://github.com/ratatui-org/ratatui/commit/49df5d46263a3e2fab2e8bdb9379c507922e3aa1)
-  _(example)_ Fix markdown syntax for note ([#730](https://github.com/ratatui-org/ratatui/issues/730))
+- [49df5d4](https://github.com/ratatui/ratatui/commit/49df5d46263a3e2fab2e8bdb9379c507922e3aa1)
+  _(example)_ Fix markdown syntax for note ([#730](https://github.com/ratatui/ratatui/issues/730))
 
-- [4b8e54e](https://github.com/ratatui-org/ratatui/commit/4b8e54e811bbd591f21ad8fe5b2467e4486aa6e9)
-  _(examples)_ Refactor Tabs example ([#861](https://github.com/ratatui-org/ratatui/issues/861))
+- [4b8e54e](https://github.com/ratatui/ratatui/commit/4b8e54e811bbd591f21ad8fe5b2467e4486aa6e9)
+  _(examples)_ Refactor Tabs example ([#861](https://github.com/ratatui/ratatui/issues/861))
 
   ```text
   - Used a few new techniques from the 0.26 features (ref widgets, text rendering,
@@ -3079,12 +3082,12 @@ Adds conversions for various Color and Modifier combinations
   ![Made with VHS](https://vhs.charm.sh/vhs-4WW21XTtepDhUSq4ZShO56.gif)
 
   ---------
-  Fixes https://github.com/ratatui-org/ratatui/issues/819
+  Fixes https://github.com/ratatui/ratatui/issues/819
   Co-authored-by: Josh McKinney <joshka@users.noreply.github.com>
   ```
 
-- [5b7ad2a](https://github.com/ratatui-org/ratatui/commit/5b7ad2ad82f38af25d5f8d40ea5bdc454fbbbc60)
-  _(examples)_ Update gauge example ([#863](https://github.com/ratatui-org/ratatui/issues/863))
+- [5b7ad2a](https://github.com/ratatui/ratatui/commit/5b7ad2ad82f38af25d5f8d40ea5bdc454fbbbc60)
+  _(examples)_ Update gauge example ([#863](https://github.com/ratatui/ratatui/issues/863))
 
   ```text
   - colored gauges
@@ -3100,15 +3103,15 @@ Adds conversions for various Color and Modifier combinations
   - change to get better output from the new code
 
   ---------
-  Fixes: https://github.com/ratatui-org/ratatui/issues/846
+  Fixes: https://github.com/ratatui/ratatui/issues/846
   Co-authored-by: Josh McKinney <joshka@users.noreply.github.com>
   ```
 
-- [f383625](https://github.com/ratatui-org/ratatui/commit/f383625f0e1cae320ae56af615f3b05c59700f93)
-  _(examples)_ Add note about example versions to all examples ([#871](https://github.com/ratatui-org/ratatui/issues/871))
+- [f383625](https://github.com/ratatui/ratatui/commit/f383625f0e1cae320ae56af615f3b05c59700f93)
+  _(examples)_ Add note about example versions to all examples ([#871](https://github.com/ratatui/ratatui/issues/871))
 
-- [847bacf](https://github.com/ratatui-org/ratatui/commit/847bacf32ee40e5af2207f8aefd2a0538beec693)
-  _(examples)_ Refactor demo2 ([#836](https://github.com/ratatui-org/ratatui/issues/836))
+- [847bacf](https://github.com/ratatui/ratatui/commit/847bacf32ee40e5af2207f8aefd2a0538beec693)
+  _(examples)_ Refactor demo2 ([#836](https://github.com/ratatui/ratatui/issues/836))
 
   ```text
   Simplified a bunch of the logic in the demo2 example
@@ -3127,8 +3130,8 @@ Adds conversions for various Color and Modifier combinations
   - Use strum for the tabs enum.
   ```
 
-- [804c841](https://github.com/ratatui-org/ratatui/commit/804c841fdc370049403282e0c6d140cbed85db7b)
-  _(examples)_ Update list example and list.tape ([#864](https://github.com/ratatui-org/ratatui/issues/864))
+- [804c841](https://github.com/ratatui/ratatui/commit/804c841fdc370049403282e0c6d140cbed85db7b)
+  _(examples)_ Update list example and list.tape ([#864](https://github.com/ratatui/ratatui/issues/864))
 
   ```text
   This PR adds:
@@ -3138,8 +3141,8 @@ Adds conversions for various Color and Modifier combinations
   - status of a TODO can be changed, further info can be seen under the list.
   ```
 
-- [eb1484b](https://github.com/ratatui-org/ratatui/commit/eb1484b6db5b21df6bda017fbe1a8f4888151ed3)
-  _(examples)_ Update tabs example and tabs.tape ([#855](https://github.com/ratatui-org/ratatui/issues/855))
+- [eb1484b](https://github.com/ratatui/ratatui/commit/eb1484b6db5b21df6bda017fbe1a8f4888151ed3)
+  _(examples)_ Update tabs example and tabs.tape ([#855](https://github.com/ratatui/ratatui/issues/855))
 
   ```text
   This PR adds:
@@ -3156,11 +3159,11 @@ Adds conversions for various Color and Modifier combinations
 
   Here is the new output:
 
-  ![tabs](https://github.com/ratatui-org/ratatui/assets/30180366/0a9371a5-e90d-42ba-aba5-70cbf66afd1f)
+  ![tabs](https://github.com/ratatui/ratatui/assets/30180366/0a9371a5-e90d-42ba-aba5-70cbf66afd1f)
   ```
 
-- [330a899](https://github.com/ratatui-org/ratatui/commit/330a899eacb1f7d2d6dc19856f2bbb782e2c53b0)
-  _(examples)_ Update table example and table.tape ([#840](https://github.com/ratatui-org/ratatui/issues/840))
+- [330a899](https://github.com/ratatui/ratatui/commit/330a899eacb1f7d2d6dc19856f2bbb782e2c53b0)
+  _(examples)_ Update table example and table.tape ([#840](https://github.com/ratatui/ratatui/issues/840))
 
   ```text
   In table.rs
@@ -3176,32 +3179,32 @@ Adds conversions for various Color and Modifier combinations
   - pushed keys changed to show the current example better
   ```
 
-  Fixes:https://github.com/ratatui-org/ratatui/issues/800
+  Fixes:<https://github.com/ratatui/ratatui/issues/800>
 
-- [41de884](https://github.com/ratatui-org/ratatui/commit/41de8846fda6b50dbd8288eb108037dd5b0a2acd)
-  _(examples)_ Document incompatible examples better ([#844](https://github.com/ratatui-org/ratatui/issues/844))
+- [41de884](https://github.com/ratatui/ratatui/commit/41de8846fda6b50dbd8288eb108037dd5b0a2acd)
+  _(examples)_ Document incompatible examples better ([#844](https://github.com/ratatui/ratatui/issues/844))
 
   ```text
   Examples often take advantage of unreleased API changes, which makes
   them not copy-paste friendly.
   ```
 
-- [3464894](https://github.com/ratatui-org/ratatui/commit/34648941d447245cf7b1b6172fe84b1867b1bd5a)
-  _(examples)_ Add warning about examples matching the main branch ([#778](https://github.com/ratatui-org/ratatui/issues/778))
+- [3464894](https://github.com/ratatui/ratatui/commit/34648941d447245cf7b1b6172fe84b1867b1bd5a)
+  _(examples)_ Add warning about examples matching the main branch ([#778](https://github.com/ratatui/ratatui/issues/778))
 
-- [fb93db0](https://github.com/ratatui-org/ratatui/commit/fb93db073029fc9bc6a365511706c1f60a64af1b)
-  _(examples)_ Simplify docs using new layout methods ([#731](https://github.com/ratatui-org/ratatui/issues/731))
+- [fb93db0](https://github.com/ratatui/ratatui/commit/fb93db073029fc9bc6a365511706c1f60a64af1b)
+  _(examples)_ Simplify docs using new layout methods ([#731](https://github.com/ratatui/ratatui/issues/731))
 
   ```text
   Use the new `Layout::horizontal` and `vertical` constructors and
   `Rect::split_array` through all the examples.
   ```
 
-- [d6b8513](https://github.com/ratatui-org/ratatui/commit/d6b851301e0edcc96274262c2351391c4d414481)
-  _(examples)_ Refactor chart example to showcase scatter ([#703](https://github.com/ratatui-org/ratatui/issues/703))
+- [d6b8513](https://github.com/ratatui/ratatui/commit/d6b851301e0edcc96274262c2351391c4d414481)
+  _(examples)_ Refactor chart example to showcase scatter ([#703](https://github.com/ratatui/ratatui/issues/703))
 
-- [fe84141](https://github.com/ratatui-org/ratatui/commit/fe84141119d87f478478fa1570344aaa7fa5f417)
-  _(layout)_ Document the difference in the split methods ([#750](https://github.com/ratatui-org/ratatui/issues/750))
+- [fe84141](https://github.com/ratatui/ratatui/commit/fe84141119d87f478478fa1570344aaa7fa5f417)
+  _(layout)_ Document the difference in the split methods ([#750](https://github.com/ratatui/ratatui/issues/750))
 
   ```text
   * docs(layout): document the difference in the split methods
@@ -3209,33 +3212,33 @@ Adds conversions for various Color and Modifier combinations
   * fix: doc suggestion
   ```
 
-- [48b0380](https://github.com/ratatui-org/ratatui/commit/48b0380cb3c50b62fe347e27fed46b6c702d0e13)
-  _(scrollbar)_ Complete scrollbar documentation ([#823](https://github.com/ratatui-org/ratatui/issues/823))
+- [48b0380](https://github.com/ratatui/ratatui/commit/48b0380cb3c50b62fe347e27fed46b6c702d0e13)
+  _(scrollbar)_ Complete scrollbar documentation ([#823](https://github.com/ratatui/ratatui/issues/823))
 
-- [e67d3c6](https://github.com/ratatui-org/ratatui/commit/e67d3c64e0192ac5a31ecb34cfb8a55c53ba7bdc)
-  _(table)_ Fix typo ([#707](https://github.com/ratatui-org/ratatui/issues/707))
+- [e67d3c6](https://github.com/ratatui/ratatui/commit/e67d3c64e0192ac5a31ecb34cfb8a55c53ba7bdc)
+  _(table)_ Fix typo ([#707](https://github.com/ratatui/ratatui/issues/707))
 
-- [065b6b0](https://github.com/ratatui-org/ratatui/commit/065b6b05b7685d30cfccc9343ff5232fe67d5a7a)
-  _(terminal)_ Document buffer diffing better ([#852](https://github.com/ratatui-org/ratatui/issues/852))
+- [065b6b0](https://github.com/ratatui/ratatui/commit/065b6b05b7685d30cfccc9343ff5232fe67d5a7a)
+  _(terminal)_ Document buffer diffing better ([#852](https://github.com/ratatui/ratatui/issues/852))
 
-- [86168aa](https://github.com/ratatui-org/ratatui/commit/86168aa7117b4f4218bd658c861a0bd2bc03e7b5)
-  _(uncategorized)_ Fix docstring for `Max` constraints ([#898](https://github.com/ratatui-org/ratatui/issues/898))
+- [86168aa](https://github.com/ratatui/ratatui/commit/86168aa7117b4f4218bd658c861a0bd2bc03e7b5)
+  _(uncategorized)_ Fix docstring for `Max` constraints ([#898](https://github.com/ratatui/ratatui/issues/898))
 
-- [11e4f6a](https://github.com/ratatui-org/ratatui/commit/11e4f6a0ba71b7adad44af5866a2b0789175aafa)
-  _(uncategorized)_ Adds better documentation for constraints and flex 📚 ([#818](https://github.com/ratatui-org/ratatui/issues/818))
+- [11e4f6a](https://github.com/ratatui/ratatui/commit/11e4f6a0ba71b7adad44af5866a2b0789175aafa)
+  _(uncategorized)_ Adds better documentation for constraints and flex 📚 ([#818](https://github.com/ratatui/ratatui/issues/818))
 
-- [1746a61](https://github.com/ratatui-org/ratatui/commit/1746a616595af019d52b8cd69bf08d5c49c0a968)
-  _(uncategorized)_ Update links to templates repository 📚 ([#810](https://github.com/ratatui-org/ratatui/issues/810))
+- [1746a61](https://github.com/ratatui/ratatui/commit/1746a616595af019d52b8cd69bf08d5c49c0a968)
+  _(uncategorized)_ Update links to templates repository 📚 ([#810](https://github.com/ratatui/ratatui/issues/810))
 
   ```text
   This PR updates links to the `templates` repository.
   ```
 
-- [43b2b57](https://github.com/ratatui-org/ratatui/commit/43b2b57191ed9226c93cbef40b8e5b899ef81fdc)
-  _(uncategorized)_ Fix typo in Table widget description ([#797](https://github.com/ratatui-org/ratatui/issues/797))
+- [43b2b57](https://github.com/ratatui/ratatui/commit/43b2b57191ed9226c93cbef40b8e5b899ef81fdc)
+  _(uncategorized)_ Fix typo in Table widget description ([#797](https://github.com/ratatui/ratatui/issues/797))
 
-- [2b4aa46](https://github.com/ratatui-org/ratatui/commit/2b4aa46a6a225c6629778257a4548b7fa55f3ef9)
-  _(uncategorized)_ GitHub admonition syntax for examples README.md ([#791](https://github.com/ratatui-org/ratatui/issues/791))
+- [2b4aa46](https://github.com/ratatui/ratatui/commit/2b4aa46a6a225c6629778257a4548b7fa55f3ef9)
+  _(uncategorized)_ GitHub admonition syntax for examples README.md ([#791](https://github.com/ratatui/ratatui/issues/791))
 
   ```text
   * docs: GitHub admonition syntax for examples README.md
@@ -3243,8 +3246,8 @@ Adds conversions for various Color and Modifier combinations
   * docs: Add link to stable release
   ```
 
-- [388aa46](https://github.com/ratatui-org/ratatui/commit/388aa467f17dd219ec8e99a177547eb03c6fa01d)
-  _(uncategorized)_ Update crate, lib and readme links ([#771](https://github.com/ratatui-org/ratatui/issues/771))
+- [388aa46](https://github.com/ratatui/ratatui/commit/388aa467f17dd219ec8e99a177547eb03c6fa01d)
+  _(uncategorized)_ Update crate, lib and readme links ([#771](https://github.com/ratatui/ratatui/issues/771))
 
   ```text
   Link to the contributing, changelog, and breaking changes docs at the
@@ -3260,8 +3263,8 @@ Adds conversions for various Color and Modifier combinations
 
 ### Performance
 
-- [1d3fbc1](https://github.com/ratatui-org/ratatui/commit/1d3fbc1b15c619f571b9981b841986a7947a4195)
-  _(buffer)_ Apply SSO technique to text buffer in `buffer::Cell` ([#601](https://github.com/ratatui-org/ratatui/issues/601)) [**breaking**]
+- [1d3fbc1](https://github.com/ratatui/ratatui/commit/1d3fbc1b15c619f571b9981b841986a7947a4195)
+  _(buffer)_ Apply SSO technique to text buffer in `buffer::Cell` ([#601](https://github.com/ratatui/ratatui/issues/601)) [**breaking**]
 
   ```text
   Use CompactString instead of String to store the Cell::symbol field.
@@ -3270,20 +3273,20 @@ Adds conversions for various Color and Modifier combinations
 
 ### Testing
 
-- [663bbde](https://github.com/ratatui-org/ratatui/commit/663bbde9c39afc1ad15cc44228811ae1b62f4343)
-  _(layout)_ Convert layout tests to use rstest ([#879](https://github.com/ratatui-org/ratatui/issues/879))
+- [663bbde](https://github.com/ratatui/ratatui/commit/663bbde9c39afc1ad15cc44228811ae1b62f4343)
+  _(layout)_ Convert layout tests to use rstest ([#879](https://github.com/ratatui/ratatui/issues/879))
 
   ```text
   This PR makes all the letters test use `rstest`
   ```
 
-- [f780be3](https://github.com/ratatui-org/ratatui/commit/f780be31f37f2305f514f4dba6f82dcae0ad3f9b)
-  _(layout)_ Parameterized tests 🚨 ([#858](https://github.com/ratatui-org/ratatui/issues/858))
+- [f780be3](https://github.com/ratatui/ratatui/commit/f780be31f37f2305f514f4dba6f82dcae0ad3f9b)
+  _(layout)_ Parameterized tests 🚨 ([#858](https://github.com/ratatui/ratatui/issues/858))
 
 ### Miscellaneous Tasks
 
-- [ba20372](https://github.com/ratatui-org/ratatui/commit/ba20372c23c65122db055e202cfe68fcddafd342)
-  _(contributing)_ Remove part about squashing commits ([#874](https://github.com/ratatui-org/ratatui/issues/874))
+- [ba20372](https://github.com/ratatui/ratatui/commit/ba20372c23c65122db055e202cfe68fcddafd342)
+  _(contributing)_ Remove part about squashing commits ([#874](https://github.com/ratatui/ratatui/issues/874))
 
   ```text
   Removes the part about squashing commits from the CONTRIBUTING file.
@@ -3293,11 +3296,11 @@ Adds conversions for various Color and Modifier combinations
   dense.
   ```
 
-- [d49bbb2](https://github.com/ratatui-org/ratatui/commit/d49bbb259091a7b061e0dec71ee06884b27e308a)
-  _(ci)_ Update the job description for installing cargo-nextest ([#839](https://github.com/ratatui-org/ratatui/issues/839))
+- [d49bbb2](https://github.com/ratatui/ratatui/commit/d49bbb259091a7b061e0dec71ee06884b27e308a)
+  _(ci)_ Update the job description for installing cargo-nextest ([#839](https://github.com/ratatui/ratatui/issues/839))
 
-- [8d77b73](https://github.com/ratatui-org/ratatui/commit/8d77b734bb5d267114afffd4bb594695d8544dce)
-  _(ci)_ Use cargo-nextest for running tests ([#717](https://github.com/ratatui-org/ratatui/issues/717))
+- [8d77b73](https://github.com/ratatui/ratatui/commit/8d77b734bb5d267114afffd4bb594695d8544dce)
+  _(ci)_ Use cargo-nextest for running tests ([#717](https://github.com/ratatui/ratatui/issues/717))
 
   ```text
   * chore(ci): use cargo-nextest for running tests
@@ -3305,8 +3308,8 @@ Adds conversions for various Color and Modifier combinations
   * refactor(make): run library tests before doc tests
   ```
 
-- [b7a4793](https://github.com/ratatui-org/ratatui/commit/b7a479392ee71574e32b5aa797ef612cdd99498f)
-  _(ci)_ Bump alpha release for breaking changes ([#495](https://github.com/ratatui-org/ratatui/issues/495))
+- [b7a4793](https://github.com/ratatui/ratatui/commit/b7a479392ee71574e32b5aa797ef612cdd99498f)
+  _(ci)_ Bump alpha release for breaking changes ([#495](https://github.com/ratatui/ratatui/issues/495))
 
   ```text
   Automatically detect breaking changes based on commit messages
@@ -3316,21 +3319,21 @@ Adds conversions for various Color and Modifier combinations
   since v0.23.0 has a breaking change.
   ```
 
-- [fab943b](https://github.com/ratatui-org/ratatui/commit/fab943b61afb1c5f79d03b1f3764067ac26945d0)
-  _(contributing)_ Add deprecation notice guideline ([#761](https://github.com/ratatui-org/ratatui/issues/761))
+- [fab943b](https://github.com/ratatui/ratatui/commit/fab943b61afb1c5f79d03b1f3764067ac26945d0)
+  _(contributing)_ Add deprecation notice guideline ([#761](https://github.com/ratatui/ratatui/issues/761))
 
-- [fc0879f](https://github.com/ratatui-org/ratatui/commit/fc0879f98dedf36699ebf77b5b1298f6f3fb3015)
-  _(layout)_ Comment tests that may fail on occasion ([#814](https://github.com/ratatui-org/ratatui/issues/814))
+- [fc0879f](https://github.com/ratatui/ratatui/commit/fc0879f98dedf36699ebf77b5b1298f6f3fb3015)
+  _(layout)_ Comment tests that may fail on occasion ([#814](https://github.com/ratatui/ratatui/issues/814))
 
   ```text
   These fails seem to fail on occasion, locally and on CI.
 
   This issue will be revisited in the PR on constraint weights:
-  https://github.com/ratatui-org/ratatui/pull/788
+  https://github.com/ratatui/ratatui/pull/788
   ```
 
-- [f8367fd](https://github.com/ratatui-org/ratatui/commit/f8367fdfdd1da0ae98705a0b23fc88d156425f4c)
-  _(uncategorized)_ Allow Buffer::with_lines to accept IntoIterator ([#901](https://github.com/ratatui-org/ratatui/issues/901))
+- [f8367fd](https://github.com/ratatui/ratatui/commit/f8367fdfdd1da0ae98705a0b23fc88d156425f4c)
+  _(uncategorized)_ Allow Buffer::with_lines to accept IntoIterator ([#901](https://github.com/ratatui/ratatui/issues/901))
 
   ```text
   This can make it easier to use `Buffer::with_lines` with iterators that
@@ -3339,22 +3342,22 @@ Adds conversions for various Color and Modifier combinations
   `collect` on it first.
   ```
 
-- [78f1c14](https://github.com/ratatui-org/ratatui/commit/78f1c1446b00824970449d9aff2d74ef875d2449)
-  _(uncategorized)_ Small fixes to constraint-explorer ([#894](https://github.com/ratatui-org/ratatui/issues/894))
+- [78f1c14](https://github.com/ratatui/ratatui/commit/78f1c1446b00824970449d9aff2d74ef875d2449)
+  _(uncategorized)_ Small fixes to constraint-explorer ([#894](https://github.com/ratatui/ratatui/issues/894))
 
-- [984afd5](https://github.com/ratatui-org/ratatui/commit/984afd580bff5be6f30622733e5a28db952c72fd)
-  _(uncategorized)_ Cache dependencies in the CI workflow to speed up builds ([#883](https://github.com/ratatui-org/ratatui/issues/883))
+- [984afd5](https://github.com/ratatui/ratatui/commit/984afd580bff5be6f30622733e5a28db952c72fd)
+  _(uncategorized)_ Cache dependencies in the CI workflow to speed up builds ([#883](https://github.com/ratatui/ratatui/issues/883))
 
-- [6e76729](https://github.com/ratatui-org/ratatui/commit/6e76729ce899e2f32af8335aff530622d9a8dbe4)
-  _(uncategorized)_ Move example vhs tapes to a folder ([#867](https://github.com/ratatui-org/ratatui/issues/867))
+- [6e76729](https://github.com/ratatui/ratatui/commit/6e76729ce899e2f32af8335aff530622d9a8dbe4)
+  _(uncategorized)_ Move example vhs tapes to a folder ([#867](https://github.com/ratatui/ratatui/issues/867))
 
-- [151db6a](https://github.com/ratatui-org/ratatui/commit/151db6ac7d93713b6212ce627e3b725879573aa9)
-  _(uncategorized)_ Add commit footers to git-cliff config ([#805](https://github.com/ratatui-org/ratatui/issues/805))
+- [151db6a](https://github.com/ratatui/ratatui/commit/151db6ac7d93713b6212ce627e3b725879573aa9)
+  _(uncategorized)_ Add commit footers to git-cliff config ([#805](https://github.com/ratatui/ratatui/issues/805))
 
-  Fixes:https://github.com/orhun/git-cliff/issues/297
+  Fixes:<https://github.com/orhun/git-cliff/issues/297>
 
-- [c24216c](https://github.com/ratatui-org/ratatui/commit/c24216cf307bba7d19ed579a10ef541e28dfd4bc)
-  _(uncategorized)_ Add comment on PRs with unsigned commits ([#768](https://github.com/ratatui-org/ratatui/issues/768))
+- [c24216c](https://github.com/ratatui/ratatui/commit/c24216cf307bba7d19ed579a10ef541e28dfd4bc)
+  _(uncategorized)_ Add comment on PRs with unsigned commits ([#768](https://github.com/ratatui/ratatui/issues/768))
 
 ### Contributors
 
@@ -3362,28 +3365,28 @@ Thank you so much to everyone that contributed to this release!
 
 Here is the list of contributors who have contributed to `ratatui` for the first time!
 
-* @yanganto
-* @akiomik
-* @Lunderberg
-* @BogdanPaul15
-* @stchris
-* @MultisampledNight
-* @lxl66566
-* @bblsh
-* @Eeelco
+- @yanganto
+- @akiomik
+- @Lunderberg
+- @BogdanPaul15
+- @stchris
+- @MultisampledNight
+- @lxl66566
+- @bblsh
+- @Eeelco
 
 ### Sponsors
 
 Shout out to our new sponsors!
 
-* @pythops
-* @DanNixon
-* @ymgyt
-* @plabayo
-* @atuinsh
-* @JeftavanderHorst!
+- @pythops
+- @DanNixon
+- @ymgyt
+- @plabayo
+- @atuinsh
+- @JeftavanderHorst!
 
-## [0.25.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.25.0) - 2023-12-18
+## [0.25.0](https://github.com/ratatui/ratatui/releases/tag/v0.25.0) - 2023-12-18
 
 We are thrilled to announce the new version of `ratatui` - a Rust library that's all about cooking up TUIs 🐭
 
@@ -3392,14 +3395,14 @@ Also, we renewed our website and updated our documentation/tutorials to get star
 
 ✨ **Release highlights**: <https://ratatui.rs/highlights/v025/>
 
-⚠️ List of breaking changes can be found [here](https://github.com/ratatui-org/ratatui/blob/main/BREAKING-CHANGES.md).
+⚠️ List of breaking changes can be found [here](https://github.com/ratatui/ratatui/blob/main/BREAKING-CHANGES.md).
 
-💖 We also enabled GitHub Sponsors for our organization, consider sponsoring us if you like `ratatui`: <https://github.com/sponsors/ratatui-org>
+💖 We also enabled GitHub Sponsors for our organization, consider sponsoring us if you like `ratatui`: <https://github.com/sponsors/ratatui>
 
 ### Features
 
-- [aef4956](https://github.com/ratatui-org/ratatui/commit/aef495604c52e563fbacfb1a6e730cd441a99129)
-  *(list)* `List::new` now accepts `IntoIterator<Item = Into<ListItem>>` ([#672](https://github.com/ratatui-org/ratatui/issues/672)) [**breaking**]
+- [aef4956](https://github.com/ratatui/ratatui/commit/aef495604c52e563fbacfb1a6e730cd441a99129)
+  _(list)_ `List::new` now accepts `IntoIterator<Item = Into<ListItem>>` ([#672](https://github.com/ratatui/ratatui/issues/672)) [**breaking**]
 
   ````text
   This allows to build list like
@@ -3409,15 +3412,15 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   ```
   ````
 
-- [8bfd666](https://github.com/ratatui-org/ratatui/commit/8bfd6661e251b6943f74bda626e4708b2e9f4b51)
-  *(paragraph)* Add `line_count` and `line_width` unstable helper methods
+- [8bfd666](https://github.com/ratatui/ratatui/commit/8bfd6661e251b6943f74bda626e4708b2e9f4b51)
+  _(paragraph)_ Add `line_count` and `line_width` unstable helper methods
 
   ````text
   This is an unstable feature that may be removed in the future
   ````
 
-- [1229b96](https://github.com/ratatui-org/ratatui/commit/1229b96e428df880a951ef57f53ca73e74ef1ea2)
-  *(rect)* Add `offset` method ([#533](https://github.com/ratatui-org/ratatui/issues/533))
+- [1229b96](https://github.com/ratatui/ratatui/commit/1229b96e428df880a951ef57f53ca73e74ef1ea2)
+  _(rect)_ Add `offset` method ([#533](https://github.com/ratatui/ratatui/issues/533))
 
   ````text
   The offset method creates a new Rect that is moved by the amount
@@ -3429,8 +3432,8 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   ```
   ````
 
-- [edacaf7](https://github.com/ratatui-org/ratatui/commit/edacaf7ff4e4b14702f6361af5a6da713b7dc564)
-  *(buffer)* Deprecate `Cell::symbol` field ([#624](https://github.com/ratatui-org/ratatui/issues/624))
+- [edacaf7](https://github.com/ratatui/ratatui/commit/edacaf7ff4e4b14702f6361af5a6da713b7dc564)
+  _(buffer)_ Deprecate `Cell::symbol` field ([#624](https://github.com/ratatui/ratatui/issues/624))
 
   ````text
   The Cell::symbol field is now accessible via a getter method (`symbol()`). This will
@@ -3438,8 +3441,8 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   `compact_str`.
   ````
 
-- [6b2efd0](https://github.com/ratatui-org/ratatui/commit/6b2efd0f6c3bf56dc06bbf042db40c0c66de577e)
-  *(layout)* Accept IntoIterator for constraints ([#663](https://github.com/ratatui-org/ratatui/issues/663))
+- [6b2efd0](https://github.com/ratatui/ratatui/commit/6b2efd0f6c3bf56dc06bbf042db40c0c66de577e)
+  _(layout)_ Accept IntoIterator for constraints ([#663](https://github.com/ratatui/ratatui/issues/663))
 
   ````text
   Layout and Table now accept IntoIterator for constraints with an Item
@@ -3449,8 +3452,8 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   them).
   ````
 
-- [753e246](https://github.com/ratatui-org/ratatui/commit/753e246531e1e9e2ea558911f8d03e738901d85f)
-  *(layout)* Allow configuring layout fill ([#633](https://github.com/ratatui-org/ratatui/issues/633))
+- [753e246](https://github.com/ratatui/ratatui/commit/753e246531e1e9e2ea558911f8d03e738901d85f)
+  _(layout)_ Allow configuring layout fill ([#633](https://github.com/ratatui/ratatui/issues/633))
 
   ````text
   The layout split will generally fill the remaining area when `split()`
@@ -3470,11 +3473,11 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   behavior. See the docs for `Layout::segment_size()` and
   `layout::SegmentSize` for more information.
 
-  Fixes https://github.com/ratatui-org/ratatui/issues/536
+  Fixes https://github.com/ratatui/ratatui/issues/536
   ````
 
-- [1e2f0be](https://github.com/ratatui-org/ratatui/commit/1e2f0be75ac3fb3d6500c1de291bd49972b808e4)
-  *(layout)* Add parameters to Layout::new() ([#557](https://github.com/ratatui-org/ratatui/issues/557)) [**breaking**]
+- [1e2f0be](https://github.com/ratatui/ratatui/commit/1e2f0be75ac3fb3d6500c1de291bd49972b808e4)
+  _(layout)_ Add parameters to Layout::new() ([#557](https://github.com/ratatui/ratatui/issues/557)) [**breaking**]
 
   ````text
   Adds a convenience function to create a layout with a direction and a
@@ -3490,21 +3493,21 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   ```
   ````
 
-- [c862aa5](https://github.com/ratatui-org/ratatui/commit/c862aa5e9ef4dbf494b5151214ac87f5c71e76d4)
-  *(list)* Support line alignment ([#599](https://github.com/ratatui-org/ratatui/issues/599))
+- [c862aa5](https://github.com/ratatui/ratatui/commit/c862aa5e9ef4dbf494b5151214ac87f5c71e76d4)
+  _(list)_ Support line alignment ([#599](https://github.com/ratatui/ratatui/issues/599))
 
   ````text
   The `List` widget now respects the alignment of `Line`s and renders them as expected.
   ````
 
-- [4424637](https://github.com/ratatui-org/ratatui/commit/4424637af252dc2f227fe4956eac71135e60fb02)
-  *(span)* Add setters for content and style ([#647](https://github.com/ratatui-org/ratatui/issues/647))
+- [4424637](https://github.com/ratatui/ratatui/commit/4424637af252dc2f227fe4956eac71135e60fb02)
+  _(span)_ Add setters for content and style ([#647](https://github.com/ratatui/ratatui/issues/647))
 
-- [ebf1f42](https://github.com/ratatui-org/ratatui/commit/ebf1f4294211d478b8633a06576ec269a50db588)
-  *(style)* Implement `From` trait for crossterm to `Style` related structs ([#686](https://github.com/ratatui-org/ratatui/issues/686))
+- [ebf1f42](https://github.com/ratatui/ratatui/commit/ebf1f4294211d478b8633a06576ec269a50db588)
+  _(style)_ Implement `From` trait for crossterm to `Style` related structs ([#686](https://github.com/ratatui/ratatui/issues/686))
 
-- [e49385b](https://github.com/ratatui-org/ratatui/commit/e49385b78c8e01fe6381b19d15137346bc6eb8a1)
-  *(table)* Add a Table::segment_size method ([#660](https://github.com/ratatui-org/ratatui/issues/660))
+- [e49385b](https://github.com/ratatui/ratatui/commit/e49385b78c8e01fe6381b19d15137346bc6eb8a1)
+  _(table)_ Add a Table::segment_size method ([#660](https://github.com/ratatui/ratatui/issues/660))
 
   ````text
   It controls how to distribute extra space to an underconstrained table.
@@ -3514,11 +3517,11 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   all columns.
   ````
 
-- [b8f71c0](https://github.com/ratatui-org/ratatui/commit/b8f71c0d6eda3da272d29c7a9b3c47181049f76a)
-  *(widgets/chart)* Add option to set the position of legend ([#378](https://github.com/ratatui-org/ratatui/issues/378))
+- [b8f71c0](https://github.com/ratatui/ratatui/commit/b8f71c0d6eda3da272d29c7a9b3c47181049f76a)
+  _(widgets/chart)_ Add option to set the position of legend ([#378](https://github.com/ratatui/ratatui/issues/378))
 
-- [5bf4f52](https://github.com/ratatui-org/ratatui/commit/5bf4f52119ab3e0e3a266af196058179dc1d18c3)
-  *(uncategorized)* Implement `From` trait for termion to `Style` related structs ([#692](https://github.com/ratatui-org/ratatui/issues/692))
+- [5bf4f52](https://github.com/ratatui/ratatui/commit/5bf4f52119ab3e0e3a266af196058179dc1d18c3)
+  _(uncategorized)_ Implement `From` trait for termion to `Style` related structs ([#692](https://github.com/ratatui/ratatui/issues/692))
 
   ````text
   * feat(termion): implement from termion color
@@ -3528,8 +3531,8 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   * feat(termion): implement from termion `Bg` and `Fg`
   ````
 
-- [d19b266](https://github.com/ratatui-org/ratatui/commit/d19b266e0eabdb0fb00660439a1818239c94024b)
-  *(uncategorized)* Add Constraint helpers (e.g. from_lengths) ([#641](https://github.com/ratatui-org/ratatui/issues/641))
+- [d19b266](https://github.com/ratatui/ratatui/commit/d19b266e0eabdb0fb00660439a1818239c94024b)
+  _(uncategorized)_ Add Constraint helpers (e.g. from_lengths) ([#641](https://github.com/ratatui/ratatui/issues/641))
 
   ````text
   Adds helper methods that convert from iterators of u16 values to the
@@ -3553,11 +3556,11 @@ Also, we renewed our website and updated our documentation/tutorials to get star
 
 ### Bug Fixes
 
-- [f69d57c](https://github.com/ratatui-org/ratatui/commit/f69d57c3b59e27b517a5ca1a002af808fee47970)
-  *(rect)* Fix underflow in the `Rect::intersection` method ([#678](https://github.com/ratatui-org/ratatui/issues/678))
+- [f69d57c](https://github.com/ratatui/ratatui/commit/f69d57c3b59e27b517a5ca1a002af808fee47970)
+  _(rect)_ Fix underflow in the `Rect::intersection` method ([#678](https://github.com/ratatui/ratatui/issues/678))
 
-- [56fc410](https://github.com/ratatui-org/ratatui/commit/56fc4101056e0f631f563f8f2c07646063e650d3)
-  *(block)* Make `inner` aware of title positions ([#657](https://github.com/ratatui-org/ratatui/issues/657))
+- [56fc410](https://github.com/ratatui/ratatui/commit/56fc4101056e0f631f563f8f2c07646063e650d3)
+  _(block)_ Make `inner` aware of title positions ([#657](https://github.com/ratatui/ratatui/issues/657))
 
   ````text
   Previously, when computing the inner rendering area of a block, all
@@ -3565,25 +3568,25 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   height of the inner area to be miscalculated.
   ````
 
-- [ec7b387](https://github.com/ratatui-org/ratatui/commit/ec7b3872b46c6828c88ce7f72308dc67731fca25)
-  *(doc)* Do not access deprecated `Cell::symbol` field in doc example ([#626](https://github.com/ratatui-org/ratatui/issues/626))
+- [ec7b387](https://github.com/ratatui/ratatui/commit/ec7b3872b46c6828c88ce7f72308dc67731fca25)
+  _(doc)_ Do not access deprecated `Cell::symbol` field in doc example ([#626](https://github.com/ratatui/ratatui/issues/626))
 
-- [37c70db](https://github.com/ratatui-org/ratatui/commit/37c70dbb8e19c0fb35ced16b29751933514a441e)
-  *(table)* Add widths parameter to new() ([#664](https://github.com/ratatui-org/ratatui/issues/664)) [**breaking**]
+- [37c70db](https://github.com/ratatui/ratatui/commit/37c70dbb8e19c0fb35ced16b29751933514a441e)
+  _(table)_ Add widths parameter to new() ([#664](https://github.com/ratatui/ratatui/issues/664)) [**breaking**]
 
   ````text
   This prevents creating a table that doesn't actually render anything.
   ````
 
-- [1f88da7](https://github.com/ratatui-org/ratatui/commit/1f88da75383f6de76e64e9258fbf38d02ec77af9)
-  *(table)* Fix new clippy lint which triggers on table widths tests ([#630](https://github.com/ratatui-org/ratatui/issues/630))
+- [1f88da7](https://github.com/ratatui/ratatui/commit/1f88da75383f6de76e64e9258fbf38d02ec77af9)
+  _(table)_ Fix new clippy lint which triggers on table widths tests ([#630](https://github.com/ratatui/ratatui/issues/630))
 
   ````text
   * fix(table): new clippy lint in 1.74.0 triggers on table widths tests
   ````
 
-- [36d8c53](https://github.com/ratatui-org/ratatui/commit/36d8c5364590a559913c40ee5f021b5d8e3466e6)
-  *(table)* Widths() now accepts AsRef<[Constraint]> ([#628](https://github.com/ratatui-org/ratatui/issues/628))
+- [36d8c53](https://github.com/ratatui/ratatui/commit/36d8c5364590a559913c40ee5f021b5d8e3466e6)
+  _(table)_ Widths() now accepts AsRef<[Constraint]> ([#628](https://github.com/ratatui/ratatui/issues/628))
 
   ````text
   This allows passing an array, slice or Vec of constraints, which is more
@@ -3602,15 +3605,15 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   ```
   ````
 
-- [34d099c](https://github.com/ratatui-org/ratatui/commit/34d099c99af27eacfdde71f9ced255c29e1e001a)
-  *(tabs)* Fixup tests broken by semantic merge conflict ([#665](https://github.com/ratatui-org/ratatui/issues/665))
+- [34d099c](https://github.com/ratatui/ratatui/commit/34d099c99af27eacfdde71f9ced255c29e1e001a)
+  _(tabs)_ Fixup tests broken by semantic merge conflict ([#665](https://github.com/ratatui/ratatui/issues/665))
 
   ````text
   Two changes without any line overlap caused the tabs tests to break
   ````
 
-- [e4579f0](https://github.com/ratatui-org/ratatui/commit/e4579f0db2b70b59590cae02e994e3736b19a1b3)
-  *(tabs)* Set the default highlight_style ([#635](https://github.com/ratatui-org/ratatui/issues/635)) [**breaking**]
+- [e4579f0](https://github.com/ratatui/ratatui/commit/e4579f0db2b70b59590cae02e994e3736b19a1b3)
+  _(tabs)_ Set the default highlight_style ([#635](https://github.com/ratatui/ratatui/issues/635)) [**breaking**]
 
   ````text
   Previously the default highlight_style was set to `Style::default()`,
@@ -3618,19 +3621,19 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   This change sets the default highlight_style to reversed text.
   ````
 
-- [28ac55b](https://github.com/ratatui-org/ratatui/commit/28ac55bc62e4e14e3ace300633d56791a1d3dea0)
-  *(tabs)* Tab widget now supports custom padding ([#629](https://github.com/ratatui-org/ratatui/issues/629))
+- [28ac55b](https://github.com/ratatui/ratatui/commit/28ac55bc62e4e14e3ace300633d56791a1d3dea0)
+  _(tabs)_ Tab widget now supports custom padding ([#629](https://github.com/ratatui/ratatui/issues/629))
 
   ````text
   The Tab widget now contains padding_left and and padding_right
   properties. Those values can be set with functions `padding_left()`,
   `padding_right()`, and `padding()` which all accept `Into<Line>`.
 
-  Fixes issue https://github.com/ratatui-org/ratatui/issues/502
+  Fixes issue https://github.com/ratatui/ratatui/issues/502
   ````
 
-- [df0eb1f](https://github.com/ratatui-org/ratatui/commit/df0eb1f8e94752db542ff58e1453f4f8beab17e2)
-  *(terminal)* Insert_before() now accepts lines > terminal height and doesn't add an extra blank line ([#596](https://github.com/ratatui-org/ratatui/issues/596))
+- [df0eb1f](https://github.com/ratatui/ratatui/commit/df0eb1f8e94752db542ff58e1453f4f8beab17e2)
+  _(terminal)_ Insert_before() now accepts lines > terminal height and doesn't add an extra blank line ([#596](https://github.com/ratatui/ratatui/issues/596))
 
   ````text
   Fixes issue with inserting content with height>viewport_area.height and adds
@@ -3640,23 +3643,23 @@ Also, we renewed our website and updated our documentation/tutorials to get star
     support testing the changes
   ````
 
-- [aaeba27](https://github.com/ratatui-org/ratatui/commit/aaeba2709c09b7373f3781ecd4b0a96b22fc2764)
-  *(uncategorized)* Truncate table when overflow ([#685](https://github.com/ratatui-org/ratatui/issues/685))
+- [aaeba27](https://github.com/ratatui/ratatui/commit/aaeba2709c09b7373f3781ecd4b0a96b22fc2764)
+  _(uncategorized)_ Truncate table when overflow ([#685](https://github.com/ratatui/ratatui/issues/685))
 
   ````text
   This prevents a panic when rendering an empty right aligned and rightmost table cell
   ````
 
-- [ffa78aa](https://github.com/ratatui-org/ratatui/commit/ffa78aa67ccd79b9aa1af0d7ccf56a2059d0f519)
-  *(uncategorized)* Add #[must_use] to Style-moving methods ([#600](https://github.com/ratatui-org/ratatui/issues/600))
+- [ffa78aa](https://github.com/ratatui/ratatui/commit/ffa78aa67ccd79b9aa1af0d7ccf56a2059d0f519)
+  _(uncategorized)_ Add #[must_use] to Style-moving methods ([#600](https://github.com/ratatui/ratatui/issues/600))
 
-- [a2f2bd5](https://github.com/ratatui-org/ratatui/commit/a2f2bd5df53a796c0f2a57bb1b22151e52b5ef03)
-  *(uncategorized)* MSRV is now `1.70.0` ([#593](https://github.com/ratatui-org/ratatui/issues/593))
+- [a2f2bd5](https://github.com/ratatui/ratatui/commit/a2f2bd5df53a796c0f2a57bb1b22151e52b5ef03)
+  _(uncategorized)_ MSRV is now `1.70.0` ([#593](https://github.com/ratatui/ratatui/issues/593))
 
 ### Refactor
 
-- [f767ea7](https://github.com/ratatui-org/ratatui/commit/f767ea7d3766887cb79145103b5aa92e0eabf8f6)
-  *(list)* `start_corner` is now `direction` ([#673](https://github.com/ratatui-org/ratatui/issues/673))
+- [f767ea7](https://github.com/ratatui/ratatui/commit/f767ea7d3766887cb79145103b5aa92e0eabf8f6)
+  _(list)_ `start_corner` is now `direction` ([#673](https://github.com/ratatui/ratatui/issues/673))
 
   ````text
   The previous name `start_corner` did not communicate clearly the intent of the method.
@@ -3665,11 +3668,11 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   `start_corner` is now deprecated
   ````
 
-- [b82451f](https://github.com/ratatui-org/ratatui/commit/b82451fb33f35ae0323a56bb6f962404b076a262)
-  *(examples)* Add vim binding ([#688](https://github.com/ratatui-org/ratatui/issues/688))
+- [b82451f](https://github.com/ratatui/ratatui/commit/b82451fb33f35ae0323a56bb6f962404b076a262)
+  _(examples)_ Add vim binding ([#688](https://github.com/ratatui/ratatui/issues/688))
 
-- [0576a8a](https://github.com/ratatui-org/ratatui/commit/0576a8aa3212c57d288c67592337a3870ae6dafc)
-  *(layout)* To natural reading order ([#681](https://github.com/ratatui-org/ratatui/issues/681))
+- [0576a8a](https://github.com/ratatui/ratatui/commit/0576a8aa3212c57d288c67592337a3870ae6dafc)
+  _(layout)_ To natural reading order ([#681](https://github.com/ratatui/ratatui/issues/681))
 
   ````text
   Structs and enums at the top of the file helps show the interaction
@@ -3681,8 +3684,8 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   This makes the code a bit more contained.
   ````
 
-- [4be18ab](https://github.com/ratatui-org/ratatui/commit/4be18aba8b535165f03d15450276b2e95a7970eb)
-  *(readme)* Reference awesome-ratatui instead of wiki ([#689](https://github.com/ratatui-org/ratatui/issues/689))
+- [4be18ab](https://github.com/ratatui/ratatui/commit/4be18aba8b535165f03d15450276b2e95a7970eb)
+  _(readme)_ Reference awesome-ratatui instead of wiki ([#689](https://github.com/ratatui/ratatui/issues/689))
 
   ````text
   * refactor(readme): link awesome-ratatui instead of wiki
@@ -3692,18 +3695,18 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   * docs(readme): Update README.md
   ````
 
-- [7ef0afc](https://github.com/ratatui-org/ratatui/commit/7ef0afcb62198f76321e84d9bb19a8a590a3b649)
-  *(widgets)* Remove unnecessary dynamic dispatch and heap allocation ([#597](https://github.com/ratatui-org/ratatui/issues/597))
+- [7ef0afc](https://github.com/ratatui/ratatui/commit/7ef0afcb62198f76321e84d9bb19a8a590a3b649)
+  _(widgets)_ Remove unnecessary dynamic dispatch and heap allocation ([#597](https://github.com/ratatui/ratatui/issues/597))
 
-- [b282a06](https://github.com/ratatui-org/ratatui/commit/b282a0693289d9d2602b54b639d3701d8c8cc8a8)
-  *(uncategorized)* Remove items deprecated since 0.10 ([#691](https://github.com/ratatui-org/ratatui/issues/691)) [**breaking**]
+- [b282a06](https://github.com/ratatui/ratatui/commit/b282a0693289d9d2602b54b639d3701d8c8cc8a8)
+  _(uncategorized)_ Remove items deprecated since 0.10 ([#691](https://github.com/ratatui/ratatui/issues/691)) [**breaking**]
 
   ````text
   Remove `Axis::title_style` and `Buffer::set_background` which are deprecated since 0.10
   ````
 
-- [7ced7c0](https://github.com/ratatui-org/ratatui/commit/7ced7c0aa3acdaa63ed6add59711614993210ba3)
-  *(uncategorized)* Define struct WrappedLine instead of anonymous tuple ([#608](https://github.com/ratatui-org/ratatui/issues/608))
+- [7ced7c0](https://github.com/ratatui/ratatui/commit/7ced7c0aa3acdaa63ed6add59711614993210ba3)
+  _(uncategorized)_ Define struct WrappedLine instead of anonymous tuple ([#608](https://github.com/ratatui/ratatui/issues/608))
 
   ````text
   It makes the type easier to document, and more obvious for users
@@ -3711,51 +3714,51 @@ Also, we renewed our website and updated our documentation/tutorials to get star
 
 ### Documentation
 
-- [fe632d7](https://github.com/ratatui-org/ratatui/commit/fe632d70cb150264d9af2f79145a1d14a3637f3e)
-  *(sparkline)* Add documentation ([#648](https://github.com/ratatui-org/ratatui/issues/648))
+- [fe632d7](https://github.com/ratatui/ratatui/commit/fe632d70cb150264d9af2f79145a1d14a3637f3e)
+  _(sparkline)_ Add documentation ([#648](https://github.com/ratatui/ratatui/issues/648))
 
-- [f4c8de0](https://github.com/ratatui-org/ratatui/commit/f4c8de041d48cec5ea9b3e1f540f57af5a09d7a4)
-  *(chart)* Document chart module ([#696](https://github.com/ratatui-org/ratatui/issues/696))
+- [f4c8de0](https://github.com/ratatui/ratatui/commit/f4c8de041d48cec5ea9b3e1f540f57af5a09d7a4)
+  _(chart)_ Document chart module ([#696](https://github.com/ratatui/ratatui/issues/696))
 
-- [1b8b626](https://github.com/ratatui-org/ratatui/commit/1b8b6261e2de29a37b2cd7d6ee8659fb46d3beff)
-  *(examples)* Add animation and FPS counter to colors_rgb ([#583](https://github.com/ratatui-org/ratatui/issues/583))
+- [1b8b626](https://github.com/ratatui/ratatui/commit/1b8b6261e2de29a37b2cd7d6ee8659fb46d3beff)
+  _(examples)_ Add animation and FPS counter to colors_rgb ([#583](https://github.com/ratatui/ratatui/issues/583))
 
-- [2169a0d](https://github.com/ratatui-org/ratatui/commit/2169a0da01e3bd6272e33b9de26a033fcb5f55f2)
-  *(examples)* Add example of half block rendering ([#687](https://github.com/ratatui-org/ratatui/issues/687))
+- [2169a0d](https://github.com/ratatui/ratatui/commit/2169a0da01e3bd6272e33b9de26a033fcb5f55f2)
+  _(examples)_ Add example of half block rendering ([#687](https://github.com/ratatui/ratatui/issues/687))
 
   ````text
   This is a fun example of how to render big text using half blocks
   ````
 
-- [41c44a4](https://github.com/ratatui-org/ratatui/commit/41c44a4af66ba791959f3a298d1b544330b9a164)
-  *(frame)* Add docs about resize events ([#697](https://github.com/ratatui-org/ratatui/issues/697))
+- [41c44a4](https://github.com/ratatui/ratatui/commit/41c44a4af66ba791959f3a298d1b544330b9a164)
+  _(frame)_ Add docs about resize events ([#697](https://github.com/ratatui/ratatui/issues/697))
 
-- [91c67eb](https://github.com/ratatui-org/ratatui/commit/91c67eb1009449e0dfdd29e6ef0132c5254cfbde)
-  *(github)* Update code owners ([#666](https://github.com/ratatui-org/ratatui/issues/666))
+- [91c67eb](https://github.com/ratatui/ratatui/commit/91c67eb1009449e0dfdd29e6ef0132c5254cfbde)
+  _(github)_ Update code owners ([#666](https://github.com/ratatui/ratatui/issues/666))
 
   ````text
   onboard @Valentin271 as maintainer
   ````
 
-- [458fa90](https://github.com/ratatui-org/ratatui/commit/458fa9036281e0e6e88bd2ec90c633e499ce547c)
-  *(lib)* Tweak the crate documentation ([#659](https://github.com/ratatui-org/ratatui/issues/659))
+- [458fa90](https://github.com/ratatui/ratatui/commit/458fa9036281e0e6e88bd2ec90c633e499ce547c)
+  _(lib)_ Tweak the crate documentation ([#659](https://github.com/ratatui/ratatui/issues/659))
 
-- [3ec4e24](https://github.com/ratatui-org/ratatui/commit/3ec4e24d00e118a12c8fea888e16ce19b75cf45f)
-  *(list)* Add documentation to the List widget ([#669](https://github.com/ratatui-org/ratatui/issues/669))
+- [3ec4e24](https://github.com/ratatui/ratatui/commit/3ec4e24d00e118a12c8fea888e16ce19b75cf45f)
+  _(list)_ Add documentation to the List widget ([#669](https://github.com/ratatui/ratatui/issues/669))
 
   ````text
   Adds documentation to the List widget and all its sub components like `ListState` and `ListItem`
   ````
 
-- [9f37100](https://github.com/ratatui-org/ratatui/commit/9f371000968044e09545d66068c4ed4ea4b35d8a)
-  *(readme)* Update README.md and fix the bug that demo2 cannot run ([#595](https://github.com/ratatui-org/ratatui/issues/595))
+- [9f37100](https://github.com/ratatui/ratatui/commit/9f371000968044e09545d66068c4ed4ea4b35d8a)
+  _(readme)_ Update README.md and fix the bug that demo2 cannot run ([#595](https://github.com/ratatui/ratatui/issues/595))
 
   ````text
-  Fixes https://github.com/ratatui-org/ratatui/issues/594
+  Fixes https://github.com/ratatui/ratatui/issues/594
   ````
 
-- [2a87251](https://github.com/ratatui-org/ratatui/commit/2a87251152432fd99c18864f32874fed2cab2f99)
-  *(security)* Add security policy ([#676](https://github.com/ratatui-org/ratatui/issues/676))
+- [2a87251](https://github.com/ratatui/ratatui/commit/2a87251152432fd99c18864f32874fed2cab2f99)
+  _(security)_ Add security policy ([#676](https://github.com/ratatui/ratatui/issues/676))
 
   ````text
   * docs: Create SECURITY.md
@@ -3763,17 +3766,17 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   * Update SECURITY.md
   ````
 
-- [987f7ee](https://github.com/ratatui-org/ratatui/commit/987f7eed4c8bd09e319b504e587eb1f3667ee64b)
-  *(website)* Rename book to website ([#661](https://github.com/ratatui-org/ratatui/issues/661))
+- [987f7ee](https://github.com/ratatui/ratatui/commit/987f7eed4c8bd09e319b504e587eb1f3667ee64b)
+  _(website)_ Rename book to website ([#661](https://github.com/ratatui/ratatui/issues/661))
 
-- [a15c3b2](https://github.com/ratatui-org/ratatui/commit/a15c3b2660bf4102bc881a5bc11959bc136f4a17)
-  *(uncategorized)* Remove deprecated table constructor from breaking changes ([#698](https://github.com/ratatui-org/ratatui/issues/698))
+- [a15c3b2](https://github.com/ratatui/ratatui/commit/a15c3b2660bf4102bc881a5bc11959bc136f4a17)
+  _(uncategorized)_ Remove deprecated table constructor from breaking changes ([#698](https://github.com/ratatui/ratatui/issues/698))
 
-- [113b4b7](https://github.com/ratatui-org/ratatui/commit/113b4b7a4ea841fe2ca7b1c153243fec781c3cc0)
-  *(uncategorized)* Rename template links to remove ratatui from name 📚 ([#690](https://github.com/ratatui-org/ratatui/issues/690))
+- [113b4b7](https://github.com/ratatui/ratatui/commit/113b4b7a4ea841fe2ca7b1c153243fec781c3cc0)
+  _(uncategorized)_ Rename template links to remove ratatui from name 📚 ([#690](https://github.com/ratatui/ratatui/issues/690))
 
-- [211160c](https://github.com/ratatui-org/ratatui/commit/211160ca165e2ad23b3d4cd9382c6e4869644a9c)
-  *(uncategorized)* Remove simple-tui-rs ([#651](https://github.com/ratatui-org/ratatui/issues/651))
+- [211160c](https://github.com/ratatui/ratatui/commit/211160ca165e2ad23b3d4cd9382c6e4869644a9c)
+  _(uncategorized)_ Remove simple-tui-rs ([#651](https://github.com/ratatui/ratatui/issues/651))
 
   ````text
   This has not been recently and doesn't lead to good code
@@ -3781,13 +3784,13 @@ Also, we renewed our website and updated our documentation/tutorials to get star
 
 ### Styling
 
-- [6a6e9dd](https://github.com/ratatui-org/ratatui/commit/6a6e9dde9dc66ecb6f47f858fd0a67d7dc9eb7d1)
-  *(tabs)* Fix doc formatting ([#662](https://github.com/ratatui-org/ratatui/issues/662))
+- [6a6e9dd](https://github.com/ratatui/ratatui/commit/6a6e9dde9dc66ecb6f47f858fd0a67d7dc9eb7d1)
+  _(tabs)_ Fix doc formatting ([#662](https://github.com/ratatui/ratatui/issues/662))
 
 ### Miscellaneous Tasks
 
-- [910ad00](https://github.com/ratatui-org/ratatui/commit/910ad00059c3603ba6b1751c95783f974fde88a1)
-  *(rustfmt)* Enable format_code_in_doc_comments ([#695](https://github.com/ratatui-org/ratatui/issues/695))
+- [910ad00](https://github.com/ratatui/ratatui/commit/910ad00059c3603ba6b1751c95783f974fde88a1)
+  _(rustfmt)_ Enable format_code_in_doc_comments ([#695](https://github.com/ratatui/ratatui/issues/695))
 
   ````text
   This enables more consistently formatted code in doc comments,
@@ -3796,8 +3799,8 @@ Also, we renewed our website and updated our documentation/tutorials to get star
   See https://rust-lang.github.io/rustfmt/?version=v1.6.0#format_code_in_doc_comments
   ````
 
-- [d118565](https://github.com/ratatui-org/ratatui/commit/d118565ef60480fba8f2906ede81f875a562cb61)
-  *(table)* Cleanup docs and builder methods ([#638](https://github.com/ratatui-org/ratatui/issues/638))
+- [d118565](https://github.com/ratatui/ratatui/commit/d118565ef60480fba8f2906ede81f875a562cb61)
+  _(table)_ Cleanup docs and builder methods ([#638](https://github.com/ratatui/ratatui/issues/638))
 
   ````text
   - Refactor the `table` module for better top to bottom readability by
@@ -3819,18 +3822,18 @@ Also, we renewed our website and updated our documentation/tutorials to get star
     the other setter methods.
   ````
 
-- [dd22e72](https://github.com/ratatui-org/ratatui/commit/dd22e721e3aed24538eb08e46e40339cec636bcb)
-  *(uncategorized)* Correct "builder methods" in docs and add `must_use` on widgets setters ([#655](https://github.com/ratatui-org/ratatui/issues/655))
+- [dd22e72](https://github.com/ratatui/ratatui/commit/dd22e721e3aed24538eb08e46e40339cec636bcb)
+  _(uncategorized)_ Correct "builder methods" in docs and add `must_use` on widgets setters ([#655](https://github.com/ratatui/ratatui/issues/655))
 
-- [18e19f6](https://github.com/ratatui-org/ratatui/commit/18e19f6ce6ae3ce9bd52110ab6cbd4ed4bcca5e6)
-  *(uncategorized)* Fix breaking changes doc versions ([#639](https://github.com/ratatui-org/ratatui/issues/639))
+- [18e19f6](https://github.com/ratatui/ratatui/commit/18e19f6ce6ae3ce9bd52110ab6cbd4ed4bcca5e6)
+  _(uncategorized)_ Fix breaking changes doc versions ([#639](https://github.com/ratatui/ratatui/issues/639))
 
   ````text
   Moves the layout::new change to unreleasedd section and adds the table change
   ````
 
-- [a58cce2](https://github.com/ratatui-org/ratatui/commit/a58cce2dba404fe394bbb298645bf3c40518fe1f)
-  *(uncategorized)* Disable default benchmarking ([#598](https://github.com/ratatui-org/ratatui/issues/598))
+- [a58cce2](https://github.com/ratatui/ratatui/commit/a58cce2dba404fe394bbb298645bf3c40518fe1f)
+  _(uncategorized)_ Disable default benchmarking ([#598](https://github.com/ratatui/ratatui/issues/598))
 
   ````text
   Disables the default benchmarking behaviour for the lib target to fix unrecognized
@@ -3841,15 +3844,15 @@ Also, we renewed our website and updated our documentation/tutorials to get star
 
 ### Continuous Integration
 
-- [59b9c32](https://github.com/ratatui-org/ratatui/commit/59b9c32fbc2bc6725bdec42e63216024fab71493)
-  *(codecov)* Adjust threshold and noise settings ([#615](https://github.com/ratatui-org/ratatui/issues/615))
+- [59b9c32](https://github.com/ratatui/ratatui/commit/59b9c32fbc2bc6725bdec42e63216024fab71493)
+  _(codecov)_ Adjust threshold and noise settings ([#615](https://github.com/ratatui/ratatui/issues/615))
 
   ````text
-  Fixes https://github.com/ratatui-org/ratatui/issues/612
+  Fixes https://github.com/ratatui/ratatui/issues/612
   ````
 
-- [03401cd](https://github.com/ratatui-org/ratatui/commit/03401cd46e6566af4d063bac11efc30f28b5358a)
-  *(uncategorized)* Fix untrusted input in pr check workflow ([#680](https://github.com/ratatui-org/ratatui/issues/680))
+- [03401cd](https://github.com/ratatui/ratatui/commit/03401cd46e6566af4d063bac11efc30f28b5358a)
+  _(uncategorized)_ Fix untrusted input in pr check workflow ([#680](https://github.com/ratatui/ratatui/issues/680))
 
 ### Contributors
 
@@ -3857,34 +3860,34 @@ Thank you so much to everyone that contributed to this release!
 
 Here is the list of contributors who have contributed to `ratatui` for the first time!
 
-* @rikonaka
-* @danny-burrows
-* @SOF3
-* @jan-ferdinand
-* @rhaskia
-* @asomers
-* @progval
-* @TylerBloom
-* @YeungKC
-* @lyuha
+- @rikonaka
+- @danny-burrows
+- @SOF3
+- @jan-ferdinand
+- @rhaskia
+- @asomers
+- @progval
+- @TylerBloom
+- @YeungKC
+- @lyuha
 
-## [0.24.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.24.0) - 2023-10-23
+## [0.24.0](https://github.com/ratatui/ratatui/releases/tag/v0.24.0) - 2023-10-23
 
 We are excited to announce the new version of `ratatui` - a Rust library that's all about cooking up TUIs 🐭
 
 In this version, we've introduced features like window size API, enhanced chart rendering, and more.
-The list of \*breaking changes\* can be found [here](https://github.com/ratatui-org/ratatui/blob/main/BREAKING-CHANGES.md) ⚠️.
-Also, we created various tutorials and walkthroughs in [Ratatui Book](https://github.com/ratatui-org/ratatui-book) which is available at <https://ratatui.rs> 🚀
+The list of \*breaking changes\* can be found [here](https://github.com/ratatui/ratatui/blob/main/BREAKING-CHANGES.md) ⚠️.
+Also, we created various tutorials and walkthroughs in [Ratatui Book](https://github.com/ratatui/ratatui-book) which is available at <https://ratatui.rs> 🚀
 
 ✨ **Release highlights**: <https://ratatui.rs/highlights/v024>
 
 ### Features
 
-- [c6c3f88](https://github.com/ratatui-org/ratatui/commit/c6c3f88a79515a085fb8a96fe150843dab6dd5bc)
-  _(backend)_ Implement common traits for `WindowSize` ([#586](https://github.com/ratatui-org/ratatui/issues/586))
+- [c6c3f88](https://github.com/ratatui/ratatui/commit/c6c3f88a79515a085fb8a96fe150843dab6dd5bc)
+  _(backend)_ Implement common traits for `WindowSize` ([#586](https://github.com/ratatui/ratatui/issues/586))
 
-- [d077903](https://github.com/ratatui-org/ratatui/commit/d0779034e741834aac36b5b7a87c54bd8c50b7f2)
-  _(backend)_ Backend provides window_size, add Size struct ([#276](https://github.com/ratatui-org/ratatui/issues/276))
+- [d077903](https://github.com/ratatui/ratatui/commit/d0779034e741834aac36b5b7a87c54bd8c50b7f2)
+  _(backend)_ Backend provides window_size, add Size struct ([#276](https://github.com/ratatui/ratatui/issues/276))
 
   ```text
   For image (sixel, iTerm2, Kitty...) support that handles graphics in
@@ -3910,8 +3913,8 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   is why there are `From` implementations between the two.
   ```
 
-- [301366c](https://github.com/ratatui-org/ratatui/commit/301366c4fa33524b0634bbd3dcf1abd1a1ebe7c6)
-  _(barchart)_ Render charts smaller than 3 lines ([#532](https://github.com/ratatui-org/ratatui/issues/532))
+- [301366c](https://github.com/ratatui/ratatui/commit/301366c4fa33524b0634bbd3dcf1abd1a1ebe7c6)
+  _(barchart)_ Render charts smaller than 3 lines ([#532](https://github.com/ratatui/ratatui/issues/532))
 
   ```text
   The bar values are not shown if the value width is equal the bar width
@@ -3920,11 +3923,11 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   Add an internal structure `LabelInfo` which stores the reserved height
   for the labels (0, 1 or 2) and also whether the labels will be shown.
 
-  Fixes ratatui-org#513
+  Fixes ratatui#513
   ```
 
-- [32e4619](https://github.com/ratatui-org/ratatui/commit/32e461953c8c9231edeef65c410b295916f26f3e)
-  _(block)_ Allow custom symbols for borders ([#529](https://github.com/ratatui-org/ratatui/issues/529)) [**breaking**]
+- [32e4619](https://github.com/ratatui/ratatui/commit/32e461953c8c9231edeef65c410b295916f26f3e)
+  _(block)_ Allow custom symbols for borders ([#529](https://github.com/ratatui/ratatui/issues/529)) [**breaking**]
 
   ````text
   Adds a new `Block::border_set` method that allows the user to specify
@@ -3943,15 +3946,15 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   ▐  ▌
   ▝▀▀▘
   ```
-  Fixes: https://github.com/ratatui-org/ratatui/issues/528
+  Fixes: https://github.com/ratatui/ratatui/issues/528
 
   BREAKING CHANGES:
   - BorderType::to_line_set is renamed to to_border_set
   - BorderType::line_symbols is renamed to border_symbols
   ````
 
-- [4541336](https://github.com/ratatui-org/ratatui/commit/45413365146ede5472dc28e0ee1970d245e2fa02)
-  _(canvas)_ Implement half block marker ([#550](https://github.com/ratatui-org/ratatui/issues/550))
+- [4541336](https://github.com/ratatui/ratatui/commit/45413365146ede5472dc28e0ee1970d245e2fa02)
+  _(canvas)_ Implement half block marker ([#550](https://github.com/ratatui/ratatui/issues/550))
 
   ```text
   * feat(canvas): implement half block marker
@@ -3973,11 +3976,11 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   This is an internal detail with no user impact.
   ```
 
-- [be55a5f](https://github.com/ratatui-org/ratatui/commit/be55a5fbcdffc4fd6aeb7edffa32f6e6c942a41e)
-  _(examples)_ Add demo2 example ([#500](https://github.com/ratatui-org/ratatui/issues/500))
+- [be55a5f](https://github.com/ratatui/ratatui/commit/be55a5fbcdffc4fd6aeb7edffa32f6e6c942a41e)
+  _(examples)_ Add demo2 example ([#500](https://github.com/ratatui/ratatui/issues/500))
 
-- [082cbcb](https://github.com/ratatui-org/ratatui/commit/082cbcbc501d4284dc7e142227f9e04ef17da61d)
-  _(frame)_ Remove generic Backend parameter ([#530](https://github.com/ratatui-org/ratatui/issues/530)) [**breaking**]
+- [082cbcb](https://github.com/ratatui/ratatui/commit/082cbcbc501d4284dc7e142227f9e04ef17da61d)
+  _(frame)_ Remove generic Backend parameter ([#530](https://github.com/ratatui/ratatui/issues/530)) [**breaking**]
 
   ````text
   This change simplifies UI code that uses the Frame type. E.g.:
@@ -3997,8 +4000,8 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   accepted a Frame<Backend> will now need to accept a Frame.
   ````
 
-- [d67fa2c](https://github.com/ratatui-org/ratatui/commit/d67fa2c00d6d6125eeefa0eeeb032664dae9a4de)
-  _(line)_ Add `Line::raw` constructor ([#511](https://github.com/ratatui-org/ratatui/issues/511))
+- [d67fa2c](https://github.com/ratatui/ratatui/commit/d67fa2c00d6d6125eeefa0eeeb032664dae9a4de)
+  _(line)_ Add `Line::raw` constructor ([#511](https://github.com/ratatui/ratatui/issues/511))
 
   ```text
   * feat(line): add `Line::raw` constructor
@@ -4009,8 +4012,8 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   Multi-line content is converted to multiple spans with the new line removed
   ```
 
-- [cbf86da](https://github.com/ratatui-org/ratatui/commit/cbf86da0e7e4a2d99ace8df68854de74157a665a)
-  _(rect)_ Add is_empty() to simplify some common checks ([#534](https://github.com/ratatui-org/ratatui/issues/534))
+- [cbf86da](https://github.com/ratatui/ratatui/commit/cbf86da0e7e4a2d99ace8df68854de74157a665a)
+  _(rect)_ Add is_empty() to simplify some common checks ([#534](https://github.com/ratatui/ratatui/issues/534))
 
   ```text
   - add `Rect::is_empty()` that checks whether either height or width == 0
@@ -4018,13 +4021,13 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
      the module is private and the type is re-exported under the `layout` module.
   ```
 
-- [15641c8](https://github.com/ratatui-org/ratatui/commit/15641c8475b7596c97a0affce0d6082c4b9586c2)
-  _(uncategorized)_ Add `buffer_mut` method on `Frame` ✨ ([#548](https://github.com/ratatui-org/ratatui/issues/548))
+- [15641c8](https://github.com/ratatui/ratatui/commit/15641c8475b7596c97a0affce0d6082c4b9586c2)
+  _(uncategorized)_ Add `buffer_mut` method on `Frame` ✨ ([#548](https://github.com/ratatui/ratatui/issues/548))
 
 ### Bug Fixes
 
-- [638d596](https://github.com/ratatui-org/ratatui/commit/638d596a3b7aec723a2354cf0e261b207ac412f8)
-  _(layout)_ Use LruCache for layout cache ([#487](https://github.com/ratatui-org/ratatui/issues/487))
+- [638d596](https://github.com/ratatui/ratatui/commit/638d596a3b7aec723a2354cf0e261b207ac412f8)
+  _(layout)_ Use LruCache for layout cache ([#487](https://github.com/ratatui/ratatui/issues/487))
 
   ```text
   The layout cache now uses a LruCache with default size set to 16 entries.
@@ -4037,8 +4040,8 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   prior to any calls to `layout::split()` as the cache is wrapped in a `OnceLock`
   ```
 
-- [8d507c4](https://github.com/ratatui-org/ratatui/commit/8d507c43fa866ab4c0eda9fd169f307fba2a1109)
-  _(backend)_ Add feature flag for underline-color ([#570](https://github.com/ratatui-org/ratatui/issues/570))
+- [8d507c4](https://github.com/ratatui/ratatui/commit/8d507c43fa866ab4c0eda9fd169f307fba2a1109)
+  _(backend)_ Add feature flag for underline-color ([#570](https://github.com/ratatui/ratatui/issues/570))
 
   ````text
   Windows 7 doesn't support the underline color attribute, so we need to
@@ -4058,24 +4061,24 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   ratatui = { version = "0.24.0", default-features = false, features = ["crossterm"] }
   ```
 
-  Fixes https://github.com/ratatui-org/ratatui/issues/555
+  Fixes https://github.com/ratatui/ratatui/issues/555
   ````
 
-- [c3155a2](https://github.com/ratatui-org/ratatui/commit/c3155a24895ec4dfb1a8e580fb9ee3d31e9af139)
-  _(barchart)_ Add horizontal labels([#518](https://github.com/ratatui-org/ratatui/issues/518))
+- [c3155a2](https://github.com/ratatui/ratatui/commit/c3155a24895ec4dfb1a8e580fb9ee3d31e9af139)
+  _(barchart)_ Add horizontal labels([#518](https://github.com/ratatui/ratatui/issues/518))
 
   ```text
   Labels were missed in the initial implementation of the horizontal
   mode for the BarChart widget. This adds them.
 
-  Fixes https://github.com/ratatui-org/ratatui/issues/499
+  Fixes https://github.com/ratatui/ratatui/issues/499
   ```
 
-- [c5ea656](https://github.com/ratatui-org/ratatui/commit/c5ea656385843c880b3bef45dccbe8ea57431d10)
-  _(barchart)_ Avoid divide by zero in rendering ([#525](https://github.com/ratatui-org/ratatui/issues/525))
+- [c5ea656](https://github.com/ratatui/ratatui/commit/c5ea656385843c880b3bef45dccbe8ea57431d10)
+  _(barchart)_ Avoid divide by zero in rendering ([#525](https://github.com/ratatui/ratatui/issues/525))
 
-- [c9b8e7c](https://github.com/ratatui-org/ratatui/commit/c9b8e7cf412de235082f1fcd1698468c4b1b6171)
-  _(barchart)_ Render value labels with unicode correctly ([#515](https://github.com/ratatui-org/ratatui/issues/515))
+- [c9b8e7c](https://github.com/ratatui/ratatui/commit/c9b8e7cf412de235082f1fcd1698468c4b1b6171)
+  _(barchart)_ Render value labels with unicode correctly ([#515](https://github.com/ratatui/ratatui/issues/515))
 
   ```text
   An earlier change introduced a bug where the width of value labels with
@@ -4083,8 +4086,8 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   instead of the unicode character count. This reverts the earlier change.
   ```
 
-- [c8ab2d5](https://github.com/ratatui-org/ratatui/commit/c8ab2d59087f5b475ecf6ffa31b89ce24b6b1d28)
-  _(chart)_ Use graph style for top line ([#462](https://github.com/ratatui-org/ratatui/issues/462))
+- [c8ab2d5](https://github.com/ratatui/ratatui/commit/c8ab2d59087f5b475ecf6ffa31b89ce24b6b1d28)
+  _(chart)_ Use graph style for top line ([#462](https://github.com/ratatui/ratatui/issues/462))
 
   ```text
   A bug in the rendering caused the top line of the chart to be rendered
@@ -4093,8 +4096,8 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   entire row.
   ```
 
-- [0c7d547](https://github.com/ratatui-org/ratatui/commit/0c7d547db196a7cf65a6bf8cde74bd908407a3ff)
-  _(docs)_ Don't fail rustdoc due to termion ([#503](https://github.com/ratatui-org/ratatui/issues/503))
+- [0c7d547](https://github.com/ratatui/ratatui/commit/0c7d547db196a7cf65a6bf8cde74bd908407a3ff)
+  _(docs)_ Don't fail rustdoc due to termion ([#503](https://github.com/ratatui/ratatui/issues/503))
 
   ```text
   Windows cannot compile termion, so it is not included in the docs.
@@ -4104,32 +4107,32 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   This replaces the link to TermionBackend with one that does not fail
   during checks.
 
-  Fixes https://github.com/ratatui-org/ratatui/issues/498
+  Fixes https://github.com/ratatui/ratatui/issues/498
   ```
 
-- [0c52ff4](https://github.com/ratatui-org/ratatui/commit/0c52ff431a1eedb0e38b5c8fb6623d4da17fa97e)
-  _(gauge)_ Fix gauge widget colors ([#572](https://github.com/ratatui-org/ratatui/issues/572))
+- [0c52ff4](https://github.com/ratatui/ratatui/commit/0c52ff431a1eedb0e38b5c8fb6623d4da17fa97e)
+  _(gauge)_ Fix gauge widget colors ([#572](https://github.com/ratatui/ratatui/issues/572))
 
   ```text
   The background colors of the gauge had a workaround for the issue we had
   with VHS / TTYD rendering the background color of the gauge. This
   workaround is no longer necessary in the updated versions of VHS / TTYD.
 
-  Fixes https://github.com/ratatui-org/ratatui/issues/501
+  Fixes https://github.com/ratatui/ratatui/issues/501
   ```
 
-- [11076d0](https://github.com/ratatui-org/ratatui/commit/11076d0af3a76229af579fb40684fdd37df172dd)
-  _(rect)_ Fix arithmetic overflow edge cases ([#543](https://github.com/ratatui-org/ratatui/issues/543))
+- [11076d0](https://github.com/ratatui/ratatui/commit/11076d0af3a76229af579fb40684fdd37df172dd)
+  _(rect)_ Fix arithmetic overflow edge cases ([#543](https://github.com/ratatui/ratatui/issues/543))
 
   ```text
-  Fixes https://github.com/ratatui-org/ratatui/issues/258
+  Fixes https://github.com/ratatui/ratatui/issues/258
   ```
 
-- [21303f2](https://github.com/ratatui-org/ratatui/commit/21303f21672de1405135bb785497c30150644078)
-  _(rect)_ Prevent overflow in inner() and area() ([#523](https://github.com/ratatui-org/ratatui/issues/523))
+- [21303f2](https://github.com/ratatui/ratatui/commit/21303f21672de1405135bb785497c30150644078)
+  _(rect)_ Prevent overflow in inner() and area() ([#523](https://github.com/ratatui/ratatui/issues/523))
 
-- [ebd3680](https://github.com/ratatui-org/ratatui/commit/ebd3680a471d96ae1d8f52cd9e4a8a80c142d060)
-  _(stylize)_ Add Stylize impl for String ([#466](https://github.com/ratatui-org/ratatui/issues/466)) [**breaking**]
+- [ebd3680](https://github.com/ratatui/ratatui/commit/ebd3680a471d96ae1d8f52cd9e4a8a80c142d060)
+  _(stylize)_ Add Stylize impl for String ([#466](https://github.com/ratatui/ratatui/issues/466)) [**breaking**]
 
   ```text
   Although the `Stylize` trait is already implemented for `&str` which
@@ -4158,8 +4161,8 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
 
 ### Refactor
 
-- [2fd85af](https://github.com/ratatui-org/ratatui/commit/2fd85af33c5cb7c04286e4e4198a939b4857eadc)
-  _(barchart)_ Simplify internal implementation ([#544](https://github.com/ratatui-org/ratatui/issues/544))
+- [2fd85af](https://github.com/ratatui/ratatui/commit/2fd85af33c5cb7c04286e4e4198a939b4857eadc)
+  _(barchart)_ Simplify internal implementation ([#544](https://github.com/ratatui/ratatui/issues/544))
 
   ```text
   Replace `remove_invisible_groups_and_bars` with `group_ticks`
@@ -4173,30 +4176,30 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
 
 ### Documentation
 
-- [0c68ebe](https://github.com/ratatui-org/ratatui/commit/0c68ebed4f63a595811006e0af221b11a83780cf)
-  _(block)_ Add documentation to Block ([#469](https://github.com/ratatui-org/ratatui/issues/469))
+- [0c68ebe](https://github.com/ratatui/ratatui/commit/0c68ebed4f63a595811006e0af221b11a83780cf)
+  _(block)_ Add documentation to Block ([#469](https://github.com/ratatui/ratatui/issues/469))
 
-- [0fe7385](https://github.com/ratatui-org/ratatui/commit/0fe738500cd461aeafa0a63b37ed6250777f3599)
-  _(gauge)_ Add docs for `Gauge` and `LineGauge` ([#514](https://github.com/ratatui-org/ratatui/issues/514))
+- [0fe7385](https://github.com/ratatui/ratatui/commit/0fe738500cd461aeafa0a63b37ed6250777f3599)
+  _(gauge)_ Add docs for `Gauge` and `LineGauge` ([#514](https://github.com/ratatui/ratatui/issues/514))
 
-- [27c5637](https://github.com/ratatui-org/ratatui/commit/27c56376756b854db6d2fd8939419bd8578f8a90)
-  _(readme)_ Fix links to CONTRIBUTING.md and BREAKING-CHANGES.md ([#577](https://github.com/ratatui-org/ratatui/issues/577))
+- [27c5637](https://github.com/ratatui/ratatui/commit/27c56376756b854db6d2fd8939419bd8578f8a90)
+  _(readme)_ Fix links to CONTRIBUTING.md and BREAKING-CHANGES.md ([#577](https://github.com/ratatui/ratatui/issues/577))
 
-- [1947c58](https://github.com/ratatui-org/ratatui/commit/1947c58c60127ee7d1a72bcd408ee23062b8c4ec)
-  _(backend)_ Improve backend module docs ([#489](https://github.com/ratatui-org/ratatui/issues/489))
+- [1947c58](https://github.com/ratatui/ratatui/commit/1947c58c60127ee7d1a72bcd408ee23062b8c4ec)
+  _(backend)_ Improve backend module docs ([#489](https://github.com/ratatui/ratatui/issues/489))
 
-- [e098731](https://github.com/ratatui-org/ratatui/commit/e098731d6c1a68a0319d544301ac91cf2d05ccb2)
-  _(barchart)_ Add documentation to `BarChart` ([#449](https://github.com/ratatui-org/ratatui/issues/449))
+- [e098731](https://github.com/ratatui/ratatui/commit/e098731d6c1a68a0319d544301ac91cf2d05ccb2)
+  _(barchart)_ Add documentation to `BarChart` ([#449](https://github.com/ratatui/ratatui/issues/449))
 
   ```text
   Add documentation to the `BarChart` widgets and its sub-modules.
   ```
 
-- [17797d8](https://github.com/ratatui-org/ratatui/commit/17797d83dab07dc6b76e7a3838e3e17fc3c94711)
-  _(canvas)_ Add support note for Braille marker ([#472](https://github.com/ratatui-org/ratatui/issues/472))
+- [17797d8](https://github.com/ratatui/ratatui/commit/17797d83dab07dc6b76e7a3838e3e17fc3c94711)
+  _(canvas)_ Add support note for Braille marker ([#472](https://github.com/ratatui/ratatui/issues/472))
 
-- [3cf0b83](https://github.com/ratatui-org/ratatui/commit/3cf0b83bda5deee18b8a1233acec0a21fde1f5f4)
-  _(color)_ Document true color support ([#477](https://github.com/ratatui-org/ratatui/issues/477))
+- [3cf0b83](https://github.com/ratatui/ratatui/commit/3cf0b83bda5deee18b8a1233acec0a21fde1f5f4)
+  _(color)_ Document true color support ([#477](https://github.com/ratatui/ratatui/issues/477))
 
   ```text
   * refactor(style): move Color to separate color mod
@@ -4204,53 +4207,53 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   * docs(color): document true color support
   ```
 
-- [e5caf17](https://github.com/ratatui-org/ratatui/commit/e5caf170c8c304b952cbff7499fd4da17ab154ea)
-  _(custom_widget)_ Make button sticky when clicking with mouse ([#561](https://github.com/ratatui-org/ratatui/issues/561))
+- [e5caf17](https://github.com/ratatui/ratatui/commit/e5caf170c8c304b952cbff7499fd4da17ab154ea)
+  _(custom_widget)_ Make button sticky when clicking with mouse ([#561](https://github.com/ratatui/ratatui/issues/561))
 
-- [ad2dc56](https://github.com/ratatui-org/ratatui/commit/ad2dc5646dae04fa5502e677182cdeb0c3630cce)
-  _(examples)_ Update examples readme ([#576](https://github.com/ratatui-org/ratatui/issues/576))
+- [ad2dc56](https://github.com/ratatui/ratatui/commit/ad2dc5646dae04fa5502e677182cdeb0c3630cce)
+  _(examples)_ Update examples readme ([#576](https://github.com/ratatui/ratatui/issues/576))
 
   ```text
   remove VHS bug info, tweak colors_rgb image, update some of the instructions. add demo2
   ```
 
-- [b61f65b](https://github.com/ratatui-org/ratatui/commit/b61f65bc20918380f2854253d4301ea804fc7437)
-  _(examples)_ Update theme to Aardvark Blue ([#574](https://github.com/ratatui-org/ratatui/issues/574))
+- [b61f65b](https://github.com/ratatui/ratatui/commit/b61f65bc20918380f2854253d4301ea804fc7437)
+  _(examples)_ Update theme to Aardvark Blue ([#574](https://github.com/ratatui/ratatui/issues/574))
 
   ```text
   This is a nicer theme that makes the colors pop
   ```
 
-- [61af0d9](https://github.com/ratatui-org/ratatui/commit/61af0d99069ec99b3075cd499ede13cc2143401f)
-  _(examples)_ Make custom widget example into a button ([#539](https://github.com/ratatui-org/ratatui/issues/539))
+- [61af0d9](https://github.com/ratatui/ratatui/commit/61af0d99069ec99b3075cd499ede13cc2143401f)
+  _(examples)_ Make custom widget example into a button ([#539](https://github.com/ratatui/ratatui/issues/539))
 
   ```text
   The widget also now supports mouse
   ```
 
-- [6b8725f](https://github.com/ratatui-org/ratatui/commit/6b8725f09173f418e9f17933d8ef8c943af444de)
-  _(examples)_ Add colors_rgb example ([#476](https://github.com/ratatui-org/ratatui/issues/476))
+- [6b8725f](https://github.com/ratatui/ratatui/commit/6b8725f09173f418e9f17933d8ef8c943af444de)
+  _(examples)_ Add colors_rgb example ([#476](https://github.com/ratatui/ratatui/issues/476))
 
-- [5c785b2](https://github.com/ratatui-org/ratatui/commit/5c785b22709fb64a0982722e4f6d0021ccf621b2)
-  _(examples)_ Move example gifs to github ([#460](https://github.com/ratatui-org/ratatui/issues/460))
+- [5c785b2](https://github.com/ratatui/ratatui/commit/5c785b22709fb64a0982722e4f6d0021ccf621b2)
+  _(examples)_ Move example gifs to github ([#460](https://github.com/ratatui/ratatui/issues/460))
 
   ```text
   - A new orphan branch named "images" is created to store the example
     images
   ```
 
-- [ca9bcd3](https://github.com/ratatui-org/ratatui/commit/ca9bcd3156f55cd2df4edf003aa1401abbed9b12)
-  _(examples)_ Add descriptions and update theme ([#460](https://github.com/ratatui-org/ratatui/issues/460))
+- [ca9bcd3](https://github.com/ratatui/ratatui/commit/ca9bcd3156f55cd2df4edf003aa1401abbed9b12)
+  _(examples)_ Add descriptions and update theme ([#460](https://github.com/ratatui/ratatui/issues/460))
 
   ```text
   - Use the OceanicMaterial consistently in examples
   ```
 
-- [080a05b](https://github.com/ratatui-org/ratatui/commit/080a05bbd3357cde3f0a02721a0f7f1aa206206b)
-  _(paragraph)_ Add docs for alignment fn ([#467](https://github.com/ratatui-org/ratatui/issues/467))
+- [080a05b](https://github.com/ratatui/ratatui/commit/080a05bbd3357cde3f0a02721a0f7f1aa206206b)
+  _(paragraph)_ Add docs for alignment fn ([#467](https://github.com/ratatui/ratatui/issues/467))
 
-- [1e20475](https://github.com/ratatui-org/ratatui/commit/1e204750617acccf952b1845a3c7ce86e2b90cf7)
-  _(stylize)_ Improve docs for style shorthands ([#491](https://github.com/ratatui-org/ratatui/issues/491))
+- [1e20475](https://github.com/ratatui/ratatui/commit/1e204750617acccf952b1845a3c7ce86e2b90cf7)
+  _(stylize)_ Improve docs for style shorthands ([#491](https://github.com/ratatui/ratatui/issues/491))
 
   ```text
   The Stylize trait was introduced in 0.22 to make styling less verbose.
@@ -4258,73 +4261,73 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   types to make this easier to discover.
   ```
 
-- [dd9a8df](https://github.com/ratatui-org/ratatui/commit/dd9a8df03ab09d2381ef5ddd0c2b6ef5517b44df)
-  _(table)_ Add documentation for `block` and `header` methods of the `Table` widget ([#505](https://github.com/ratatui-org/ratatui/issues/505))
+- [dd9a8df](https://github.com/ratatui/ratatui/commit/dd9a8df03ab09d2381ef5ddd0c2b6ef5517b44df)
+  _(table)_ Add documentation for `block` and `header` methods of the `Table` widget ([#505](https://github.com/ratatui/ratatui/issues/505))
 
-- [232be80](https://github.com/ratatui-org/ratatui/commit/232be80325cb899359ea1389516c421e57bc9cce)
-  _(table)_ Add documentation for `Table::new()` ([#471](https://github.com/ratatui-org/ratatui/issues/471))
+- [232be80](https://github.com/ratatui/ratatui/commit/232be80325cb899359ea1389516c421e57bc9cce)
+  _(table)_ Add documentation for `Table::new()` ([#471](https://github.com/ratatui/ratatui/issues/471))
 
-- [3bda372](https://github.com/ratatui-org/ratatui/commit/3bda37284781b62560cde2a7fa774211f651ec25)
-  _(tabs)_ Add documentation to `Tabs` ([#535](https://github.com/ratatui-org/ratatui/issues/535))
+- [3bda372](https://github.com/ratatui/ratatui/commit/3bda37284781b62560cde2a7fa774211f651ec25)
+  _(tabs)_ Add documentation to `Tabs` ([#535](https://github.com/ratatui/ratatui/issues/535))
 
-- [42f8169](https://github.com/ratatui-org/ratatui/commit/42f816999e2cd573c498c4885069a5523707663c)
-  _(terminal)_ Add docs for terminal module ([#486](https://github.com/ratatui-org/ratatui/issues/486))
+- [42f8169](https://github.com/ratatui/ratatui/commit/42f816999e2cd573c498c4885069a5523707663c)
+  _(terminal)_ Add docs for terminal module ([#486](https://github.com/ratatui/ratatui/issues/486))
 
   ```text
   - moves the impl Terminal block up to be closer to the type definition
   ```
 
-- [28e7fd4](https://github.com/ratatui-org/ratatui/commit/28e7fd4bc58edf537b66b69095691ae06872acd8)
-  _(terminal)_ Fix doc comment ([#452](https://github.com/ratatui-org/ratatui/issues/452))
+- [28e7fd4](https://github.com/ratatui/ratatui/commit/28e7fd4bc58edf537b66b69095691ae06872acd8)
+  _(terminal)_ Fix doc comment ([#452](https://github.com/ratatui/ratatui/issues/452))
 
-- [51fdcbe](https://github.com/ratatui-org/ratatui/commit/51fdcbe7e936b3af3ee6a8ae8fee43df31aab27c)
-  _(title)_ Add documentation to title ([#443](https://github.com/ratatui-org/ratatui/issues/443))
+- [51fdcbe](https://github.com/ratatui/ratatui/commit/51fdcbe7e936b3af3ee6a8ae8fee43df31aab27c)
+  _(title)_ Add documentation to title ([#443](https://github.com/ratatui/ratatui/issues/443))
 
   ```text
   This adds documentation for Title and Position
   ```
 
-- [d4976d4](https://github.com/ratatui-org/ratatui/commit/d4976d4b63d4a17adb31bbe853a82109e2caaf1b)
-  _(widgets)_ Update the list of available widgets ([#496](https://github.com/ratatui-org/ratatui/issues/496))
+- [d4976d4](https://github.com/ratatui/ratatui/commit/d4976d4b63d4a17adb31bbe853a82109e2caaf1b)
+  _(widgets)_ Update the list of available widgets ([#496](https://github.com/ratatui/ratatui/issues/496))
 
-- [6c7bef8](https://github.com/ratatui-org/ratatui/commit/6c7bef8d111bbc3ecfe228b14002c5db9634841c)
-  _(uncategorized)_ Replace colons with dashes in README.md for consistency ([#566](https://github.com/ratatui-org/ratatui/issues/566))
+- [6c7bef8](https://github.com/ratatui/ratatui/commit/6c7bef8d111bbc3ecfe228b14002c5db9634841c)
+  _(uncategorized)_ Replace colons with dashes in README.md for consistency ([#566](https://github.com/ratatui/ratatui/issues/566))
 
-- [88ae348](https://github.com/ratatui-org/ratatui/commit/88ae3485c2c540b4ee630ab13e613e84efa7440a)
-  _(uncategorized)_ Update `Frame` docstring to remove reference to generic backend ([#564](https://github.com/ratatui-org/ratatui/issues/564))
+- [88ae348](https://github.com/ratatui/ratatui/commit/88ae3485c2c540b4ee630ab13e613e84efa7440a)
+  _(uncategorized)_ Update `Frame` docstring to remove reference to generic backend ([#564](https://github.com/ratatui/ratatui/issues/564))
 
-- [089f8ba](https://github.com/ratatui-org/ratatui/commit/089f8ba66a50847780c4416b9b8833778a95e558)
-  _(uncategorized)_ Add double quotes to instructions for features ([#560](https://github.com/ratatui-org/ratatui/issues/560))
+- [089f8ba](https://github.com/ratatui/ratatui/commit/089f8ba66a50847780c4416b9b8833778a95e558)
+  _(uncategorized)_ Add double quotes to instructions for features ([#560](https://github.com/ratatui/ratatui/issues/560))
 
-- [346e7b4](https://github.com/ratatui-org/ratatui/commit/346e7b4f4d53063ee13b04758b1b994e4f14e51c)
-  _(uncategorized)_ Add summary to breaking changes ([#549](https://github.com/ratatui-org/ratatui/issues/549))
+- [346e7b4](https://github.com/ratatui/ratatui/commit/346e7b4f4d53063ee13b04758b1b994e4f14e51c)
+  _(uncategorized)_ Add summary to breaking changes ([#549](https://github.com/ratatui/ratatui/issues/549))
 
-- [401a7a7](https://github.com/ratatui-org/ratatui/commit/401a7a7f7111989d7dda11524b211a488483e732)
-  _(uncategorized)_ Improve clarity in documentation for `Frame` and `Terminal` 📚 ([#545](https://github.com/ratatui-org/ratatui/issues/545))
+- [401a7a7](https://github.com/ratatui/ratatui/commit/401a7a7f7111989d7dda11524b211a488483e732)
+  _(uncategorized)_ Improve clarity in documentation for `Frame` and `Terminal` 📚 ([#545](https://github.com/ratatui/ratatui/issues/545))
 
-- [e35e413](https://github.com/ratatui-org/ratatui/commit/e35e4135c9080389baa99e13814aace7784d9cb3)
-  _(uncategorized)_ Fix terminal comment ([#547](https://github.com/ratatui-org/ratatui/issues/547))
+- [e35e413](https://github.com/ratatui/ratatui/commit/e35e4135c9080389baa99e13814aace7784d9cb3)
+  _(uncategorized)_ Fix terminal comment ([#547](https://github.com/ratatui/ratatui/issues/547))
 
-- [8ae4403](https://github.com/ratatui-org/ratatui/commit/8ae4403b63a82d353b224c898b15249f30215476)
-  _(uncategorized)_ Fix `Terminal` docstring ([#546](https://github.com/ratatui-org/ratatui/issues/546))
+- [8ae4403](https://github.com/ratatui/ratatui/commit/8ae4403b63a82d353b224c898b15249f30215476)
+  _(uncategorized)_ Fix `Terminal` docstring ([#546](https://github.com/ratatui/ratatui/issues/546))
 
-- [9cfb133](https://github.com/ratatui-org/ratatui/commit/9cfb133a981c070a27342d78f4b9451673d8b349)
-  _(uncategorized)_ Document alpha release process ([#542](https://github.com/ratatui-org/ratatui/issues/542))
+- [9cfb133](https://github.com/ratatui/ratatui/commit/9cfb133a981c070a27342d78f4b9451673d8b349)
+  _(uncategorized)_ Document alpha release process ([#542](https://github.com/ratatui/ratatui/issues/542))
 
   ```text
-  Fixes https://github.com/ratatui-org/ratatui/issues/412
+  Fixes https://github.com/ratatui/ratatui/issues/412
   ```
 
-- [4548a9b](https://github.com/ratatui-org/ratatui/commit/4548a9b7e22b07c1bd6839280c44123b8679589d)
-  _(uncategorized)_ Add BREAKING-CHANGES.md ([#538](https://github.com/ratatui-org/ratatui/issues/538))
+- [4548a9b](https://github.com/ratatui/ratatui/commit/4548a9b7e22b07c1bd6839280c44123b8679589d)
+  _(uncategorized)_ Add BREAKING-CHANGES.md ([#538](https://github.com/ratatui/ratatui/issues/538))
 
   ```text
   Document the breaking changes in each version. This document is
   manually curated by summarizing the breaking changes in the changelog.
   ```
 
-- [c0991cc](https://github.com/ratatui-org/ratatui/commit/c0991cc576b3ade02494cb33fd7c290aba55bfb8)
-  _(uncategorized)_ Make library and README consistent ([#526](https://github.com/ratatui-org/ratatui/issues/526))
+- [c0991cc](https://github.com/ratatui/ratatui/commit/c0991cc576b3ade02494cb33fd7c290aba55bfb8)
+  _(uncategorized)_ Make library and README consistent ([#526](https://github.com/ratatui/ratatui/issues/526))
 
   ```text
   * docs: make library and README consistent
@@ -4339,8 +4342,8 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   - add docsrs example, vhs tape and images that will end up in the README
   ```
 
-- [1414fbc](https://github.com/ratatui-org/ratatui/commit/1414fbcc05b4dfd7706cc68fcaba7d883e22f869)
-  _(uncategorized)_ Import prelude::\* in doc examples ([#490](https://github.com/ratatui-org/ratatui/issues/490))
+- [1414fbc](https://github.com/ratatui/ratatui/commit/1414fbcc05b4dfd7706cc68fcaba7d883e22f869)
+  _(uncategorized)_ Import prelude::\* in doc examples ([#490](https://github.com/ratatui/ratatui/issues/490))
 
   ```text
   This commit adds `prelude::*` all doc examples and widget::* to those
@@ -4353,22 +4356,22 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
     than `prelude::*` and `widget::*`.
   ```
 
-- [74c5244](https://github.com/ratatui-org/ratatui/commit/74c5244be12031e372797c3c7949914552293f5c)
-  _(uncategorized)_ Add logo and favicon to docs.rs page ([#473](https://github.com/ratatui-org/ratatui/issues/473))
+- [74c5244](https://github.com/ratatui/ratatui/commit/74c5244be12031e372797c3c7949914552293f5c)
+  _(uncategorized)_ Add logo and favicon to docs.rs page ([#473](https://github.com/ratatui/ratatui/issues/473))
 
-- [927a5d8](https://github.com/ratatui-org/ratatui/commit/927a5d8251a7947446100f4bb4d7a8e3ec2ad962)
-  _(uncategorized)_ Fix documentation lint warnings ([#450](https://github.com/ratatui-org/ratatui/issues/450))
+- [927a5d8](https://github.com/ratatui/ratatui/commit/927a5d8251a7947446100f4bb4d7a8e3ec2ad962)
+  _(uncategorized)_ Fix documentation lint warnings ([#450](https://github.com/ratatui/ratatui/issues/450))
 
-- [eda2fb7](https://github.com/ratatui-org/ratatui/commit/eda2fb7077dcf0b158d1a69d2725aeb9464162be)
-  _(uncategorized)_ Use ratatui 📚 ([#446](https://github.com/ratatui-org/ratatui/issues/446))
+- [eda2fb7](https://github.com/ratatui/ratatui/commit/eda2fb7077dcf0b158d1a69d2725aeb9464162be)
+  _(uncategorized)_ Use ratatui 📚 ([#446](https://github.com/ratatui/ratatui/issues/446))
 
 ### Testing
 
-- [ea70bff](https://github.com/ratatui-org/ratatui/commit/ea70bffe5d3ec68dcf9eff015437d2474c08f855)
-  _(barchart)_ Add benchmarks ([#455](https://github.com/ratatui-org/ratatui/issues/455))
+- [ea70bff](https://github.com/ratatui/ratatui/commit/ea70bffe5d3ec68dcf9eff015437d2474c08f855)
+  _(barchart)_ Add benchmarks ([#455](https://github.com/ratatui/ratatui/issues/455))
 
-- [94af2a2](https://github.com/ratatui-org/ratatui/commit/94af2a29e10248ed709bbc8a7bf2f569894abc62)
-  _(buffer)_ Allow with_lines to accept Vec<Into<Line>> ([#494](https://github.com/ratatui-org/ratatui/issues/494))
+- [94af2a2](https://github.com/ratatui/ratatui/commit/94af2a29e10248ed709bbc8a7bf2f569894abc62)
+  _(buffer)_ Allow with_lines to accept Vec<Into<Line>> ([#494](https://github.com/ratatui/ratatui/issues/494))
 
   ```text
   This allows writing unit tests without having to call set_style on the
@@ -4377,11 +4380,11 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
 
 ### Miscellaneous Tasks
 
-- [1278131](https://github.com/ratatui-org/ratatui/commit/127813120eb17a7652b90e4333bb576e510ff51b)
-  _(changelog)_ Make the scopes lowercase in the changelog ([#479](https://github.com/ratatui-org/ratatui/issues/479))
+- [1278131](https://github.com/ratatui/ratatui/commit/127813120eb17a7652b90e4333bb576e510ff51b)
+  _(changelog)_ Make the scopes lowercase in the changelog ([#479](https://github.com/ratatui/ratatui/issues/479))
 
-- [82b40be](https://github.com/ratatui-org/ratatui/commit/82b40be4ab8aa735070dff1681c3d711147792e1)
-  _(ci)_ Improve checking the PR title ([#464](https://github.com/ratatui-org/ratatui/issues/464))
+- [82b40be](https://github.com/ratatui/ratatui/commit/82b40be4ab8aa735070dff1681c3d711147792e1)
+  _(ci)_ Improve checking the PR title ([#464](https://github.com/ratatui/ratatui/issues/464))
 
   ```text
   - Use [`action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request)
@@ -4389,8 +4392,8 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   - Enable merge group
   ```
 
-- [a20bd6a](https://github.com/ratatui-org/ratatui/commit/a20bd6adb5431d19140acdf1f9201381a31b2b24)
-  _(deps)_ Update lru requirement from 0.11.1 to 0.12.0 ([#581](https://github.com/ratatui-org/ratatui/issues/581))
+- [a20bd6a](https://github.com/ratatui/ratatui/commit/a20bd6adb5431d19140acdf1f9201381a31b2b24)
+  _(deps)_ Update lru requirement from 0.11.1 to 0.12.0 ([#581](https://github.com/ratatui/ratatui/issues/581))
 
   ```text
   Updates the requirements on [lru](https://github.com/jeromefroe/lru-rs) to permit the latest version.
@@ -4404,8 +4407,8 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   ...
   ```
 
-- [5213f78](https://github.com/ratatui-org/ratatui/commit/5213f78d25927d834ada29b8c1023fcba5c891c6)
-  _(deps)_ Bump actions/checkout from 3 to 4 ([#580](https://github.com/ratatui-org/ratatui/issues/580))
+- [5213f78](https://github.com/ratatui/ratatui/commit/5213f78d25927d834ada29b8c1023fcba5c891c6)
+  _(deps)_ Bump actions/checkout from 3 to 4 ([#580](https://github.com/ratatui/ratatui/issues/580))
 
   ```text
   Bumps [actions/checkout](https://github.com/actions/checkout) from 3 to 4.
@@ -4421,15 +4424,15 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   ...
   ```
 
-- [6cbdb06](https://github.com/ratatui-org/ratatui/commit/6cbdb06fd86858849d2454d09393a8e43c10741f)
-  _(examples)_ Refactor some examples ([#578](https://github.com/ratatui-org/ratatui/issues/578))
+- [6cbdb06](https://github.com/ratatui/ratatui/commit/6cbdb06fd86858849d2454d09393a8e43c10741f)
+  _(examples)_ Refactor some examples ([#578](https://github.com/ratatui/ratatui/issues/578))
 
   ```text
   * chore(examples): Simplify timeout calculation with `Duration::saturating_sub`
   ```
 
-- [12f9291](https://github.com/ratatui-org/ratatui/commit/12f92911c74211a22c6c142762ccb459d399763b)
-  _(github)_ Create dependabot.yml ([#575](https://github.com/ratatui-org/ratatui/issues/575))
+- [12f9291](https://github.com/ratatui/ratatui/commit/12f92911c74211a22c6c142762ccb459d399763b)
+  _(github)_ Create dependabot.yml ([#575](https://github.com/ratatui/ratatui/issues/575))
 
   ```text
   * chore: Create dependabot.yml
@@ -4437,11 +4440,11 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   * Update .github/dependabot.yml
   ```
 
-- [3a57e76](https://github.com/ratatui-org/ratatui/commit/3a57e76ed18b93f0bcee264d818a469920ce70db)
-  _(github)_ Add contact links for issues ([#567](https://github.com/ratatui-org/ratatui/issues/567))
+- [3a57e76](https://github.com/ratatui/ratatui/commit/3a57e76ed18b93f0bcee264d818a469920ce70db)
+  _(github)_ Add contact links for issues ([#567](https://github.com/ratatui/ratatui/issues/567))
 
-- [5498a88](https://github.com/ratatui-org/ratatui/commit/5498a889ae8bd4ccb51b04d3a848dd2f58935906)
-  _(spans)_ Remove deprecated `Spans` type ([#426](https://github.com/ratatui-org/ratatui/issues/426))
+- [5498a88](https://github.com/ratatui/ratatui/commit/5498a889ae8bd4ccb51b04d3a848dd2f58935906)
+  _(spans)_ Remove deprecated `Spans` type ([#426](https://github.com/ratatui/ratatui/issues/426))
 
   ```text
   The `Spans` type (plural, not singular) was replaced with a more ergonomic `Line` type
@@ -4452,46 +4455,46 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   - `Buffer::set_line` replaces `Buffer::set_spans`
   ```
 
-- [fbf1a45](https://github.com/ratatui-org/ratatui/commit/fbf1a451c85871db598cf1df2ad9a50edbe07cd2)
-  _(uncategorized)_ Simplify constraints ([#556](https://github.com/ratatui-org/ratatui/issues/556))
+- [fbf1a45](https://github.com/ratatui/ratatui/commit/fbf1a451c85871db598cf1df2ad9a50edbe07cd2)
+  _(uncategorized)_ Simplify constraints ([#556](https://github.com/ratatui/ratatui/issues/556))
 
   ```text
   Use bare arrays rather than array refs / Vecs for all constraint
   examples.
   ```
 
-- [a7bf4b3](https://github.com/ratatui-org/ratatui/commit/a7bf4b3f36f3281017d112ac1a67af7e82308261)
-  _(uncategorized)_ Use modern modules syntax ([#492](https://github.com/ratatui-org/ratatui/issues/492))
+- [a7bf4b3](https://github.com/ratatui/ratatui/commit/a7bf4b3f36f3281017d112ac1a67af7e82308261)
+  _(uncategorized)_ Use modern modules syntax ([#492](https://github.com/ratatui/ratatui/issues/492))
 
   ```text
   Move xxx/mod.rs to xxx.rs
   ```
 
-- [af36282](https://github.com/ratatui-org/ratatui/commit/af36282df5d8dd1b4e6b32bba0539dba3382c23c)
-  _(uncategorized)_ Only run check pr action on pull_request_target events ([#485](https://github.com/ratatui-org/ratatui/issues/485))
+- [af36282](https://github.com/ratatui/ratatui/commit/af36282df5d8dd1b4e6b32bba0539dba3382c23c)
+  _(uncategorized)_ Only run check pr action on pull_request_target events ([#485](https://github.com/ratatui/ratatui/issues/485))
 
-- [322e46f](https://github.com/ratatui-org/ratatui/commit/322e46f15d8326d18c951be4c57e3b47005285bc)
-  _(uncategorized)_ Prevent PR merge with do not merge labels ♻️ ([#484](https://github.com/ratatui-org/ratatui/issues/484))
+- [322e46f](https://github.com/ratatui/ratatui/commit/322e46f15d8326d18c951be4c57e3b47005285bc)
+  _(uncategorized)_ Prevent PR merge with do not merge labels ♻️ ([#484](https://github.com/ratatui/ratatui/issues/484))
 
-- [983ea7f](https://github.com/ratatui-org/ratatui/commit/983ea7f7a5371dd608891a0e2a7444a16e9fdc54)
-  _(uncategorized)_ Fix check for if breaking change label should be added ♻️ ([#483](https://github.com/ratatui-org/ratatui/issues/483))
+- [983ea7f](https://github.com/ratatui/ratatui/commit/983ea7f7a5371dd608891a0e2a7444a16e9fdc54)
+  _(uncategorized)_ Fix check for if breaking change label should be added ♻️ ([#483](https://github.com/ratatui/ratatui/issues/483))
 
-- [384e616](https://github.com/ratatui-org/ratatui/commit/384e616231c1579328e7a4ba1a7130f624753ad1)
-  _(uncategorized)_ Add a check for if breaking change label should be added ♻️ ([#481](https://github.com/ratatui-org/ratatui/issues/481))
+- [384e616](https://github.com/ratatui/ratatui/commit/384e616231c1579328e7a4ba1a7130f624753ad1)
+  _(uncategorized)_ Add a check for if breaking change label should be added ♻️ ([#481](https://github.com/ratatui/ratatui/issues/481))
 
-- [5f6aa30](https://github.com/ratatui-org/ratatui/commit/5f6aa30be54ea5dfcef730d709707a814e64deee)
-  _(uncategorized)_ Check documentation lint ([#454](https://github.com/ratatui-org/ratatui/issues/454))
+- [5f6aa30](https://github.com/ratatui/ratatui/commit/5f6aa30be54ea5dfcef730d709707a814e64deee)
+  _(uncategorized)_ Check documentation lint ([#454](https://github.com/ratatui/ratatui/issues/454))
 
-- [47ae602](https://github.com/ratatui-org/ratatui/commit/47ae602df43674928f10016e2edc97c550b01ba2)
-  _(uncategorized)_ Check that PR title matches conventional commit guidelines ♻️ ([#459](https://github.com/ratatui-org/ratatui/issues/459))
+- [47ae602](https://github.com/ratatui/ratatui/commit/47ae602df43674928f10016e2edc97c550b01ba2)
+  _(uncategorized)_ Check that PR title matches conventional commit guidelines ♻️ ([#459](https://github.com/ratatui/ratatui/issues/459))
 
-- [28c6157](https://github.com/ratatui-org/ratatui/commit/28c61571e8a90345a866285a6f8459b24b70578a)
-  _(uncategorized)_ Add documentation guidelines ([#447](https://github.com/ratatui-org/ratatui/issues/447))
+- [28c6157](https://github.com/ratatui/ratatui/commit/28c61571e8a90345a866285a6f8459b24b70578a)
+  _(uncategorized)_ Add documentation guidelines ([#447](https://github.com/ratatui/ratatui/issues/447))
 
 ### Continuous Integration
 
-- [343c6cd](https://github.com/ratatui-org/ratatui/commit/343c6cdc47c4fe38e64633d982aa413be356fb90)
-  _(lint)_ Move formatting and doc checks first ([#465](https://github.com/ratatui-org/ratatui/issues/465))
+- [343c6cd](https://github.com/ratatui/ratatui/commit/343c6cdc47c4fe38e64633d982aa413be356fb90)
+  _(lint)_ Move formatting and doc checks first ([#465](https://github.com/ratatui/ratatui/issues/465))
 
   ```text
   Putting the formatting and doc checks first to ensure that more critical
@@ -4499,15 +4502,15 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   not prevent the formatting and doc checks from running).
   ```
 
-- [c95a75c](https://github.com/ratatui-org/ratatui/commit/c95a75c5d5e0370c98a2a37bcbd65bde996b2306)
-  _(makefile)_ Remove termion dependency from doc lint ([#470](https://github.com/ratatui-org/ratatui/issues/470))
+- [c95a75c](https://github.com/ratatui/ratatui/commit/c95a75c5d5e0370c98a2a37bcbd65bde996b2306)
+  _(makefile)_ Remove termion dependency from doc lint ([#470](https://github.com/ratatui/ratatui/issues/470))
 
   ```text
   Only build termion on non-windows targets
   ```
 
-- [b996102](https://github.com/ratatui-org/ratatui/commit/b996102837dad7c77710bcbbc524c6e9691bd96f)
-  _(makefile)_ Add format target ([#468](https://github.com/ratatui-org/ratatui/issues/468))
+- [b996102](https://github.com/ratatui/ratatui/commit/b996102837dad7c77710bcbbc524c6e9691bd96f)
+  _(makefile)_ Add format target ([#468](https://github.com/ratatui/ratatui/issues/468))
 
   ```text
   - add format target to Makefile.toml that actually fixes the formatting
@@ -4518,11 +4521,11 @@ Also, we created various tutorials and walkthroughs in [Ratatui Book](https://gi
   - add section to CONTRIBUTING.md about formatting
   ```
 
-- [572df75](https://github.com/ratatui-org/ratatui/commit/572df758ba1056759aa6f79c9e975854d27331db)
-  _(uncategorized)_ Put commit id first in changelog ([#463](https://github.com/ratatui-org/ratatui/issues/463))
+- [572df75](https://github.com/ratatui/ratatui/commit/572df758ba1056759aa6f79c9e975854d27331db)
+  _(uncategorized)_ Put commit id first in changelog ([#463](https://github.com/ratatui/ratatui/issues/463))
 
-- [878b6fc](https://github.com/ratatui-org/ratatui/commit/878b6fc258110b41e85833c35150d7dfcedf31ca)
-  _(uncategorized)_ Ignore benches from code coverage ([#461](https://github.com/ratatui-org/ratatui/issues/461))
+- [878b6fc](https://github.com/ratatui/ratatui/commit/878b6fc258110b41e85833c35150d7dfcedf31ca)
+  _(uncategorized)_ Ignore benches from code coverage ([#461](https://github.com/ratatui/ratatui/issues/461))
 
 ### Contributors
 
@@ -4537,7 +4540,7 @@ Here is the list of contributors who have contributed to `ratatui` for the first
 - @[tz629](https://github.com/tz629)
 - @[hueblu](https://github.com/hueblu)
 
-## [v0.23.0](https://github.com/ratatui-org/ratatui/releases/tag/v0.23.0) - 2023-08-28
+## [v0.23.0](https://github.com/ratatui/ratatui/releases/tag/v0.23.0) - 2023-08-28
 
 We are thrilled to release the new version of `ratatui` 🐭, the official successor[\*](https://github.com/fdehau/tui-rs/commit/335f5a4563342f9a4ee19e2462059e1159dcbf25) of [`tui-rs`](https://github.com/fdehau/tui-rs).
 
@@ -4547,8 +4550,8 @@ Here is a blog post that highlights the new features and breaking changes along 
 
 ### Features
 
-- *(barchart)* Add direction attribute. (horizontal bars support) ([#325](https://github.com/ratatui-org/ratatui/issues/325))
-([0dca6a6](https://github.com/ratatui-org/ratatui/commit/0dca6a689a7af640c5de8f7c87c2f1e03f0adf25))
+- _(barchart)_ Add direction attribute. (horizontal bars support) ([#325](https://github.com/ratatui/ratatui/issues/325))
+([0dca6a6](https://github.com/ratatui/ratatui/commit/0dca6a689a7af640c5de8f7c87c2f1e03f0adf25))
 
   ````text
   * feat(barchart): Add direction attribute
@@ -4557,8 +4560,8 @@ Here is a blog post that highlights the new features and breaking changes along 
   make more efficient use of the available space.
   ````
 
-- *(cell)* Add voluntary skipping capability for sixel ([#215](https://github.com/ratatui-org/ratatui/issues/215))
-([e4bcf78](https://github.com/ratatui-org/ratatui/commit/e4bcf78afabe6b06970c51b4284246e345002cf5))
+- _(cell)_ Add voluntary skipping capability for sixel ([#215](https://github.com/ratatui/ratatui/issues/215))
+([e4bcf78](https://github.com/ratatui/ratatui/commit/e4bcf78afabe6b06970c51b4284246e345002cf5))
 
   ````text
   > Sixel is a bitmap graphics format supported by terminals.
@@ -4592,8 +4595,8 @@ Here is a blog post that highlights the new features and breaking changes along 
   https://github.com/benjajaja/ratatu-image.
   ````
 
-- *(list)* Add option to always allocate the "selection" column width ([#394](https://github.com/ratatui-org/ratatui/issues/394))
-([4d70169](https://github.com/ratatui-org/ratatui/commit/4d70169bef86898d331f46013ff72ef6d1c275ed))
+- _(list)_ Add option to always allocate the "selection" column width ([#394](https://github.com/ratatui/ratatui/issues/394))
+([4d70169](https://github.com/ratatui/ratatui/commit/4d70169bef86898d331f46013ff72ef6d1c275ed))
 
   ````text
   * feat(list): add option to always allocate the "selection" column width
@@ -4606,8 +4609,8 @@ Here is a blog post that highlights the new features and breaking changes along 
   * style: change "highlight_spacing" doc comment to use inline code-block for reference
   ````
 
-- *(release)* Add automated nightly releases ([#359](https://github.com/ratatui-org/ratatui/issues/359))
-([aad164a](https://github.com/ratatui-org/ratatui/commit/aad164a5311b0a6d6d3f752a87ed385d5f0c1962))
+- _(release)_ Add automated nightly releases ([#359](https://github.com/ratatui/ratatui/issues/359))
+([aad164a](https://github.com/ratatui/ratatui/commit/aad164a5311b0a6d6d3f752a87ed385d5f0c1962))
 
   ````text
   * feat(release): add automated nightly releases
@@ -4617,16 +4620,16 @@ Here is a blog post that highlights the new features and breaking changes along 
   * refactor(release): simplify the release calculation
   ````
 
-- *(scrollbar)* Add optional track symbol ([#360](https://github.com/ratatui-org/ratatui/issues/360))
-([1727fa5](https://github.com/ratatui-org/ratatui/commit/1727fa5120fa4bfcddd57484e532b2d5da88bc73)) [**breaking**]
+- _(scrollbar)_ Add optional track symbol ([#360](https://github.com/ratatui/ratatui/issues/360))
+([1727fa5](https://github.com/ratatui/ratatui/commit/1727fa5120fa4bfcddd57484e532b2d5da88bc73)) [**breaking**]
 
   ````text
   The track symbol is now optional, simplifying composition with other
   widgets.
   ````
 
-- *(table)* Add support for line alignment in the table widget ([#392](https://github.com/ratatui-org/ratatui/issues/392))
-([7748720](https://github.com/ratatui-org/ratatui/commit/77487209634f26da32bc59d9280769d80cc7c25c))
+- _(table)_ Add support for line alignment in the table widget ([#392](https://github.com/ratatui/ratatui/issues/392))
+([7748720](https://github.com/ratatui/ratatui/commit/77487209634f26da32bc59d9280769d80cc7c25c))
 
   ````text
   * feat(table): enforce line alignment in table render
@@ -4634,8 +4637,8 @@ Here is a blog post that highlights the new features and breaking changes along 
   * test(table): add table alignment render test
   ````
 
-- *(widgets::table)* Add option to always allocate the "selection" constraint ([#375](https://github.com/ratatui-org/ratatui/issues/375))
-([f63ac72](https://github.com/ratatui-org/ratatui/commit/f63ac72305f80062727d81996f9bdb523e666099))
+- _(widgets::table)_ Add option to always allocate the "selection" constraint ([#375](https://github.com/ratatui/ratatui/issues/375))
+([f63ac72](https://github.com/ratatui/ratatui/commit/f63ac72305f80062727d81996f9bdb523e666099))
 
   ````text
   * feat(table): add option to configure selection layout changes
@@ -4658,23 +4661,23 @@ Here is a blog post that highlights the new features and breaking changes along 
   * style(table): apply doc-comment suggestions from code review
   ````
 
-- *(uncategorized)* Expand serde attributes for `TestBuffer` ([#389](https://github.com/ratatui-org/ratatui/issues/389))
-([57ea871](https://github.com/ratatui-org/ratatui/commit/57ea871753a5b23f302c6f0a83d98f6a1988abfb))
+- _(uncategorized)_ Expand serde attributes for `TestBuffer` ([#389](https://github.com/ratatui/ratatui/issues/389))
+([57ea871](https://github.com/ratatui/ratatui/commit/57ea871753a5b23f302c6f0a83d98f6a1988abfb))
 
-- *(uncategorized)* Add weak constraints to make rects closer to each other in size ✨ ([#395](https://github.com/ratatui-org/ratatui/issues/395))
-([6153371](https://github.com/ratatui-org/ratatui/commit/61533712be57f3921217a905618b319975f90330))
+- _(uncategorized)_ Add weak constraints to make rects closer to each other in size ✨ ([#395](https://github.com/ratatui/ratatui/issues/395))
+([6153371](https://github.com/ratatui/ratatui/commit/61533712be57f3921217a905618b319975f90330))
 
   ````text
   Also make `Max` and `Min` constraints MEDIUM strength for higher priority over equal chunks
   ````
 
-- *(uncategorized)* Simplify split function ✨ ([#411](https://github.com/ratatui-org/ratatui/issues/411))
-([b090101](https://github.com/ratatui-org/ratatui/commit/b090101b231a467628c910f05a73715809cb8d73))
+- _(uncategorized)_ Simplify split function ✨ ([#411](https://github.com/ratatui/ratatui/issues/411))
+([b090101](https://github.com/ratatui/ratatui/commit/b090101b231a467628c910f05a73715809cb8d73))
 
 ### Bug Fixes
 
-- *(barchart)* Empty groups causes panic ([#333](https://github.com/ratatui-org/ratatui/issues/333))
-([9c95673](https://github.com/ratatui-org/ratatui/commit/9c956733f740b18616974e2c7d786ca761666f79))
+- _(barchart)_ Empty groups causes panic ([#333](https://github.com/ratatui/ratatui/issues/333))
+([9c95673](https://github.com/ratatui/ratatui/commit/9c956733f740b18616974e2c7d786ca761666f79))
 
   ````text
   This unlikely to happen, since nobody wants to add an empty group.
@@ -4682,25 +4685,25 @@ Here is a blog post that highlights the new features and breaking changes along 
   So it is better to just not add them to the BarChart.
   ````
 
-- *(block)* Fixed title_style not rendered ([#349](https://github.com/ratatui-org/ratatui/issues/349)) ([#363](https://github.com/ratatui-org/ratatui/issues/363))
-([49a82e0](https://github.com/ratatui-org/ratatui/commit/49a82e062f2c46dc3060cdfdb230b65d9dbfb2d9))
+- _(block)_ Fixed title_style not rendered ([#349](https://github.com/ratatui/ratatui/issues/349)) ([#363](https://github.com/ratatui/ratatui/issues/363))
+([49a82e0](https://github.com/ratatui/ratatui/commit/49a82e062f2c46dc3060cdfdb230b65d9dbfb2d9))
 
-- *(cargo)* Adjust minimum paste version ([#348](https://github.com/ratatui-org/ratatui/issues/348))
-([8db9fb4](https://github.com/ratatui-org/ratatui/commit/8db9fb4aebd01e5ddc4edd68482361928f7e9c97))
+- _(cargo)_ Adjust minimum paste version ([#348](https://github.com/ratatui/ratatui/issues/348))
+([8db9fb4](https://github.com/ratatui/ratatui/commit/8db9fb4aebd01e5ddc4edd68482361928f7e9c97))
 
   ````text
   ratatui is using features that are currently only available in paste 1.0.2; specifying the minimum version to be 1.0 will consequently cause a compilation error if cargo is only able to use a version less than 1.0.2.
   ````
 
-- *(example)* Fix typo ([#337](https://github.com/ratatui-org/ratatui/issues/337))
-([daf5890](https://github.com/ratatui-org/ratatui/commit/daf589015290ac8b379389d29ef90a1af15e3f75))
+- _(example)_ Fix typo ([#337](https://github.com/ratatui/ratatui/issues/337))
+([daf5890](https://github.com/ratatui/ratatui/commit/daf589015290ac8b379389d29ef90a1af15e3f75))
 
   ````text
   the existential feels
   ````
 
-- *(layout)* Don't leave gaps between chunks ([#408](https://github.com/ratatui-org/ratatui/issues/408))
-([56455e0](https://github.com/ratatui-org/ratatui/commit/56455e0fee57616f87ea43872fb7d5d9bb14aff5))
+- _(layout)_ Don't leave gaps between chunks ([#408](https://github.com/ratatui/ratatui/issues/408))
+([56455e0](https://github.com/ratatui/ratatui/commit/56455e0fee57616f87ea43872fb7d5d9bb14aff5))
 
   ````text
   Previously the layout used the floor of the calculated start and width
@@ -4721,30 +4724,30 @@ Here is a blog post that highlights the new features and breaking changes along 
   whereas previously it would have left odd gaps between columns.
   ````
 
-- *(layout)* Ensure left <= right ([#410](https://github.com/ratatui-org/ratatui/issues/410))
-([f4ed3b7](https://github.com/ratatui-org/ratatui/commit/f4ed3b758450ef9c257705f3a1ea937329a968b4))
+- _(layout)_ Ensure left <= right ([#410](https://github.com/ratatui/ratatui/issues/410))
+([f4ed3b7](https://github.com/ratatui/ratatui/commit/f4ed3b758450ef9c257705f3a1ea937329a968b4))
 
   ````text
   The recent refactor missed the positive width constraint
   ````
 
-- *(readme)* Fix typo in readme ([#344](https://github.com/ratatui-org/ratatui/issues/344))
-([d05ab6f](https://github.com/ratatui-org/ratatui/commit/d05ab6fb700527f0e062f334c7a5319c07099b04))
+- _(readme)_ Fix typo in readme ([#344](https://github.com/ratatui/ratatui/issues/344))
+([d05ab6f](https://github.com/ratatui/ratatui/commit/d05ab6fb700527f0e062f334c7a5319c07099b04))
 
-- *(readme)* Fix incorrect template link ([#338](https://github.com/ratatui-org/ratatui/issues/338))
-([b9290b3](https://github.com/ratatui-org/ratatui/commit/b9290b35d13df57726d65a16d3c8bb18ce43e8c2))
+- _(readme)_ Fix incorrect template link ([#338](https://github.com/ratatui/ratatui/issues/338))
+([b9290b3](https://github.com/ratatui/ratatui/commit/b9290b35d13df57726d65a16d3c8bb18ce43e8c2))
 
-- *(readme)* Fix typo in readme ([#336](https://github.com/ratatui-org/ratatui/issues/336))
-([7e37a96](https://github.com/ratatui-org/ratatui/commit/7e37a96678440bc62cce52de840fef82eed58dd8))
+- _(readme)_ Fix typo in readme ([#336](https://github.com/ratatui/ratatui/issues/336))
+([7e37a96](https://github.com/ratatui/ratatui/commit/7e37a96678440bc62cce52de840fef82eed58dd8))
 
-- *(release)* Fix the last tag retrieval for alpha releases ([#416](https://github.com/ratatui-org/ratatui/issues/416))
-([b6b2da5](https://github.com/ratatui-org/ratatui/commit/b6b2da5eb761ac5894cc7a2ee67f422312b63cfc))
+- _(release)_ Fix the last tag retrieval for alpha releases ([#416](https://github.com/ratatui/ratatui/issues/416))
+([b6b2da5](https://github.com/ratatui/ratatui/commit/b6b2da5eb761ac5894cc7a2ee67f422312b63cfc))
 
-- *(release)* Set the correct permissions for creating alpha releases ([#400](https://github.com/ratatui-org/ratatui/issues/400))
-([778c320](https://github.com/ratatui-org/ratatui/commit/778c32000815b9abb0246c73997b1800256aade2))
+- _(release)_ Set the correct permissions for creating alpha releases ([#400](https://github.com/ratatui/ratatui/issues/400))
+([778c320](https://github.com/ratatui/ratatui/commit/778c32000815b9abb0246c73997b1800256aade2))
 
-- *(scrollbar)* Move symbols to symbols module ([#330](https://github.com/ratatui-org/ratatui/issues/330))
-([7539f77](https://github.com/ratatui-org/ratatui/commit/7539f775fef4d816495e1e06732f6500cf08c126)) [**breaking**]
+- _(scrollbar)_ Move symbols to symbols module ([#330](https://github.com/ratatui/ratatui/issues/330))
+([7539f77](https://github.com/ratatui/ratatui/commit/7539f775fef4d816495e1e06732f6500cf08c126)) [**breaking**]
 
   ````text
   The symbols and sets are moved from `widgets::scrollbar` to
@@ -4753,8 +4756,8 @@ Here is a blog post that highlights the new features and breaking changes along 
   re-exporting it.
   ````
 
-- *(table)* Fix unit tests broken due to rounding ([#419](https://github.com/ratatui-org/ratatui/issues/419))
-([dc55211](https://github.com/ratatui-org/ratatui/commit/dc552116cf5e83c7ffcc2f5299c00d2315490c1d))
+- _(table)_ Fix unit tests broken due to rounding ([#419](https://github.com/ratatui/ratatui/issues/419))
+([dc55211](https://github.com/ratatui/ratatui/commit/dc552116cf5e83c7ffcc2f5299c00d2315490c1d))
 
   ````text
   The merge of the table unit tests after the rounding layout fix was not
@@ -4763,21 +4766,21 @@ Here is a blog post that highlights the new features and breaking changes along 
   is working as expected.
   ````
 
-- *(uncategorized)* Correct minor typos in documentation ([#331](https://github.com/ratatui-org/ratatui/issues/331))
-([13fb11a](https://github.com/ratatui-org/ratatui/commit/13fb11a62c826da412045d498a03673d130ec057))
+- _(uncategorized)_ Correct minor typos in documentation ([#331](https://github.com/ratatui/ratatui/issues/331))
+([13fb11a](https://github.com/ratatui/ratatui/commit/13fb11a62c826da412045d498a03673d130ec057))
 
 ### Refactor
 
-- *(barchart)* Reduce some calculations ([#430](https://github.com/ratatui-org/ratatui/issues/430))
-([fc727df](https://github.com/ratatui-org/ratatui/commit/fc727df7d2d8347434a7d3a4e19465b29d7a0ed8))
+- _(barchart)_ Reduce some calculations ([#430](https://github.com/ratatui/ratatui/issues/430))
+([fc727df](https://github.com/ratatui/ratatui/commit/fc727df7d2d8347434a7d3a4e19465b29d7a0ed8))
 
   ````text
   Calculating the label_offset is unnecessary, if we just render the
   group label after rendering the bars. We can just reuse bar_y.
   ````
 
-- *(layout)* Simplify and doc split() ([#405](https://github.com/ratatui-org/ratatui/issues/405))
-([de25de0](https://github.com/ratatui-org/ratatui/commit/de25de0a9506e53df1378929251594bccf63d932))
+- _(layout)_ Simplify and doc split() ([#405](https://github.com/ratatui/ratatui/issues/405))
+([de25de0](https://github.com/ratatui/ratatui/commit/de25de0a9506e53df1378929251594bccf63d932))
 
   ````text
   * test(layout): add tests for split()
@@ -4788,8 +4791,8 @@ Here is a blog post that highlights the new features and breaking changes along 
   improving mainatainability so that the algorithm is clear.
   ````
 
-- *(layout)* Simplify split() function ([#396](https://github.com/ratatui-org/ratatui/issues/396))
-([5195099](https://github.com/ratatui-org/ratatui/commit/519509945be866c3b2f6a4230ee317262266f894))
+- _(layout)_ Simplify split() function ([#396](https://github.com/ratatui/ratatui/issues/396))
+([5195099](https://github.com/ratatui/ratatui/commit/519509945be866c3b2f6a4230ee317262266f894))
 
   ````text
   Removes some unnecessary code and makes the function more readable.
@@ -4799,11 +4802,11 @@ Here is a blog post that highlights the new features and breaking changes along 
 
 ### Documentation
 
-- *(examples)* Fix the instructions for generating demo GIF ([#442](https://github.com/ratatui-org/ratatui/issues/442))
-([7a70602](https://github.com/ratatui-org/ratatui/commit/7a70602ec6bfcfec51bafd3bdbd35ff68b64340c))
+- _(examples)_ Fix the instructions for generating demo GIF ([#442](https://github.com/ratatui/ratatui/issues/442))
+([7a70602](https://github.com/ratatui/ratatui/commit/7a70602ec6bfcfec51bafd3bdbd35ff68b64340c))
 
-- *(examples)* Show layout constraints ([#393](https://github.com/ratatui-org/ratatui/issues/393))
-([10dbd6f](https://github.com/ratatui-org/ratatui/commit/10dbd6f2075285473ef47c4c898ef2f643180cd1))
+- _(examples)_ Show layout constraints ([#393](https://github.com/ratatui/ratatui/issues/393))
+([10dbd6f](https://github.com/ratatui/ratatui/commit/10dbd6f2075285473ef47c4c898ef2f643180cd1))
 
   ````text
   Shows the way that layout constraints interact visually
@@ -4811,8 +4814,8 @@ Here is a blog post that highlights the new features and breaking changes along 
   ![example](https://vhs.charm.sh/vhs-1ZNoNLNlLtkJXpgg9nCV5e.gif)
   ````
 
-- *(examples)* Add color and modifiers examples ([#345](https://github.com/ratatui-org/ratatui/issues/345))
-([6ad4bd4](https://github.com/ratatui-org/ratatui/commit/6ad4bd4cf2e7ea7548e49e64f92114c30d61ebb2))
+- _(examples)_ Add color and modifiers examples ([#345](https://github.com/ratatui/ratatui/issues/345))
+([6ad4bd4](https://github.com/ratatui/ratatui/commit/6ad4bd4cf2e7ea7548e49e64f92114c30d61ebb2))
 
   ````text
   The intent of these examples is to show the available colors and
@@ -4824,18 +4827,18 @@ Here is a blog post that highlights the new features and breaking changes along 
   ![modifiers](https://vhs.charm.sh/vhs-2ovGBz5l3tfRGdZ7FCw0am.gif)
   ````
 
-- *(examples)* Regen block.gif in readme ([#365](https://github.com/ratatui-org/ratatui/issues/365))
-([e82521e](https://github.com/ratatui-org/ratatui/commit/e82521ea798d1385f671e1849c48de42857bf87a))
+- _(examples)_ Regen block.gif in readme ([#365](https://github.com/ratatui/ratatui/issues/365))
+([e82521e](https://github.com/ratatui/ratatui/commit/e82521ea798d1385f671e1849c48de42857bf87a))
 
-- *(examples)* Update block example ([#351](https://github.com/ratatui-org/ratatui/issues/351))
-([554805d](https://github.com/ratatui-org/ratatui/commit/554805d6cbbf140c6da474daa891e9e754a5d281))
+- _(examples)_ Update block example ([#351](https://github.com/ratatui/ratatui/issues/351))
+([554805d](https://github.com/ratatui/ratatui/commit/554805d6cbbf140c6da474daa891e9e754a5d281))
 
   ````text
   ![Block example](https://vhs.charm.sh/vhs-5X6hpReuDBKjD6hLxmDQ6F.gif)
   ````
 
-- *(examples)* Add examples readme with gifs ([#303](https://github.com/ratatui-org/ratatui/issues/303))
-([add578a](https://github.com/ratatui-org/ratatui/commit/add578a7d6d342e3ebaa26e69452a2ab5b08b0c7))
+- _(examples)_ Add examples readme with gifs ([#303](https://github.com/ratatui/ratatui/issues/303))
+([add578a](https://github.com/ratatui/ratatui/commit/add578a7d6d342e3ebaa26e69452a2ab5b08b0c7))
 
   ````text
   This commit adds a readme to the examples directory with gifs of each
@@ -4856,14 +4859,14 @@ Here is a blog post that highlights the new features and breaking changes along 
   constrained on each block (which is now a paragraph with a block).
   ````
 
-- *(layout)* Add doc comments ([#403](https://github.com/ratatui-org/ratatui/issues/403))
-([418ed20](https://github.com/ratatui-org/ratatui/commit/418ed20479e060c1bd2f430ae127eae19a013afc))
+- _(layout)_ Add doc comments ([#403](https://github.com/ratatui/ratatui/issues/403))
+([418ed20](https://github.com/ratatui/ratatui/commit/418ed20479e060c1bd2f430ae127eae19a013afc))
 
-- *(layout::Constraint)* Add doc-comments for all variants ([#371](https://github.com/ratatui-org/ratatui/issues/371))
-([c8ddc16](https://github.com/ratatui-org/ratatui/commit/c8ddc164c7941c31b1b5fa82345e452923ec56e7))
+- _(layout::Constraint)_ Add doc-comments for all variants ([#371](https://github.com/ratatui/ratatui/issues/371))
+([c8ddc16](https://github.com/ratatui/ratatui/commit/c8ddc164c7941c31b1b5fa82345e452923ec56e7))
 
-- *(lib)* Extract feature documentation from Cargo.toml ([#438](https://github.com/ratatui-org/ratatui/issues/438))
-([8b36683](https://github.com/ratatui-org/ratatui/commit/8b36683571e078792b20d6f693b817522cf6e992))
+- _(lib)_ Extract feature documentation from Cargo.toml ([#438](https://github.com/ratatui/ratatui/issues/438))
+([8b36683](https://github.com/ratatui/ratatui/commit/8b36683571e078792b20d6f693b817522cf6e992))
 
   ````text
   * docs(lib): extract feature documentation from Cargo.toml
@@ -4873,11 +4876,11 @@ Here is a blog post that highlights the new features and breaking changes along 
   * docs(lib): document the serde feature from features section
   ````
 
-- *(paragraph)* Add more docs ([#428](https://github.com/ratatui-org/ratatui/issues/428))
-([6d6ecee](https://github.com/ratatui-org/ratatui/commit/6d6eceeb88b4da593c63dad258d2724cd583f9e0))
+- _(paragraph)_ Add more docs ([#428](https://github.com/ratatui/ratatui/issues/428))
+([6d6ecee](https://github.com/ratatui/ratatui/commit/6d6eceeb88b4da593c63dad258d2724cd583f9e0))
 
-- *(project)* Make the project description cooler ([#441](https://github.com/ratatui-org/ratatui/issues/441))
-([47fe4ad](https://github.com/ratatui-org/ratatui/commit/47fe4ad69f527fcbf879e9fec2a4d3702badc76b))
+- _(project)_ Make the project description cooler ([#441](https://github.com/ratatui/ratatui/issues/441))
+([47fe4ad](https://github.com/ratatui/ratatui/commit/47fe4ad69f527fcbf879e9fec2a4d3702badc76b))
 
   ````text
   * docs(project): make the project description cooler
@@ -4885,26 +4888,26 @@ Here is a blog post that highlights the new features and breaking changes along 
   * docs(lib): simplify description
   ````
 
-- *(readme)* Use the correct version for MSRV ([#369](https://github.com/ratatui-org/ratatui/issues/369))
-([3a37d2f](https://github.com/ratatui-org/ratatui/commit/3a37d2f6ede02fdde9ddffbb996059d6b95f98e7))
+- _(readme)_ Use the correct version for MSRV ([#369](https://github.com/ratatui/ratatui/issues/369))
+([3a37d2f](https://github.com/ratatui/ratatui/commit/3a37d2f6ede02fdde9ddffbb996059d6b95f98e7))
 
-- *(readme)* Fix widget docs links ([#346](https://github.com/ratatui-org/ratatui/issues/346))
-([2920e04](https://github.com/ratatui-org/ratatui/commit/2920e045ba23aa2eb3a4049625cd256ff37076c9))
+- _(readme)_ Fix widget docs links ([#346](https://github.com/ratatui/ratatui/issues/346))
+([2920e04](https://github.com/ratatui/ratatui/commit/2920e045ba23aa2eb3a4049625cd256ff37076c9))
 
   ````text
   Add scrollbar, clear. Fix Block link. Sort
   ````
 
-- *(span)* Update docs and tests for `Span` ([#427](https://github.com/ratatui-org/ratatui/issues/427))
-([d0ee04a](https://github.com/ratatui-org/ratatui/commit/d0ee04a69f30506fae706b429f15fe63b056b79e))
+- _(span)_ Update docs and tests for `Span` ([#427](https://github.com/ratatui/ratatui/issues/427))
+([d0ee04a](https://github.com/ratatui/ratatui/commit/d0ee04a69f30506fae706b429f15fe63b056b79e))
 
-- *(uncategorized)* Improve scrollbar doc comment ([#329](https://github.com/ratatui-org/ratatui/issues/329))
-([c3f87f2](https://github.com/ratatui-org/ratatui/commit/c3f87f245a5a2fc180d4c8f64557bcff716d09a9))
+- _(uncategorized)_ Improve scrollbar doc comment ([#329](https://github.com/ratatui/ratatui/issues/329))
+([c3f87f2](https://github.com/ratatui/ratatui/commit/c3f87f245a5a2fc180d4c8f64557bcff716d09a9))
 
 ### Performance
 
-- *(bench)* Used `iter_batched` to clone widgets in setup function ([#383](https://github.com/ratatui-org/ratatui/issues/383))
-([149d489](https://github.com/ratatui-org/ratatui/commit/149d48919d870e29a7f104664db11eb77fb951a8))
+- _(bench)_ Used `iter_batched` to clone widgets in setup function ([#383](https://github.com/ratatui/ratatui/issues/383))
+([149d489](https://github.com/ratatui/ratatui/commit/149d48919d870e29a7f104664db11eb77fb951a8))
 
   ````text
   Replaced `Bencher::iter` by `Bencher::iter_batched` to clone the widget in the setup function instead of in the benchmark timing.
@@ -4912,8 +4915,8 @@ Here is a blog post that highlights the new features and breaking changes along 
 
 ### Styling
 
-- *(paragraph)* Add documentation for "scroll"'s "offset" ([#355](https://github.com/ratatui-org/ratatui/issues/355))
-([ab5e616](https://github.com/ratatui-org/ratatui/commit/ab5e6166358b2e6f0e9601a1ec5480760b91ca8e))
+- _(paragraph)_ Add documentation for "scroll"'s "offset" ([#355](https://github.com/ratatui/ratatui/issues/355))
+([ab5e616](https://github.com/ratatui/ratatui/commit/ab5e6166358b2e6f0e9601a1ec5480760b91ca8e))
 
   ````text
   * style(paragraph): add documentation for "scroll"'s "offset"
@@ -4923,72 +4926,72 @@ Here is a blog post that highlights the new features and breaking changes along 
 
 ### Testing
 
-- *(block)* Test all block methods ([#431](https://github.com/ratatui-org/ratatui/issues/431))
-([a890f2a](https://github.com/ratatui-org/ratatui/commit/a890f2ac004b0e45db40de222fe3560fe0fdf94b))
+- _(block)_ Test all block methods ([#431](https://github.com/ratatui/ratatui/issues/431))
+([a890f2a](https://github.com/ratatui/ratatui/commit/a890f2ac004b0e45db40de222fe3560fe0fdf94b))
 
-- *(block)* Add benchmarks ([#368](https://github.com/ratatui-org/ratatui/issues/368))
-([e18393d](https://github.com/ratatui-org/ratatui/commit/e18393dbc6781a8b1266906e8ba7da019a0a5d82))
+- _(block)_ Add benchmarks ([#368](https://github.com/ratatui/ratatui/issues/368))
+([e18393d](https://github.com/ratatui/ratatui/commit/e18393dbc6781a8b1266906e8ba7da019a0a5d82))
 
   ````text
   Added benchmarks to the block widget to uncover eventual performance issues
   ````
 
-- *(canvas)* Add unit tests for line ([#437](https://github.com/ratatui-org/ratatui/issues/437))
-([ad3413e](https://github.com/ratatui-org/ratatui/commit/ad3413eeec9aab1568f8519caaf5efb951b2800c))
+- _(canvas)_ Add unit tests for line ([#437](https://github.com/ratatui/ratatui/issues/437))
+([ad3413e](https://github.com/ratatui/ratatui/commit/ad3413eeec9aab1568f8519caaf5efb951b2800c))
 
   ````text
   Also add constructor to simplify creating lines
   ````
 
-- *(canvas)* Add tests for rectangle ([#429](https://github.com/ratatui-org/ratatui/issues/429))
-([ad4d6e7](https://github.com/ratatui-org/ratatui/commit/ad4d6e7dec0f7e4c4e2e5624ccec54eb71c3f5ca))
+- _(canvas)_ Add tests for rectangle ([#429](https://github.com/ratatui/ratatui/issues/429))
+([ad4d6e7](https://github.com/ratatui/ratatui/commit/ad4d6e7dec0f7e4c4e2e5624ccec54eb71c3f5ca))
 
-- *(clear)* Test Clear rendering ([#432](https://github.com/ratatui-org/ratatui/issues/432))
-([e9bd736](https://github.com/ratatui-org/ratatui/commit/e9bd736b1a680204fa801a7208cddc477f208680))
+- _(clear)_ Test Clear rendering ([#432](https://github.com/ratatui/ratatui/issues/432))
+([e9bd736](https://github.com/ratatui/ratatui/commit/e9bd736b1a680204fa801a7208cddc477f208680))
 
-- *(list)* Added benchmarks ([#377](https://github.com/ratatui-org/ratatui/issues/377))
-([664fb4c](https://github.com/ratatui-org/ratatui/commit/664fb4cffd71c85da87545cb4258165c1a44afa6))
+- _(list)_ Added benchmarks ([#377](https://github.com/ratatui/ratatui/issues/377))
+([664fb4c](https://github.com/ratatui/ratatui/commit/664fb4cffd71c85da87545cb4258165c1a44afa6))
 
   ````text
   Added benchmarks for the list widget (render and render half scrolled)
   ````
 
-- *(map)* Add unit tests ([#436](https://github.com/ratatui-org/ratatui/issues/436))
-([f0716ed](https://github.com/ratatui-org/ratatui/commit/f0716edbcfd33d50e4e74eaf51fe5ad945dab6b3))
+- _(map)_ Add unit tests ([#436](https://github.com/ratatui/ratatui/issues/436))
+([f0716ed](https://github.com/ratatui/ratatui/commit/f0716edbcfd33d50e4e74eaf51fe5ad945dab6b3))
 
-- *(sparkline)* Added benchmark ([#384](https://github.com/ratatui-org/ratatui/issues/384))
-([3293c6b](https://github.com/ratatui-org/ratatui/commit/3293c6b80b0505f9ed031fc8d9678e3db627b7ad))
+- _(sparkline)_ Added benchmark ([#384](https://github.com/ratatui/ratatui/issues/384))
+([3293c6b](https://github.com/ratatui/ratatui/commit/3293c6b80b0505f9ed031fc8d9678e3db627b7ad))
 
   ````text
   Added benchmark for the `sparkline` widget testing a basic render with different amount of data
   ````
 
-- *(styled_grapheme)* Test StyledGrapheme methods ([#433](https://github.com/ratatui-org/ratatui/issues/433))
-([292a11d](https://github.com/ratatui-org/ratatui/commit/292a11d81e2f8c7676cc897f3493b75903025766))
+- _(styled_grapheme)_ Test StyledGrapheme methods ([#433](https://github.com/ratatui/ratatui/issues/433))
+([292a11d](https://github.com/ratatui/ratatui/commit/292a11d81e2f8c7676cc897f3493b75903025766))
 
-- *(table)* Add test for consistent table-column-width ([#404](https://github.com/ratatui-org/ratatui/issues/404))
-([4cd843e](https://github.com/ratatui-org/ratatui/commit/4cd843eda97abbc8fa7af85a03c2fffafce3c676))
+- _(table)_ Add test for consistent table-column-width ([#404](https://github.com/ratatui/ratatui/issues/404))
+([4cd843e](https://github.com/ratatui/ratatui/commit/4cd843eda97abbc8fa7af85a03c2fffafce3c676))
 
-- *(tabs)* Add unit tests ([#439](https://github.com/ratatui-org/ratatui/issues/439))
-([14eb6b6](https://github.com/ratatui-org/ratatui/commit/14eb6b69796550648f7d0d0427384b64c31e36d8))
+- _(tabs)_ Add unit tests ([#439](https://github.com/ratatui/ratatui/issues/439))
+([14eb6b6](https://github.com/ratatui/ratatui/commit/14eb6b69796550648f7d0d0427384b64c31e36d8))
 
-- *(test_backend)* Add tests for TestBackend coverage ([#434](https://github.com/ratatui-org/ratatui/issues/434))
-([b35f19e](https://github.com/ratatui-org/ratatui/commit/b35f19ec442d3eb4810f6181e03ba0d4c077b768))
+- _(test_backend)_ Add tests for TestBackend coverage ([#434](https://github.com/ratatui/ratatui/issues/434))
+([b35f19e](https://github.com/ratatui/ratatui/commit/b35f19ec442d3eb4810f6181e03ba0d4c077b768))
 
   ````text
   These are mostly to catch any future bugs introduced in the test backend
   ````
 
-- *(text)* Add unit tests ([#435](https://github.com/ratatui-org/ratatui/issues/435))
-([fc9f637](https://github.com/ratatui-org/ratatui/commit/fc9f637fb08fdc2959a52ed3eb12643565c634d9))
+- _(text)_ Add unit tests ([#435](https://github.com/ratatui/ratatui/issues/435))
+([fc9f637](https://github.com/ratatui/ratatui/commit/fc9f637fb08fdc2959a52ed3eb12643565c634d9))
 
 ### Miscellaneous Tasks
 
-- *(changelog)* Ignore alpha tags ([#440](https://github.com/ratatui-org/ratatui/issues/440))
-([6009844](https://github.com/ratatui-org/ratatui/commit/6009844e256cf926039fa969b9ad8896e2289213))
+- _(changelog)_ Ignore alpha tags ([#440](https://github.com/ratatui/ratatui/issues/440))
+([6009844](https://github.com/ratatui/ratatui/commit/6009844e256cf926039fa969b9ad8896e2289213))
 
-- *(changelog)* Show full commit message ([#423](https://github.com/ratatui-org/ratatui/issues/423))
-([a937500](https://github.com/ratatui-org/ratatui/commit/a937500ae4ac0a60fc5db82f6ce105a1154215f6))
+- _(changelog)_ Show full commit message ([#423](https://github.com/ratatui/ratatui/issues/423))
+([a937500](https://github.com/ratatui/ratatui/commit/a937500ae4ac0a60fc5db82f6ce105a1154215f6))
 
   ````text
   This allows someone reading the changelog to search for information
@@ -5000,48 +5003,48 @@ Here is a blog post that highlights the new features and breaking changes along 
   - Automatically changed the existing * lists to - lists
   ````
 
-- *(ci)* Update the name of the CI workflow ([#417](https://github.com/ratatui-org/ratatui/issues/417))
-([89ef0e2](https://github.com/ratatui-org/ratatui/commit/89ef0e29f56078ed0629f2dce89656c1131ebda1))
+- _(ci)_ Update the name of the CI workflow ([#417](https://github.com/ratatui/ratatui/issues/417))
+([89ef0e2](https://github.com/ratatui/ratatui/commit/89ef0e29f56078ed0629f2dce89656c1131ebda1))
 
-- *(codecov)* Fix yaml syntax ([#407](https://github.com/ratatui-org/ratatui/issues/407))
-([ea48af1](https://github.com/ratatui-org/ratatui/commit/ea48af1c9abac7012e3bf79e78c6179f889a6321))
+- _(codecov)_ Fix yaml syntax ([#407](https://github.com/ratatui/ratatui/issues/407))
+([ea48af1](https://github.com/ratatui/ratatui/commit/ea48af1c9abac7012e3bf79e78c6179f889a6321))
 
   ````text
   a yaml file cannot contain tabs outside of strings
   ````
 
-- *(docs)* Add doc comment bump to release documentation ([#382](https://github.com/ratatui-org/ratatui/issues/382))
-([8b28672](https://github.com/ratatui-org/ratatui/commit/8b286721314142dc7078354015db909e6938068c))
+- _(docs)_ Add doc comment bump to release documentation ([#382](https://github.com/ratatui/ratatui/issues/382))
+([8b28672](https://github.com/ratatui/ratatui/commit/8b286721314142dc7078354015db909e6938068c))
 
-- *(github)* Add kdheepak as a maintainer ([#343](https://github.com/ratatui-org/ratatui/issues/343))
-([60a4131](https://github.com/ratatui-org/ratatui/commit/60a4131384e6c0b38b6a6e933e62646b5265ca60))
+- _(github)_ Add kdheepak as a maintainer ([#343](https://github.com/ratatui/ratatui/issues/343))
+([60a4131](https://github.com/ratatui/ratatui/commit/60a4131384e6c0b38b6a6e933e62646b5265ca60))
 
-- *(github)* Rename `tui-rs-revival` references to `ratatui-org` ([#340](https://github.com/ratatui-org/ratatui/issues/340))
-([964190a](https://github.com/ratatui-org/ratatui/commit/964190a859e6479f22c6ccae8305192f548fbcc3))
+- _(github)_ Rename `tui-rs-revival` references to `ratatui-org` ([#340](https://github.com/ratatui/ratatui/issues/340))
+([964190a](https://github.com/ratatui/ratatui/commit/964190a859e6479f22c6ccae8305192f548fbcc3))
 
-- *(make)* Add task descriptions to Makefile.toml ([#398](https://github.com/ratatui-org/ratatui/issues/398))
-([268bbed](https://github.com/ratatui-org/ratatui/commit/268bbed17e0ebc18b39f3253c9beb92c21946c80))
+- _(make)_ Add task descriptions to Makefile.toml ([#398](https://github.com/ratatui/ratatui/issues/398))
+([268bbed](https://github.com/ratatui/ratatui/commit/268bbed17e0ebc18b39f3253c9beb92c21946c80))
 
-- *(toolchain)* Bump msrv to 1.67 ([#361](https://github.com/ratatui-org/ratatui/issues/361))
-([8cd3205](https://github.com/ratatui-org/ratatui/commit/8cd3205d70a1395d2c60fc26d76c300a2a463c9e)) [**breaking**]
+- _(toolchain)_ Bump msrv to 1.67 ([#361](https://github.com/ratatui/ratatui/issues/361))
+([8cd3205](https://github.com/ratatui/ratatui/commit/8cd3205d70a1395d2c60fc26d76c300a2a463c9e)) [**breaking**]
 
   ````text
   * chore(toolchain)!: bump msrv to 1.67
   ````
 
-- *(traits)* Add Display and FromStr traits ([#425](https://github.com/ratatui-org/ratatui/issues/425))
-([98155dc](https://github.com/ratatui-org/ratatui/commit/98155dce25bbc0e8fe271735024a1f6bf2279d67))
+- _(traits)_ Add Display and FromStr traits ([#425](https://github.com/ratatui/ratatui/issues/425))
+([98155dc](https://github.com/ratatui/ratatui/commit/98155dce25bbc0e8fe271735024a1f6bf2279d67))
 
   ````text
   Use strum for most of these, with a couple of manual implementations,
   and related tests
   ````
 
-- *(uncategorized)* Create rust-toolchain.toml ([#415](https://github.com/ratatui-org/ratatui/issues/415))
-([d2429bc](https://github.com/ratatui-org/ratatui/commit/d2429bc3e44a34197511192dbd215dd32fdf2d9c))
+- _(uncategorized)_ Create rust-toolchain.toml ([#415](https://github.com/ratatui/ratatui/issues/415))
+([d2429bc](https://github.com/ratatui/ratatui/commit/d2429bc3e44a34197511192dbd215dd32fdf2d9c))
 
-- *(uncategorized)* Use vhs to create demo.gif ([#390](https://github.com/ratatui-org/ratatui/issues/390))
-([8c55158](https://github.com/ratatui-org/ratatui/commit/8c551588224ca97ee07948b445aa2ac9d05f997d))
+- _(uncategorized)_ Use vhs to create demo.gif ([#390](https://github.com/ratatui/ratatui/issues/390))
+([8c55158](https://github.com/ratatui/ratatui/commit/8c551588224ca97ee07948b445aa2ac9d05f997d))
 
   ````text
   The bug that prevented braille rendering is fixed, so switch to VHS for
@@ -5050,8 +5053,8 @@ Here is a blog post that highlights the new features and breaking changes along 
   ![Demo of Ratatui](https://vhs.charm.sh/vhs-tF0QbuPbtHgUeG0sTVgFr.gif)
   ````
 
-- *(uncategorized)* Implement `Hash` common traits ([#381](https://github.com/ratatui-org/ratatui/issues/381))
-([8c4a2e0](https://github.com/ratatui-org/ratatui/commit/8c4a2e0fbfd021f1e087bb7256d9c6457742ea39))
+- _(uncategorized)_ Implement `Hash` common traits ([#381](https://github.com/ratatui/ratatui/issues/381))
+([8c4a2e0](https://github.com/ratatui/ratatui/commit/8c4a2e0fbfd021f1e087bb7256d9c6457742ea39))
 
   ````text
   Reorder the derive fields to be more consistent:
@@ -5063,8 +5066,8 @@ Here is a blog post that highlights the new features and breaking changes along 
   we should consider wrap f64 into a new type.
   ````
 
-- *(uncategorized)* Implement `Eq & PartialEq` common traits ([#357](https://github.com/ratatui-org/ratatui/issues/357))
-([181706c](https://github.com/ratatui-org/ratatui/commit/181706c564d86e02991f89ec674b1af1d7f393fe))
+- _(uncategorized)_ Implement `Eq & PartialEq` common traits ([#357](https://github.com/ratatui/ratatui/issues/357))
+([181706c](https://github.com/ratatui/ratatui/commit/181706c564d86e02991f89ec674b1af1d7f393fe))
 
   ````text
   Reorder the derive fields to be more consistent:
@@ -5072,8 +5075,8 @@ Here is a blog post that highlights the new features and breaking changes along 
       Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash
   ````
 
-- *(uncategorized)* Implement `Clone & Copy` common traits ([#350](https://github.com/ratatui-org/ratatui/issues/350))
-([440f62f](https://github.com/ratatui-org/ratatui/commit/440f62ff5435af9536c55d17707a9bc48dae92cc))
+- _(uncategorized)_ Implement `Clone & Copy` common traits ([#350](https://github.com/ratatui/ratatui/issues/350))
+([440f62f](https://github.com/ratatui/ratatui/commit/440f62ff5435af9536c55d17707a9bc48dae92cc))
 
   ````text
   Implement `Clone & Copy` common traits for most structs in src.
@@ -5085,8 +5088,8 @@ Here is a blog post that highlights the new features and breaking changes along 
       Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash
   ````
 
-- *(uncategorized)* Implement `Debug & Default` common traits ([#339](https://github.com/ratatui-org/ratatui/issues/339))
-([bf49446](https://github.com/ratatui-org/ratatui/commit/bf4944683d6afb6f42bec80a1bd308ecdac50cbc))
+- _(uncategorized)_ Implement `Debug & Default` common traits ([#339](https://github.com/ratatui/ratatui/issues/339))
+([bf49446](https://github.com/ratatui/ratatui/commit/bf4944683d6afb6f42bec80a1bd308ecdac50cbc))
 
   ````text
   Implement `Debug & Default` common traits for most structs in src.
@@ -5098,18 +5101,18 @@ Here is a blog post that highlights the new features and breaking changes along 
 
 ### Build
 
-- *(deps)* Upgrade crossterm to 0.27 ([#380](https://github.com/ratatui-org/ratatui/issues/380))
-([37fa6ab](https://github.com/ratatui-org/ratatui/commit/37fa6abe9d5dc459dc9855ea10f06afa72717c98))
+- _(deps)_ Upgrade crossterm to 0.27 ([#380](https://github.com/ratatui/ratatui/issues/380))
+([37fa6ab](https://github.com/ratatui/ratatui/commit/37fa6abe9d5dc459dc9855ea10f06afa72717c98))
 
-- *(examples)* Fix cargo make run-examples ([#327](https://github.com/ratatui-org/ratatui/issues/327))
-([e2cb11c](https://github.com/ratatui-org/ratatui/commit/e2cb11cc30072d90b20e04270c1fa97c18ab6f3f))
+- _(examples)_ Fix cargo make run-examples ([#327](https://github.com/ratatui/ratatui/issues/327))
+([e2cb11c](https://github.com/ratatui/ratatui/commit/e2cb11cc30072d90b20e04270c1fa97c18ab6f3f))
 
   ````text
   Enables the all-widgets feature so that the calendar example runs correctly
   ````
 
-- *(uncategorized)* Forbid unsafe code ([#332](https://github.com/ratatui-org/ratatui/issues/332))
-([0fb1ed8](https://github.com/ratatui-org/ratatui/commit/0fb1ed85c6232966ab25c8b3cab0fc277e9b69a6))
+- _(uncategorized)_ Forbid unsafe code ([#332](https://github.com/ratatui/ratatui/issues/332))
+([0fb1ed8](https://github.com/ratatui/ratatui/commit/0fb1ed85c6232966ab25c8b3cab0fc277e9b69a6))
 
   ````text
   This indicates good (high level) code and is used by tools like cargo-geiger.
@@ -5117,11 +5120,11 @@ Here is a blog post that highlights the new features and breaking changes along 
 
 ### Continuous Integration
 
-- *(coverage)* Exclude examples directory from coverage ([#373](https://github.com/ratatui-org/ratatui/issues/373))
-([de9f52f](https://github.com/ratatui-org/ratatui/commit/de9f52ff2cc606e1bf6b6bd8b97907afd73860fe))
+- _(coverage)_ Exclude examples directory from coverage ([#373](https://github.com/ratatui/ratatui/issues/373))
+([de9f52f](https://github.com/ratatui/ratatui/commit/de9f52ff2cc606e1bf6b6bd8b97907afd73860fe))
 
-- *(uncategorized)* Don't fail fast ([#364](https://github.com/ratatui-org/ratatui/issues/364))
-([9191ad6](https://github.com/ratatui-org/ratatui/commit/9191ad60fd4fc3ddf8650a8f5eed87216a0e5c6f))
+- _(uncategorized)_ Don't fail fast ([#364](https://github.com/ratatui/ratatui/issues/364))
+([9191ad6](https://github.com/ratatui/ratatui/commit/9191ad60fd4fc3ddf8650a8f5eed87216a0e5c6f))
 
   ````text
   Run all the tests rather than canceling when one test fails. This allows
@@ -5130,8 +5133,8 @@ Here is a blog post that highlights the new features and breaking changes along 
   toolchain or backend.
   ````
 
-- *(uncategorized)* Add coverage token ([#352](https://github.com/ratatui-org/ratatui/issues/352))
-([6f659cf](https://github.com/ratatui-org/ratatui/commit/6f659cfb07aad5ad2524f32fe46c45b84c8e9e34))
+- _(uncategorized)_ Add coverage token ([#352](https://github.com/ratatui/ratatui/issues/352))
+([6f659cf](https://github.com/ratatui/ratatui/commit/6f659cfb07aad5ad2524f32fe46c45b84c8e9e34))
 
 ### Contributors
 
@@ -5155,93 +5158,93 @@ Here is the list of contributors who have contributed to `ratatui` for the first
 
 ### Features
 
-- *(barchart)* Set custom text value in the bar ([#309](https://github.com/ratatui-org/ratatui/issues/309))
-- *(barchart)* Enable barchart groups ([#288](https://github.com/ratatui-org/ratatui/issues/288))
-- *(block)* Support for having more than one title ([#232](https://github.com/ratatui-org/ratatui/issues/232))
-- *(examples)* User_input example cursor movement ([#302](https://github.com/ratatui-org/ratatui/issues/302))
-- *(misc)* Make builder fn const ([#275](https://github.com/ratatui-org/ratatui/issues/275)) ([#275](https://github.com/ratatui-org/ratatui/issues/275))
-- *(prelude)* Add a prelude ([#304](https://github.com/ratatui-org/ratatui/issues/304))
-- *(style)* Enable setting the underline color for crossterm ([#308](https://github.com/ratatui-org/ratatui/issues/308)) ([#310](https://github.com/ratatui-org/ratatui/issues/310))
-- *(style)* Allow Modifiers add/remove in const ([#287](https://github.com/ratatui-org/ratatui/issues/287))
-- *(stylize)* Allow all widgets to be styled ([#289](https://github.com/ratatui-org/ratatui/issues/289))
-- *(terminal)* Expose 'swap_buffers' method
-- *(uncategorized)* Stylization shorthands ([#283](https://github.com/ratatui-org/ratatui/issues/283))
-- *(uncategorized)* Add scrollbar widget ([#228](https://github.com/ratatui-org/ratatui/issues/228))
+- _(barchart)_ Set custom text value in the bar ([#309](https://github.com/ratatui/ratatui/issues/309))
+- _(barchart)_ Enable barchart groups ([#288](https://github.com/ratatui/ratatui/issues/288))
+- _(block)_ Support for having more than one title ([#232](https://github.com/ratatui/ratatui/issues/232))
+- _(examples)_ User_input example cursor movement ([#302](https://github.com/ratatui/ratatui/issues/302))
+- _(misc)_ Make builder fn const ([#275](https://github.com/ratatui/ratatui/issues/275)) ([#275](https://github.com/ratatui/ratatui/issues/275))
+- _(prelude)_ Add a prelude ([#304](https://github.com/ratatui/ratatui/issues/304))
+- _(style)_ Enable setting the underline color for crossterm ([#308](https://github.com/ratatui/ratatui/issues/308)) ([#310](https://github.com/ratatui/ratatui/issues/310))
+- _(style)_ Allow Modifiers add/remove in const ([#287](https://github.com/ratatui/ratatui/issues/287))
+- _(stylize)_ Allow all widgets to be styled ([#289](https://github.com/ratatui/ratatui/issues/289))
+- _(terminal)_ Expose 'swap_buffers' method
+- _(uncategorized)_ Stylization shorthands ([#283](https://github.com/ratatui/ratatui/issues/283))
+- _(uncategorized)_ Add scrollbar widget ([#228](https://github.com/ratatui/ratatui/issues/228))
 
 ### Bug Fixes
 
-- *(clippy)* Unused_mut lint for layout ([#285](https://github.com/ratatui-org/ratatui/issues/285))
-- *(examples)* Correct progress label in gague example ([#263](https://github.com/ratatui-org/ratatui/issues/263))
-- *(layout)* Cap Constraint::apply to 100% length ([#264](https://github.com/ratatui-org/ratatui/issues/264))
-- *(lint)* Suspicious_double_ref_op is new in 1.71 ([#311](https://github.com/ratatui-org/ratatui/issues/311))
-- *(prelude)* Remove widgets module from prelude ([#317](https://github.com/ratatui-org/ratatui/issues/317))
-- *(title)* Remove default alignment and position ([#323](https://github.com/ratatui-org/ratatui/issues/323))
-- *(typos)* Configure typos linter ([#233](https://github.com/ratatui-org/ratatui/issues/233))
-- *(uncategorized)* Rust-tui-template became a revival project ([#320](https://github.com/ratatui-org/ratatui/issues/320))
-- *(uncategorized)* Revert removal of WTFPL from deny.toml ([#266](https://github.com/ratatui-org/ratatui/issues/266))
+- _(clippy)_ Unused_mut lint for layout ([#285](https://github.com/ratatui/ratatui/issues/285))
+- _(examples)_ Correct progress label in gague example ([#263](https://github.com/ratatui/ratatui/issues/263))
+- _(layout)_ Cap Constraint::apply to 100% length ([#264](https://github.com/ratatui/ratatui/issues/264))
+- _(lint)_ Suspicious_double_ref_op is new in 1.71 ([#311](https://github.com/ratatui/ratatui/issues/311))
+- _(prelude)_ Remove widgets module from prelude ([#317](https://github.com/ratatui/ratatui/issues/317))
+- _(title)_ Remove default alignment and position ([#323](https://github.com/ratatui/ratatui/issues/323))
+- _(typos)_ Configure typos linter ([#233](https://github.com/ratatui/ratatui/issues/233))
+- _(uncategorized)_ Rust-tui-template became a revival project ([#320](https://github.com/ratatui/ratatui/issues/320))
+- _(uncategorized)_ Revert removal of WTFPL from deny.toml ([#266](https://github.com/ratatui/ratatui/issues/266))
 
 ### Refactor
 
-- *(ci)* Simplify cargo-make installation ([#240](https://github.com/ratatui-org/ratatui/issues/240))
-- *(text)* Simplify reflow implementation ([#290](https://github.com/ratatui-org/ratatui/issues/290))
+- _(ci)_ Simplify cargo-make installation ([#240](https://github.com/ratatui/ratatui/issues/240))
+- _(text)_ Simplify reflow implementation ([#290](https://github.com/ratatui/ratatui/issues/290))
 
 ### Documentation
 
-- *(color)* Parse more color formats and add docs ([#306](https://github.com/ratatui-org/ratatui/issues/306))
-- *(lib)* Add `tui-term` a pseudoterminal library ([#268](https://github.com/ratatui-org/ratatui/issues/268))
-- *(lib)* Fixup tui refs in widgets/mod.rs ([#216](https://github.com/ratatui-org/ratatui/issues/216))
-- *(lib)* Add backend docs ([#213](https://github.com/ratatui-org/ratatui/issues/213))
-- *(readme)* Remove duplicated mention of tui-rs-tree-widgets ([#223](https://github.com/ratatui-org/ratatui/issues/223))
-- *(uncategorized)* Improve CONTRIBUTING.md ([#277](https://github.com/ratatui-org/ratatui/issues/277))
-- *(uncategorized)* Fix scrollbar ascii illustrations and calendar doc paths ([#272](https://github.com/ratatui-org/ratatui/issues/272))
-- *(uncategorized)* README tweaks ([#225](https://github.com/ratatui-org/ratatui/issues/225))
-- *(uncategorized)* Add CODEOWNERS file ([#212](https://github.com/ratatui-org/ratatui/issues/212))
-- *(uncategorized)* Update README.md and add hello_world example ([#204](https://github.com/ratatui-org/ratatui/issues/204))
+- _(color)_ Parse more color formats and add docs ([#306](https://github.com/ratatui/ratatui/issues/306))
+- _(lib)_ Add `tui-term` a pseudoterminal library ([#268](https://github.com/ratatui/ratatui/issues/268))
+- _(lib)_ Fixup tui refs in widgets/mod.rs ([#216](https://github.com/ratatui/ratatui/issues/216))
+- _(lib)_ Add backend docs ([#213](https://github.com/ratatui/ratatui/issues/213))
+- _(readme)_ Remove duplicated mention of tui-rs-tree-widgets ([#223](https://github.com/ratatui/ratatui/issues/223))
+- _(uncategorized)_ Improve CONTRIBUTING.md ([#277](https://github.com/ratatui/ratatui/issues/277))
+- _(uncategorized)_ Fix scrollbar ascii illustrations and calendar doc paths ([#272](https://github.com/ratatui/ratatui/issues/272))
+- _(uncategorized)_ README tweaks ([#225](https://github.com/ratatui/ratatui/issues/225))
+- _(uncategorized)_ Add CODEOWNERS file ([#212](https://github.com/ratatui/ratatui/issues/212))
+- _(uncategorized)_ Update README.md and add hello_world example ([#204](https://github.com/ratatui/ratatui/issues/204))
 
 ### Styling
 
-- *(comments)* Set comment length to wrap at 100 chars ([#218](https://github.com/ratatui-org/ratatui/issues/218))
-- *(config)* Apply formatting to config files ([#238](https://github.com/ratatui-org/ratatui/issues/238))
-- *(manifest)* Apply formatting to Cargo.toml ([#237](https://github.com/ratatui-org/ratatui/issues/237))
-- *(readme)* Update the style of badges in README.md ([#299](https://github.com/ratatui-org/ratatui/issues/299))
-- *(widget)* Inline format arguments ([#279](https://github.com/ratatui-org/ratatui/issues/279))
-- *(uncategorized)* Fix formatting ([#292](https://github.com/ratatui-org/ratatui/issues/292))
-- *(uncategorized)* Reformat imports ([#219](https://github.com/ratatui-org/ratatui/issues/219))
+- _(comments)_ Set comment length to wrap at 100 chars ([#218](https://github.com/ratatui/ratatui/issues/218))
+- _(config)_ Apply formatting to config files ([#238](https://github.com/ratatui/ratatui/issues/238))
+- _(manifest)_ Apply formatting to Cargo.toml ([#237](https://github.com/ratatui/ratatui/issues/237))
+- _(readme)_ Update the style of badges in README.md ([#299](https://github.com/ratatui/ratatui/issues/299))
+- _(widget)_ Inline format arguments ([#279](https://github.com/ratatui/ratatui/issues/279))
+- _(uncategorized)_ Fix formatting ([#292](https://github.com/ratatui/ratatui/issues/292))
+- _(uncategorized)_ Reformat imports ([#219](https://github.com/ratatui/ratatui/issues/219))
 
 ### Testing
 
-- *(barchart)* Add unit tests ([#301](https://github.com/ratatui-org/ratatui/issues/301))
-- *(paragraph)* Simplify paragraph benchmarks ([#282](https://github.com/ratatui-org/ratatui/issues/282))
-- *(uncategorized)* Add benchmarks for paragraph ([#262](https://github.com/ratatui-org/ratatui/issues/262))
+- _(barchart)_ Add unit tests ([#301](https://github.com/ratatui/ratatui/issues/301))
+- _(paragraph)_ Simplify paragraph benchmarks ([#282](https://github.com/ratatui/ratatui/issues/282))
+- _(uncategorized)_ Add benchmarks for paragraph ([#262](https://github.com/ratatui/ratatui/issues/262))
 
 ### Miscellaneous Tasks
 
-- *(ci)* Bump cargo-make version ([#239](https://github.com/ratatui-org/ratatui/issues/239))
-- *(ci)* Enable merge queue for builds ([#235](https://github.com/ratatui-org/ratatui/issues/235))
-- *(ci)* Integrate cargo-deny for linting dependencies ([#221](https://github.com/ratatui-org/ratatui/issues/221))
-- *(commitizen)* Add commitizen config ([#222](https://github.com/ratatui-org/ratatui/issues/222))
-- *(demo)* Update demo gif ([#234](https://github.com/ratatui-org/ratatui/issues/234))
-- *(demo)* Update demo gif with a fixed unicode gauge ([#227](https://github.com/ratatui-org/ratatui/issues/227))
-- *(features)* Enable building with all-features ([#286](https://github.com/ratatui-org/ratatui/issues/286))
-- *(github)* Add EditorConfig config ([#300](https://github.com/ratatui-org/ratatui/issues/300))
-- *(github)* Simplify the CODEOWNERS file ([#271](https://github.com/ratatui-org/ratatui/issues/271))
-- *(github)* Add pull request template ([#269](https://github.com/ratatui-org/ratatui/issues/269))
-- *(github)* Fix the syntax in CODEOWNERS file ([#236](https://github.com/ratatui-org/ratatui/issues/236))
-- *(license)* Add Ratatui developers to license ([#297](https://github.com/ratatui-org/ratatui/issues/297))
-- *(tests)* Add coverage job to bacon ([#312](https://github.com/ratatui-org/ratatui/issues/312))
-- *(uncategorized)* Lint and doc cleanup ([#191](https://github.com/ratatui-org/ratatui/issues/191))
+- _(ci)_ Bump cargo-make version ([#239](https://github.com/ratatui/ratatui/issues/239))
+- _(ci)_ Enable merge queue for builds ([#235](https://github.com/ratatui/ratatui/issues/235))
+- _(ci)_ Integrate cargo-deny for linting dependencies ([#221](https://github.com/ratatui/ratatui/issues/221))
+- _(commitizen)_ Add commitizen config ([#222](https://github.com/ratatui/ratatui/issues/222))
+- _(demo)_ Update demo gif ([#234](https://github.com/ratatui/ratatui/issues/234))
+- _(demo)_ Update demo gif with a fixed unicode gauge ([#227](https://github.com/ratatui/ratatui/issues/227))
+- _(features)_ Enable building with all-features ([#286](https://github.com/ratatui/ratatui/issues/286))
+- _(github)_ Add EditorConfig config ([#300](https://github.com/ratatui/ratatui/issues/300))
+- _(github)_ Simplify the CODEOWNERS file ([#271](https://github.com/ratatui/ratatui/issues/271))
+- _(github)_ Add pull request template ([#269](https://github.com/ratatui/ratatui/issues/269))
+- _(github)_ Fix the syntax in CODEOWNERS file ([#236](https://github.com/ratatui/ratatui/issues/236))
+- _(license)_ Add Ratatui developers to license ([#297](https://github.com/ratatui/ratatui/issues/297))
+- _(tests)_ Add coverage job to bacon ([#312](https://github.com/ratatui/ratatui/issues/312))
+- _(uncategorized)_ Lint and doc cleanup ([#191](https://github.com/ratatui/ratatui/issues/191))
 
 ### Build
 
-- *(deps)* Upgrade bitflags to 2.3 ([#205](https://github.com/ratatui-org/ratatui/issues/205)) [**breaking**]
-- *(uncategorized)* Add git pre-push hooks using cargo-husky ([#274](https://github.com/ratatui-org/ratatui/issues/274))
+- _(deps)_ Upgrade bitflags to 2.3 ([#205](https://github.com/ratatui/ratatui/issues/205)) [**breaking**]
+- _(uncategorized)_ Add git pre-push hooks using cargo-husky ([#274](https://github.com/ratatui/ratatui/issues/274))
 
 ### Continuous Integration
 
-- *(makefile)* Split CI jobs ([#278](https://github.com/ratatui-org/ratatui/issues/278))
-- *(uncategorized)* Parallelize CI jobs ([#318](https://github.com/ratatui-org/ratatui/issues/318))
-- *(uncategorized)* Add feat-wrapping on push and on pull request ci triggers ([#267](https://github.com/ratatui-org/ratatui/issues/267))
-- *(uncategorized)* Add code coverage action ([#209](https://github.com/ratatui-org/ratatui/issues/209))
+- _(makefile)_ Split CI jobs ([#278](https://github.com/ratatui/ratatui/issues/278))
+- _(uncategorized)_ Parallelize CI jobs ([#318](https://github.com/ratatui/ratatui/issues/318))
+- _(uncategorized)_ Add feat-wrapping on push and on pull request ci triggers ([#267](https://github.com/ratatui/ratatui/issues/267))
+- _(uncategorized)_ Add code coverage action ([#209](https://github.com/ratatui/ratatui/issues/209))
 
 ### Contributors
 
@@ -5265,75 +5268,75 @@ Here is the list of contributors who have contributed to `ratatui` for the first
 
 ### Features
 
-- *(backend)* Add termwiz backend and example ([#5](https://github.com/ratatui-org/ratatui/issues/5))
-- *(block)* Support placing the title on bottom ([#36](https://github.com/ratatui-org/ratatui/issues/36))
-- *(border)* Add border! macro for easy bitflag manipulation ([#11](https://github.com/ratatui-org/ratatui/issues/11))
-- *(calendar)* Add calendar widget ([#138](https://github.com/ratatui-org/ratatui/issues/138))
-- *(color)* Add `FromStr` implementation for `Color` ([#180](https://github.com/ratatui-org/ratatui/issues/180))
-- *(list)* Add len() to List ([#24](https://github.com/ratatui-org/ratatui/pull/24))
-- *(paragraph)* Allow Lines to be individually aligned ([#149](https://github.com/ratatui-org/ratatui/issues/149))
-- *(sparkline)* Finish #1 Sparkline directions PR ([#134](https://github.com/ratatui-org/ratatui/issues/134))
-- *(terminal)* Add inline viewport ([#114](https://github.com/ratatui-org/ratatui/issues/114)) [**breaking**]
-- *(test)* Expose test buffer ([#160](https://github.com/ratatui-org/ratatui/issues/160))
-- *(text)* Add `Masked` to display secure data ([#168](https://github.com/ratatui-org/ratatui/issues/168)) [**breaking**]
-- *(widget)* Add circle widget ([#159](https://github.com/ratatui-org/ratatui/issues/159))
-- *(widget)* Add style methods to Span, Spans, Text ([#148](https://github.com/ratatui-org/ratatui/issues/148))
-- *(widget)* Support adding padding to Block ([#20](https://github.com/ratatui-org/ratatui/issues/20))
-- *(widget)* Add offset() and offset_mut() for table and list state ([#12](https://github.com/ratatui-org/ratatui/issues/12))
+- _(backend)_ Add termwiz backend and example ([#5](https://github.com/ratatui/ratatui/issues/5))
+- _(block)_ Support placing the title on bottom ([#36](https://github.com/ratatui/ratatui/issues/36))
+- _(border)_ Add border! macro for easy bitflag manipulation ([#11](https://github.com/ratatui/ratatui/issues/11))
+- _(calendar)_ Add calendar widget ([#138](https://github.com/ratatui/ratatui/issues/138))
+- _(color)_ Add `FromStr` implementation for `Color` ([#180](https://github.com/ratatui/ratatui/issues/180))
+- _(list)_ Add len() to List ([#24](https://github.com/ratatui/ratatui/pull/24))
+- _(paragraph)_ Allow Lines to be individually aligned ([#149](https://github.com/ratatui/ratatui/issues/149))
+- _(sparkline)_ Finish #1 Sparkline directions PR ([#134](https://github.com/ratatui/ratatui/issues/134))
+- _(terminal)_ Add inline viewport ([#114](https://github.com/ratatui/ratatui/issues/114)) [**breaking**]
+- _(test)_ Expose test buffer ([#160](https://github.com/ratatui/ratatui/issues/160))
+- _(text)_ Add `Masked` to display secure data ([#168](https://github.com/ratatui/ratatui/issues/168)) [**breaking**]
+- _(widget)_ Add circle widget ([#159](https://github.com/ratatui/ratatui/issues/159))
+- _(widget)_ Add style methods to Span, Spans, Text ([#148](https://github.com/ratatui/ratatui/issues/148))
+- _(widget)_ Support adding padding to Block ([#20](https://github.com/ratatui/ratatui/issues/20))
+- _(widget)_ Add offset() and offset_mut() for table and list state ([#12](https://github.com/ratatui/ratatui/issues/12))
 
 ### Bug Fixes
 
-- *(canvas)* Use full block for Marker::Block ([#133](https://github.com/ratatui-org/ratatui/issues/133)) [**breaking**]
-- *(example)* Update input in examples to only use press events ([#129](https://github.com/ratatui-org/ratatui/issues/129))
-- *(uncategorized)* Cleanup doc example ([#145](https://github.com/ratatui-org/ratatui/issues/145))
-- *(reflow)* Remove debug macro call ([#198](https://github.com/ratatui-org/ratatui/issues/198))
+- _(canvas)_ Use full block for Marker::Block ([#133](https://github.com/ratatui/ratatui/issues/133)) [**breaking**]
+- _(example)_ Update input in examples to only use press events ([#129](https://github.com/ratatui/ratatui/issues/129))
+- _(uncategorized)_ Cleanup doc example ([#145](https://github.com/ratatui/ratatui/issues/145))
+- _(reflow)_ Remove debug macro call ([#198](https://github.com/ratatui/ratatui/issues/198))
 
 ### Refactor
 
-- *(example)* Remove redundant `vec![]` in `user_input` example ([#26](https://github.com/ratatui-org/ratatui/issues/26))
-- *(example)* Refactor paragraph example ([#152](https://github.com/ratatui-org/ratatui/issues/152))
-- *(style)* Mark some Style fns const so they can be defined globally ([#115](https://github.com/ratatui-org/ratatui/issues/115))
-- *(text)* Replace `Spans` with `Line` ([#178](https://github.com/ratatui-org/ratatui/issues/178))
+- _(example)_ Remove redundant `vec![]` in `user_input` example ([#26](https://github.com/ratatui/ratatui/issues/26))
+- _(example)_ Refactor paragraph example ([#152](https://github.com/ratatui/ratatui/issues/152))
+- _(style)_ Mark some Style fns const so they can be defined globally ([#115](https://github.com/ratatui/ratatui/issues/115))
+- _(text)_ Replace `Spans` with `Line` ([#178](https://github.com/ratatui/ratatui/issues/178))
 
 ### Documentation
 
-- *(apps)* Fix rsadsb/adsb_deku radar link ([#140](https://github.com/ratatui-org/ratatui/issues/140))
-- *(apps)* Add tenere ([#141](https://github.com/ratatui-org/ratatui/issues/141))
-- *(apps)* Add twitch-tui ([#124](https://github.com/ratatui-org/ratatui/issues/124))
-- *(apps)* Add oxycards ([#113](https://github.com/ratatui-org/ratatui/issues/113))
-- *(apps)* Re-add trippy to APPS.md ([#117](https://github.com/ratatui-org/ratatui/issues/117))
-- *(block)* Add example for block.inner ([#158](https://github.com/ratatui-org/ratatui/issues/158))
-- *(changelog)* Update the empty profile link in contributors ([#112](https://github.com/ratatui-org/ratatui/issues/112))
-- *(readme)* Fix small typo in readme ([#186](https://github.com/ratatui-org/ratatui/issues/186))
-- *(readme)* Add termwiz demo to examples ([#183](https://github.com/ratatui-org/ratatui/issues/183))
-- *(readme)* Add acknowledgement section ([#154](https://github.com/ratatui-org/ratatui/issues/154))
-- *(readme)* Update project description ([#127](https://github.com/ratatui-org/ratatui/issues/127))
-- *(uncategorized)* Scrape example code from examples/* ([#195](https://github.com/ratatui-org/ratatui/issues/195))
+- _(apps)_ Fix rsadsb/adsb_deku radar link ([#140](https://github.com/ratatui/ratatui/issues/140))
+- _(apps)_ Add tenere ([#141](https://github.com/ratatui/ratatui/issues/141))
+- _(apps)_ Add twitch-tui ([#124](https://github.com/ratatui/ratatui/issues/124))
+- _(apps)_ Add oxycards ([#113](https://github.com/ratatui/ratatui/issues/113))
+- _(apps)_ Re-add trippy to APPS.md ([#117](https://github.com/ratatui/ratatui/issues/117))
+- _(block)_ Add example for block.inner ([#158](https://github.com/ratatui/ratatui/issues/158))
+- _(changelog)_ Update the empty profile link in contributors ([#112](https://github.com/ratatui/ratatui/issues/112))
+- _(readme)_ Fix small typo in readme ([#186](https://github.com/ratatui/ratatui/issues/186))
+- _(readme)_ Add termwiz demo to examples ([#183](https://github.com/ratatui/ratatui/issues/183))
+- _(readme)_ Add acknowledgement section ([#154](https://github.com/ratatui/ratatui/issues/154))
+- _(readme)_ Update project description ([#127](https://github.com/ratatui/ratatui/issues/127))
+- _(uncategorized)_ Scrape example code from examples/* ([#195](https://github.com/ratatui/ratatui/issues/195))
 
 ### Styling
 
-- *(apps)* Update the style of application list ([#184](https://github.com/ratatui-org/ratatui/issues/184))
-- *(readme)* Update project introduction in README.md ([#153](https://github.com/ratatui-org/ratatui/issues/153))
-- *(uncategorized)* Clippy's variable inlining in format macros
+- _(apps)_ Update the style of application list ([#184](https://github.com/ratatui/ratatui/issues/184))
+- _(readme)_ Update project introduction in README.md ([#153](https://github.com/ratatui/ratatui/issues/153))
+- _(uncategorized)_ Clippy's variable inlining in format macros
 
 ### Testing
 
-- *(buffer)* Add `assert_buffer_eq!` and Debug implementation ([#161](https://github.com/ratatui-org/ratatui/issues/161))
-- *(list)* Add characterization tests for list ([#167](https://github.com/ratatui-org/ratatui/issues/167))
-- *(widget)* Add unit tests for Paragraph ([#156](https://github.com/ratatui-org/ratatui/issues/156))
+- _(buffer)_ Add `assert_buffer_eq!` and Debug implementation ([#161](https://github.com/ratatui/ratatui/issues/161))
+- _(list)_ Add characterization tests for list ([#167](https://github.com/ratatui/ratatui/issues/167))
+- _(widget)_ Add unit tests for Paragraph ([#156](https://github.com/ratatui/ratatui/issues/156))
 
 ### Miscellaneous Tasks
 
-- *(uncategorized)* Inline format args ([#190](https://github.com/ratatui-org/ratatui/issues/190))
-- *(uncategorized)* Minor lints, making Clippy happier ([#189](https://github.com/ratatui-org/ratatui/issues/189))
+- _(uncategorized)_ Inline format args ([#190](https://github.com/ratatui/ratatui/issues/190))
+- _(uncategorized)_ Minor lints, making Clippy happier ([#189](https://github.com/ratatui/ratatui/issues/189))
 
 ### Build
 
-- *(uncategorized)* Bump MSRV to 1.65.0 ([#171](https://github.com/ratatui-org/ratatui/issues/171))
+- _(uncategorized)_ Bump MSRV to 1.65.0 ([#171](https://github.com/ratatui/ratatui/issues/171))
 
 ### Continuous Integration
 
-- *(uncategorized)* Add ci, build, and revert to allowed commit types
+- _(uncategorized)_ Add ci, build, and revert to allowed commit types
 
 ### Contributors
 
@@ -5361,12 +5364,12 @@ Here is the list of contributors who have contributed to `ratatui` for the first
 
 ### Bug Fixes
 
-- *(style)* Bold needs a bit ([#104](https://github.com/ratatui-org/ratatui/issues/104))
+- _(style)_ Bold needs a bit ([#104](https://github.com/ratatui/ratatui/issues/104))
 
 ### Documentation
 
-- *(apps)* Add "logss" to apps ([#105](https://github.com/ratatui-org/ratatui/issues/105))
-- *(uncategorized)* Fixup remaining tui references ([#106](https://github.com/ratatui-org/ratatui/issues/106))
+- _(apps)_ Add "logss" to apps ([#105](https://github.com/ratatui/ratatui/issues/105))
+- _(uncategorized)_ Fixup remaining tui references ([#106](https://github.com/ratatui/ratatui/issues/106))
 
 ### Contributors
 
@@ -5386,68 +5389,68 @@ Here is a list of changes:
 
 ### Features
 
-- *(cd)* Add continuous deployment workflow ([#93](https://github.com/ratatui-org/ratatui/issues/93))
-- *(ci)* Add MacOS to CI ([#60](https://github.com/ratatui-org/ratatui/issues/60))
-- *(widget)* Add `offset()` to `TableState` ([#10](https://github.com/ratatui-org/ratatui/issues/10))
-- *(widget)* Add `width()` to ListItem ([#17](https://github.com/ratatui-org/ratatui/issues/17))
+- _(cd)_ Add continuous deployment workflow ([#93](https://github.com/ratatui/ratatui/issues/93))
+- _(ci)_ Add MacOS to CI ([#60](https://github.com/ratatui/ratatui/issues/60))
+- _(widget)_ Add `offset()` to `TableState` ([#10](https://github.com/ratatui/ratatui/issues/10))
+- _(widget)_ Add `width()` to ListItem ([#17](https://github.com/ratatui/ratatui/issues/17))
 
 ### Bug Fixes
 
-- *(ci)* Test MSRV compatibility on CI ([#85](https://github.com/ratatui-org/ratatui/issues/85))
-- *(ci)* Bump Rust version to 1.63.0 ([#80](https://github.com/ratatui-org/ratatui/issues/80))
-- *(ci)* Use env for the cargo-make version ([#76](https://github.com/ratatui-org/ratatui/issues/76))
-- *(ci)* Fix deprecation warnings on CI ([#58](https://github.com/ratatui-org/ratatui/issues/58))
-- *(doc)* Add 3rd party libraries accidentally removed at #21 ([#61](https://github.com/ratatui-org/ratatui/issues/61))
-- *(widget)* List should not ignore empty string items ([#42](https://github.com/ratatui-org/ratatui/issues/42)) [**breaking**]
-- *(uncategorized)* Cassowary/layouts: add extra constraints for fixing Min(v)/Max(v) combination. ([#31](https://github.com/ratatui-org/ratatui/issues/31))
-- *(uncategorized)* Fix user_input example double key press registered on windows
-- *(uncategorized)* Ignore zero-width symbol on rendering `Paragraph`
-- *(uncategorized)* Fix typos ([#45](https://github.com/ratatui-org/ratatui/issues/45))
-- *(uncategorized)* Fix typos ([#47](https://github.com/ratatui-org/ratatui/issues/47))
+- _(ci)_ Test MSRV compatibility on CI ([#85](https://github.com/ratatui/ratatui/issues/85))
+- _(ci)_ Bump Rust version to 1.63.0 ([#80](https://github.com/ratatui/ratatui/issues/80))
+- _(ci)_ Use env for the cargo-make version ([#76](https://github.com/ratatui/ratatui/issues/76))
+- _(ci)_ Fix deprecation warnings on CI ([#58](https://github.com/ratatui/ratatui/issues/58))
+- _(doc)_ Add 3rd party libraries accidentally removed at #21 ([#61](https://github.com/ratatui/ratatui/issues/61))
+- _(widget)_ List should not ignore empty string items ([#42](https://github.com/ratatui/ratatui/issues/42)) [**breaking**]
+- _(uncategorized)_ Cassowary/layouts: add extra constraints for fixing Min(v)/Max(v) combination. ([#31](https://github.com/ratatui/ratatui/issues/31))
+- _(uncategorized)_ Fix user_input example double key press registered on windows
+- _(uncategorized)_ Ignore zero-width symbol on rendering `Paragraph`
+- _(uncategorized)_ Fix typos ([#45](https://github.com/ratatui/ratatui/issues/45))
+- _(uncategorized)_ Fix typos ([#47](https://github.com/ratatui/ratatui/issues/47))
 
 ### Refactor
 
-- *(style)* Make bitflags smaller ([#13](https://github.com/ratatui-org/ratatui/issues/13))
+- _(style)_ Make bitflags smaller ([#13](https://github.com/ratatui/ratatui/issues/13))
 
 ### Documentation
 
-- *(apps)* Move 'apps using ratatui' to dedicated file ([#98](https://github.com/ratatui-org/ratatui/issues/98)) ([#99](https://github.com/ratatui-org/ratatui/issues/99))
-- *(canvas)* Add documentation for x_bounds, y_bounds ([#35](https://github.com/ratatui-org/ratatui/issues/35))
-- *(contributing)* Specify the use of unsafe for optimization ([#67](https://github.com/ratatui-org/ratatui/issues/67))
-- *(github)* Remove pull request template ([#68](https://github.com/ratatui-org/ratatui/issues/68))
-- *(readme)* Update crate status badge ([#102](https://github.com/ratatui-org/ratatui/issues/102))
-- *(readme)* Small edits before first release ([#101](https://github.com/ratatui-org/ratatui/issues/101))
-- *(readme)* Add install instruction and update title ([#100](https://github.com/ratatui-org/ratatui/issues/100))
-- *(readme)* Add systeroid to application list ([#92](https://github.com/ratatui-org/ratatui/issues/92))
-- *(readme)* Add glicol-cli to showcase list ([#95](https://github.com/ratatui-org/ratatui/issues/95))
-- *(readme)* Add oxker to application list ([#74](https://github.com/ratatui-org/ratatui/issues/74))
-- *(readme)* Add app kubectl-watch which uses tui ([#73](https://github.com/ratatui-org/ratatui/issues/73))
-- *(readme)* Add poketex to 'apps using tui' in README ([#64](https://github.com/ratatui-org/ratatui/issues/64))
-- *(readme)* Update README.md ([#39](https://github.com/ratatui-org/ratatui/issues/39))
-- *(readme)* Update README.md ([#40](https://github.com/ratatui-org/ratatui/issues/40))
-- *(readme)* Clarify README.md fork status update
-- *(uncategorized)* Fix: fix typos ([#90](https://github.com/ratatui-org/ratatui/issues/90))
-- *(uncategorized)* Update to build more backends ([#81](https://github.com/ratatui-org/ratatui/issues/81))
-- *(uncategorized)* Expand "Apps" and "Third-party" sections ([#21](https://github.com/ratatui-org/ratatui/issues/21))
-- *(uncategorized)* Add tui-input and update xplr in README.md
-- *(uncategorized)* Add hncli to list of applications made with tui-rs ([#41](https://github.com/ratatui-org/ratatui/issues/41))
-- *(uncategorized)* Updated readme and contributing guide with updates about the fork ([#46](https://github.com/ratatui-org/ratatui/issues/46))
+- _(apps)_ Move 'apps using ratatui' to dedicated file ([#98](https://github.com/ratatui/ratatui/issues/98)) ([#99](https://github.com/ratatui/ratatui/issues/99))
+- _(canvas)_ Add documentation for x_bounds, y_bounds ([#35](https://github.com/ratatui/ratatui/issues/35))
+- _(contributing)_ Specify the use of unsafe for optimization ([#67](https://github.com/ratatui/ratatui/issues/67))
+- _(github)_ Remove pull request template ([#68](https://github.com/ratatui/ratatui/issues/68))
+- _(readme)_ Update crate status badge ([#102](https://github.com/ratatui/ratatui/issues/102))
+- _(readme)_ Small edits before first release ([#101](https://github.com/ratatui/ratatui/issues/101))
+- _(readme)_ Add install instruction and update title ([#100](https://github.com/ratatui/ratatui/issues/100))
+- _(readme)_ Add systeroid to application list ([#92](https://github.com/ratatui/ratatui/issues/92))
+- _(readme)_ Add glicol-cli to showcase list ([#95](https://github.com/ratatui/ratatui/issues/95))
+- _(readme)_ Add oxker to application list ([#74](https://github.com/ratatui/ratatui/issues/74))
+- _(readme)_ Add app kubectl-watch which uses tui ([#73](https://github.com/ratatui/ratatui/issues/73))
+- _(readme)_ Add poketex to 'apps using tui' in README ([#64](https://github.com/ratatui/ratatui/issues/64))
+- _(readme)_ Update README.md ([#39](https://github.com/ratatui/ratatui/issues/39))
+- _(readme)_ Update README.md ([#40](https://github.com/ratatui/ratatui/issues/40))
+- _(readme)_ Clarify README.md fork status update
+- _(uncategorized)_ Fix: fix typos ([#90](https://github.com/ratatui/ratatui/issues/90))
+- _(uncategorized)_ Update to build more backends ([#81](https://github.com/ratatui/ratatui/issues/81))
+- _(uncategorized)_ Expand "Apps" and "Third-party" sections ([#21](https://github.com/ratatui/ratatui/issues/21))
+- _(uncategorized)_ Add tui-input and update xplr in README.md
+- _(uncategorized)_ Add hncli to list of applications made with tui-rs ([#41](https://github.com/ratatui/ratatui/issues/41))
+- _(uncategorized)_ Updated readme and contributing guide with updates about the fork ([#46](https://github.com/ratatui/ratatui/issues/46))
 
 ### Performance
 
-- *(layout)* Better safe shared layout cache ([#62](https://github.com/ratatui-org/ratatui/issues/62))
+- _(layout)_ Better safe shared layout cache ([#62](https://github.com/ratatui/ratatui/issues/62))
 
 ### Miscellaneous Tasks
 
-- *(cargo)* Update project metadata ([#94](https://github.com/ratatui-org/ratatui/issues/94))
-- *(ci)* Integrate `typos` for checking typos ([#91](https://github.com/ratatui-org/ratatui/issues/91))
-- *(ci)* Change the target branch to main ([#79](https://github.com/ratatui-org/ratatui/issues/79))
-- *(ci)* Re-enable clippy on CI ([#59](https://github.com/ratatui-org/ratatui/issues/59))
-- *(uncategorized)* Integrate `committed` for checking conventional commits ([#77](https://github.com/ratatui-org/ratatui/issues/77))
-- *(uncategorized)* Update `rust-version` to 1.59 in Cargo.toml ([#57](https://github.com/ratatui-org/ratatui/issues/57))
-- *(uncategorized)* Update deps ([#51](https://github.com/ratatui-org/ratatui/issues/51))
-- *(uncategorized)* Fix typo in layout.rs ([#619](https://github.com/ratatui-org/ratatui/issues/619))
-- *(uncategorized)* Add apps using `tui`
+- _(cargo)_ Update project metadata ([#94](https://github.com/ratatui/ratatui/issues/94))
+- _(ci)_ Integrate `typos` for checking typos ([#91](https://github.com/ratatui/ratatui/issues/91))
+- _(ci)_ Change the target branch to main ([#79](https://github.com/ratatui/ratatui/issues/79))
+- _(ci)_ Re-enable clippy on CI ([#59](https://github.com/ratatui/ratatui/issues/59))
+- _(uncategorized)_ Integrate `committed` for checking conventional commits ([#77](https://github.com/ratatui/ratatui/issues/77))
+- _(uncategorized)_ Update `rust-version` to 1.59 in Cargo.toml ([#57](https://github.com/ratatui/ratatui/issues/57))
+- _(uncategorized)_ Update deps ([#51](https://github.com/ratatui/ratatui/issues/51))
+- _(uncategorized)_ Fix typo in layout.rs ([#619](https://github.com/ratatui/ratatui/issues/619))
+- _(uncategorized)_ Add apps using `tui`
 
 ### Contributors
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ creating a new issue before making the change, or starting a discussion on
 
 ## Reporting issues
 
-Before reporting an issue on the [issue tracker](https://github.com/ratatui-org/ratatui/issues),
+Before reporting an issue on the [issue tracker](https://github.com/ratatui/ratatui/issues),
 please check that it has not already been reported by searching for some related keywords. Please
 also check [`tui-rs` issues](https://github.com/fdehau/tui-rs/issues/) and link any related issues
 found.
@@ -79,14 +79,14 @@ defaults depending on your platform of choice. Building the project should be as
 `cargo make build`.
 
 ```shell
-git clone https://github.com/ratatui-org/ratatui.git
+git clone https://github.com/ratatui/ratatui.git
 cd ratatui
 cargo make build
 ```
 
 ### Tests
 
-The [test coverage](https://app.codecov.io/gh/ratatui-org/ratatui) of the crate is reasonably
+The [test coverage](https://app.codecov.io/gh/ratatui/ratatui) of the crate is reasonably
 good, but this can always be improved. Focus on keeping the tests simple and obvious and write unit
 tests for all new or modified code. Beside the usual doc and unit tests, one of the most valuable
 test you can write for Ratatui is a test against the `TestBackend`. It allows you to assert the
@@ -171,7 +171,7 @@ time to update. However, if a deprecation is blocking for us to implement a new 
 
 We don't currently use any unsafe code in Ratatui, and would like to keep it that way. However, there
 may be specific cases that this becomes necessary in order to avoid slowness. Please see [this
-discussion](https://github.com/ratatui-org/ratatui/discussions/66) for more about the decision.
+discussion](https://github.com/ratatui/ratatui/discussions/66) for more about the decision.
 
 ## Continuous Integration
 
@@ -196,7 +196,7 @@ it is useful to refer to when contributing code, documentation, or issues with R
 
 We imported all the PRs from the original repository, implemented many of the smaller ones, and
 made notes on the leftovers. These are marked as draft PRs and labelled as [imported from
-tui](https://github.com/ratatui-org/ratatui/pulls?q=is%3Apr+is%3Aopen+label%3A%22imported+from+tui%22).
+tui](https://github.com/ratatui/ratatui/pulls?q=is%3Apr+is%3Aopen+label%3A%22imported+from+tui%22).
 We have documented the current state of those PRs, and anyone is welcome to pick them up and
 continue the work on them.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.28.0" # crate version
 authors = ["Florian Dehau <work@fdehau.com>", "The Ratatui Developers"]
 description = "A library that's all about cooking up terminal user interfaces"
 documentation = "https://docs.rs/ratatui/latest/ratatui/"
-repository = "https://github.com/ratatui-org/ratatui"
+repository = "https://github.com/ratatui/ratatui"
 homepage = "https://ratatui.rs"
 keywords = ["tui", "terminal", "dashboard"]
 categories = ["command-line-interface"]
@@ -162,7 +162,7 @@ unstable = ["unstable-rendered-line-info", "unstable-widget-ref"]
 ## Enables the [`Paragraph::line_count`](widgets::Paragraph::line_count)
 ## [`Paragraph::line_width`](widgets::Paragraph::line_width) methods
 ## which are experimental and may change in the future.
-## See [Issue 293](https://github.com/ratatui-org/ratatui/issues/293) for more details.
+## See [Issue 293](https://github.com/ratatui/ratatui/issues/293) for more details.
 unstable-rendered-line-info = []
 
 ## Enables the [`WidgetRef`](widgets::WidgetRef) and [`StatefulWidgetRef`](widgets::StatefulWidgetRef) traits which are experimental and may change in

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 <!-- cargo-rdme start -->
 
-![Demo](https://github.com/ratatui-org/ratatui/blob/87ae72dbc756067c97f6400d3e2a58eeb383776e/examples/demo2-destroy.gif?raw=true)
+![Demo](https://github.com/ratatui/ratatui/blob/87ae72dbc756067c97f6400d3e2a58eeb383776e/examples/demo2-destroy.gif?raw=true)
 
 <div align="center">
 
@@ -280,21 +280,21 @@ Running this example produces the following output:
 [Handling Events]: https://ratatui.rs/concepts/event-handling/
 [Layout]: https://ratatui.rs/how-to/layout/
 [Styling Text]: https://ratatui.rs/how-to/render/style-text/
-[templates]: https://github.com/ratatui-org/templates/
-[Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples/README.md
-[Report a bug]: https://github.com/ratatui-org/ratatui/issues/new?labels=bug&projects=&template=bug_report.md
-[Request a Feature]: https://github.com/ratatui-org/ratatui/issues/new?labels=enhancement&projects=&template=feature_request.md
-[Create a Pull Request]: https://github.com/ratatui-org/ratatui/compare
+[templates]: https://github.com/ratatui/templates/
+[Examples]: https://github.com/ratatui/ratatui/tree/main/examples/README.md
+[Report a bug]: https://github.com/ratatui/ratatui/issues/new?labels=bug&projects=&template=bug_report.md
+[Request a Feature]: https://github.com/ratatui/ratatui/issues/new?labels=enhancement&projects=&template=feature_request.md
+[Create a Pull Request]: https://github.com/ratatui/ratatui/compare
 [git-cliff]: https://git-cliff.org
 [Conventional Commits]: https://www.conventionalcommits.org
 [API Docs]: https://docs.rs/ratatui
-[Changelog]: https://github.com/ratatui-org/ratatui/blob/main/CHANGELOG.md
-[Contributing]: https://github.com/ratatui-org/ratatui/blob/main/CONTRIBUTING.md
-[Breaking Changes]: https://github.com/ratatui-org/ratatui/blob/main/BREAKING-CHANGES.md
+[Changelog]: https://github.com/ratatui/ratatui/blob/main/CHANGELOG.md
+[Contributing]: https://github.com/ratatui/ratatui/blob/main/CONTRIBUTING.md
+[Breaking Changes]: https://github.com/ratatui/ratatui/blob/main/BREAKING-CHANGES.md
 [FOSDEM 2024 talk]: https://www.youtube.com/watch?v=NU0q6NOLJ20
-[docsrs-hello]: https://github.com/ratatui-org/ratatui/blob/c3c3c289b1eb8d562afb1931adb4dc719cd48490/examples/docsrs-hello.png?raw=true
-[docsrs-layout]: https://github.com/ratatui-org/ratatui/blob/c3c3c289b1eb8d562afb1931adb4dc719cd48490/examples/docsrs-layout.png?raw=true
-[docsrs-styling]: https://github.com/ratatui-org/ratatui/blob/c3c3c289b1eb8d562afb1931adb4dc719cd48490/examples/docsrs-styling.png?raw=true
+[docsrs-hello]: https://github.com/ratatui/ratatui/blob/c3c3c289b1eb8d562afb1931adb4dc719cd48490/examples/docsrs-hello.png?raw=true
+[docsrs-layout]: https://github.com/ratatui/ratatui/blob/c3c3c289b1eb8d562afb1931adb4dc719cd48490/examples/docsrs-layout.png?raw=true
+[docsrs-styling]: https://github.com/ratatui/ratatui/blob/c3c3c289b1eb8d562afb1931adb4dc719cd48490/examples/docsrs-styling.png?raw=true
 [`Frame`]: terminal::Frame
 [`render_widget`]: terminal::Frame::render_widget
 [`Widget`]: widgets::Widget
@@ -313,15 +313,15 @@ Running this example produces the following output:
 [Termion]: https://crates.io/crates/termion
 [Termwiz]: https://crates.io/crates/termwiz
 [tui-rs]: https://crates.io/crates/tui
-[GitHub Sponsors]: https://github.com/sponsors/ratatui-org
+[GitHub Sponsors]: https://github.com/sponsors/ratatui
 [Crate Badge]: https://img.shields.io/crates/v/ratatui?logo=rust&style=flat-square&logoColor=E05D44&color=E05D44
 [License Badge]: https://img.shields.io/crates/l/ratatui?style=flat-square&color=1370D3
-[CI Badge]: https://img.shields.io/github/actions/workflow/status/ratatui-org/ratatui/ci.yml?style=flat-square&logo=github
-[CI Workflow]: https://github.com/ratatui-org/ratatui/actions/workflows/ci.yml
-[Codecov Badge]: https://img.shields.io/codecov/c/github/ratatui-org/ratatui?logo=codecov&style=flat-square&token=BAQ8SOKEST&color=C43AC3&logoColor=C43AC3
-[Codecov]: https://app.codecov.io/gh/ratatui-org/ratatui
-[Deps.rs Badge]: https://deps.rs/repo/github/ratatui-org/ratatui/status.svg?style=flat-square
-[Deps.rs]: https://deps.rs/repo/github/ratatui-org/ratatui
+[CI Badge]: https://img.shields.io/github/actions/workflow/status/ratatui/ratatui/ci.yml?style=flat-square&logo=github
+[CI Workflow]: https://github.com/ratatui/ratatui/actions/workflows/ci.yml
+[Codecov Badge]: https://img.shields.io/codecov/c/github/ratatui/ratatui?logo=codecov&style=flat-square&token=BAQ8SOKEST&color=C43AC3&logoColor=C43AC3
+[Codecov]: https://app.codecov.io/gh/ratatui/ratatui
+[Deps.rs Badge]: https://deps.rs/repo/github/ratatui/ratatui/status.svg?style=flat-square
+[Deps.rs]: https://deps.rs/repo/github/ratatui/ratatui
 [Discord Badge]: https://img.shields.io/discord/1070692720437383208?label=discord&logo=discord&style=flat-square&color=1370D3&logoColor=1370D3
 [Discord Server]: https://discord.gg/pMCEU9hNEj
 [Docs Badge]: https://img.shields.io/docsrs/ratatui?logo=rust&style=flat-square&logoColor=E05D44
@@ -329,7 +329,7 @@ Running this example produces the following output:
 [Matrix]: https://matrix.to/#/#ratatui:matrix.org
 [Forum Badge]: https://img.shields.io/discourse/likes?server=https%3A%2F%2Fforum.ratatui.rs&style=flat-square&logo=discourse&label=forum&color=C43AC3
 [Forum]: https://forum.ratatui.rs
-[Sponsors Badge]: https://img.shields.io/github/sponsors/ratatui-org?logo=github&style=flat-square&color=1370D3
+[Sponsors Badge]: https://img.shields.io/github/sponsors/ratatui?logo=github&style=flat-square&color=1370D3
 
 <!-- cargo-rdme end -->
 
@@ -387,7 +387,7 @@ be installed with `cargo install cargo-make`).
   `ratatui::text::Text`
 - [color-to-tui](https://github.com/uttarayan21/color-to-tui) — Parse hex colors to
   `ratatui::style::Color`
-- [templates](https://github.com/ratatui-org/templates) — Starter templates for
+- [templates](https://github.com/ratatui/templates) — Starter templates for
   bootstrapping a Rust TUI application with Ratatui & crossterm
 - [tui-builder](https://github.com/jkelleyrtp/tui-builder) — Batteries-included MVC framework for
   Tui-rs + Crossterm apps
@@ -411,7 +411,7 @@ be installed with `cargo install cargo-make`).
 
 ## Apps
 
-Check out [awesome-ratatui](https://github.com/ratatui-org/awesome-ratatui) for a curated list of
+Check out [awesome-ratatui](https://github.com/ratatui/awesome-ratatui) for a curated list of
 awesome apps/libraries built with `ratatui`!
 
 ## Alternatives
@@ -422,7 +422,7 @@ to build text user interfaces in Rust.
 ## Acknowledgments
 
 Special thanks to [**Pavel Fomchenkov**](https://github.com/nawok) for his work in designing **an
-awesome logo** for the ratatui project and ratatui-org organization.
+awesome logo** for the ratatui project and ratatui organization.
 
 ## License
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,7 @@ actions](.github/workflows/cd.yml) and triggered by pushing a tag.
    ```
 
 1. Switch branches to the images branch and copy demo2.gif to examples/, commit, and push.
-1. Grab the permalink from <https://github.com/ratatui-org/ratatui/blob/images/examples/demo2.gif> and
+1. Grab the permalink from <https://github.com/ratatui/ratatui/blob/images/examples/demo2.gif> and
    append `?raw=true` to redirect to the actual image url. Then update the link in the main README.
    Avoid adding the gif to the git repo as binary files tend to bloat repositories.
 
@@ -23,14 +23,14 @@ actions](.github/workflows/cd.yml) and triggered by pushing a tag.
 1. Commit and push the changes.
 1. Create a new tag: `git tag -a v[X.Y.Z]`
 1. Push the tag: `git push --tags`
-1. Wait for [Continuous Deployment](https://github.com/ratatui-org/ratatui/actions) workflow to
+1. Wait for [Continuous Deployment](https://github.com/ratatui/ratatui/actions) workflow to
    finish.
 
 ## Alpha Releases
 
 Alpha releases are automatically released every Saturday via [cd.yml](./.github/workflows/cd.yml)
 and can be manually be created when necessary by triggering the [Continuous
-Deployment](https://github.com/ratatui-org/ratatui/actions/workflows/cd.yml) workflow.
+Deployment](https://github.com/ratatui/ratatui/actions/workflows/cd.yml) workflow.
 
 We automatically release an alpha release with a patch level bump + alpha.num weekly (and when we
 need to manually). E.g. the last release was 0.22.0, and the most recent alpha release is
@@ -40,5 +40,5 @@ These releases will have whatever happened to be in main at the time of release,
 for apps that need to get releases from crates.io, but may contain more bugs and be generally less
 tested than normal releases.
 
-See [#147](https://github.com/ratatui-org/ratatui/issues/147) and
-[#359](https://github.com/ratatui-org/ratatui/pull/359) for more info on the alpha release process.
+See [#147](https://github.com/ratatui/ratatui/issues/147) and
+[#359](https://github.com/ratatui/ratatui/pull/359) for more info on the alpha release process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,4 +6,4 @@ We only support the latest version of this crate.
 
 ## Reporting a Vulnerability
 
-To report secuirity vulnerability, please use the form at <https://github.com/ratatui-org/ratatui/security/advisories/new>
+To report secuirity vulnerability, please use the form at <https://github.com/ratatui/ratatui/security/advisories/new>

--- a/benches/main/barchart.rs
+++ b/benches/main/barchart.rs
@@ -59,7 +59,7 @@ fn barchart(c: &mut Criterion) {
 fn render(bencher: &mut Bencher, barchart: &BarChart) {
     let mut buffer = Buffer::empty(Rect::new(0, 0, 200, 50));
     // We use `iter_batched` to clone the value in the setup function.
-    // See https://github.com/ratatui-org/ratatui/pull/377.
+    // See https://github.com/ratatui/ratatui/pull/377.
     bencher.iter_batched(
         || barchart.clone(),
         |bench_barchart| {

--- a/benches/main/block.rs
+++ b/benches/main/block.rs
@@ -48,7 +48,7 @@ fn block(c: &mut Criterion) {
 fn render(bencher: &mut Bencher, block: &Block, size: Rect) {
     let mut buffer = Buffer::empty(size);
     // We use `iter_batched` to clone the value in the setup function.
-    // See https://github.com/ratatui-org/ratatui/pull/377.
+    // See https://github.com/ratatui/ratatui/pull/377.
     bencher.iter_batched(
         || block.to_owned(),
         |bench_block| {

--- a/benches/main/list.rs
+++ b/benches/main/list.rs
@@ -45,7 +45,7 @@ fn list(c: &mut Criterion) {
 fn render(bencher: &mut Bencher, list: &List) {
     let mut buffer = Buffer::empty(Rect::new(0, 0, 200, 50));
     // We use `iter_batched` to clone the value in the setup function.
-    // See https://github.com/ratatui-org/ratatui/pull/377.
+    // See https://github.com/ratatui/ratatui/pull/377.
     bencher.iter_batched(
         || list.to_owned(),
         |bench_list| {
@@ -59,7 +59,7 @@ fn render(bencher: &mut Bencher, list: &List) {
 fn render_stateful(bencher: &mut Bencher, list: &List, mut state: ListState) {
     let mut buffer = Buffer::empty(Rect::new(0, 0, 200, 50));
     // We use `iter_batched` to clone the value in the setup function.
-    // See https://github.com/ratatui-org/ratatui/pull/377.
+    // See https://github.com/ratatui/ratatui/pull/377.
     bencher.iter_batched(
         || list.to_owned(),
         |bench_list| {

--- a/benches/main/paragraph.rs
+++ b/benches/main/paragraph.rs
@@ -70,7 +70,7 @@ fn paragraph(c: &mut Criterion) {
 fn render(bencher: &mut Bencher, paragraph: &Paragraph, width: u16) {
     let mut buffer = Buffer::empty(Rect::new(0, 0, width, 50));
     // We use `iter_batched` to clone the value in the setup function.
-    // See https://github.com/ratatui-org/ratatui/pull/377.
+    // See https://github.com/ratatui/ratatui/pull/377.
     bencher.iter_batched(
         || paragraph.to_owned(),
         |bench_paragraph| {

--- a/benches/main/sparkline.rs
+++ b/benches/main/sparkline.rs
@@ -31,7 +31,7 @@ fn sparkline(c: &mut Criterion) {
 fn render(bencher: &mut Bencher, sparkline: &Sparkline) {
     let mut buffer = Buffer::empty(Rect::new(0, 0, 200, 50));
     // We use `iter_batched` to clone the value in the setup function.
-    // See https://github.com/ratatui-org/ratatui/pull/377.
+    // See https://github.com/ratatui/ratatui/pull/377.
     bencher.iter_batched(
         || sparkline.clone(),
         |bench_sparkline| {

--- a/cliff.toml
+++ b/cliff.toml
@@ -2,7 +2,7 @@
 # https://git-cliff.org/docs/configuration
 
 [remote.github]
-owner = "ratatui-org"
+owner = "ratatui"
 repo = "ratatui"
 
 [changelog]
@@ -24,11 +24,11 @@ body = """
 {%- if not version %}
 ## [unreleased]
 {% else -%}
-## [{{ version }}](https://github.com/ratatui-org/ratatui/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version }}](https://github.com/ratatui/ratatui/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
 {% endif -%}
 
 {% macro commit(commit) -%}
-- [{{ commit.id | truncate(length=7, end="") }}]({{ "https://github.com/ratatui-org/ratatui/commit/" ~ commit.id }}) \
+- [{{ commit.id | truncate(length=7, end="") }}]({{ "https://github.com/ratatui/ratatui/commit/" ~ commit.id }}) \
   *({{commit.scope | default(value = "uncategorized") | lower }})* {{ commit.message | upper_first | trim }}\
   {% if commit.github.username %} by @{{ commit.github.username }}{%- endif -%}\
   {% if commit.github.pr_number %} in [#{{ commit.github.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.github.pr_number }}){%- endif %}\

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,7 +3,7 @@ avoid-breaking-exported-api = false
 # https://rust-lang.github.io/rust-clippy/master/index.html#/multiple_crate_versions
 # ratatui -> bitflags v2.3
 # termwiz -> wezterm-blob-leases -> mac_address -> nix -> bitflags v1.3.2
-# crossterm -> all the windows- deps https://github.com/ratatui-org/ratatui/pull/1064#issuecomment-2078848980
+# crossterm -> all the windows- deps https://github.com/ratatui/ratatui/pull/1064#issuecomment-2078848980
 allowed-duplicate-crates = [
     "bitflags",
     "windows-targets",

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,13 +10,13 @@ This folder might use unreleased code. View the examples for the latest release 
 > There are a few workaround for this problem:
 >
 > - View the examples as they were when the latest version was release by selecting the tag that
->   matches that version. E.g. <https://github.com/ratatui-org/ratatui/tree/v0.26.1/examples>.
+>   matches that version. E.g. <https://github.com/ratatui/ratatui/tree/v0.26.1/examples>.
 > - If you're viewing this file on GitHub, there is a combo box at the top of this page  which
 >   allows you to select any previous tagged version.
 > - To view the code locally, checkout the tag. E.g. `git switch --detach v0.26.1`.
 > - Use the latest [alpha version of Ratatui] in your app. These are released weekly on Saturdays.
 > - Compile your code against the main branch either locally by adding e.g. `path = "../ratatui"` to
->   the dependency, or remotely by adding `git = "https://github.com/ratatui-org/ratatui"`
+>   the dependency, or remotely by adding `git = "https://github.com/ratatui/ratatui"`
 >
 > For a list of unreleased breaking changes, see [BREAKING-CHANGES.md].
 >
@@ -170,7 +170,7 @@ cargo run --example=colors_rgb --features=crossterm
 Note: VHs renders full screen animations poorly, so this is a screen capture rather than the output
 of the VHS tape.
 
-<https://github.com/ratatui-org/ratatui/assets/381361/485e775a-e0b5-4133-899b-1e8aeb56e774>
+<https://github.com/ratatui/ratatui/assets/381361/485e775a-e0b5-4133-899b-1e8aeb56e774>
 
 ## Constraint Explorer
 
@@ -441,38 +441,38 @@ examples/vhs/generate.bash
 ```
 -->
 
-[barchart.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/barchart.gif?raw=true
-[barchart-grouped.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/barchart-grouped.gif?raw=true
-[block.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/block.gif?raw=true
-[calendar.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/calendar.gif?raw=true
-[canvas.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/canvas.gif?raw=true
-[chart.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/chart.gif?raw=true
-[colors.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/colors.gif?raw=true
-[constraint-explorer.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/constraint-explorer.gif?raw=true
-[constraints.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/constraints.gif?raw=true
-[custom_widget.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/custom_widget.gif?raw=true
-[demo.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/demo.gif?raw=true
-[demo2.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/demo2.gif?raw=true
-[flex.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/flex.gif?raw=true
-[gauge.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/gauge.gif?raw=true
-[hello_world.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/hello_world.gif?raw=true
-[hyperlink.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/hyperlink.gif?raw=true
-[inline.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/inline.gif?raw=true
-[layout.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/layout.gif?raw=true
-[list.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/list.gif?raw=true
-[line_gauge.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/line_gauge.gif?raw=true
-[minimal.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/minimal.gif?raw=true
-[modifiers.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/modifiers.gif?raw=true
-[panic.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/panic.gif?raw=true
-[paragraph.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/paragraph.gif?raw=true
-[popup.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/popup.gif?raw=true
-[ratatui-logo.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/ratatui-logo.gif?raw=true
-[scrollbar.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/scrollbar.gif?raw=true
-[sparkline.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/sparkline.gif?raw=true
+[barchart.gif]: https://github.com/ratatui/ratatui/blob/images/examples/barchart.gif?raw=true
+[barchart-grouped.gif]: https://github.com/ratatui/ratatui/blob/images/examples/barchart-grouped.gif?raw=true
+[block.gif]: https://github.com/ratatui/ratatui/blob/images/examples/block.gif?raw=true
+[calendar.gif]: https://github.com/ratatui/ratatui/blob/images/examples/calendar.gif?raw=true
+[canvas.gif]: https://github.com/ratatui/ratatui/blob/images/examples/canvas.gif?raw=true
+[chart.gif]: https://github.com/ratatui/ratatui/blob/images/examples/chart.gif?raw=true
+[colors.gif]: https://github.com/ratatui/ratatui/blob/images/examples/colors.gif?raw=true
+[constraint-explorer.gif]: https://github.com/ratatui/ratatui/blob/images/examples/constraint-explorer.gif?raw=true
+[constraints.gif]: https://github.com/ratatui/ratatui/blob/images/examples/constraints.gif?raw=true
+[custom_widget.gif]: https://github.com/ratatui/ratatui/blob/images/examples/custom_widget.gif?raw=true
+[demo.gif]: https://github.com/ratatui/ratatui/blob/images/examples/demo.gif?raw=true
+[demo2.gif]: https://github.com/ratatui/ratatui/blob/images/examples/demo2.gif?raw=true
+[flex.gif]: https://github.com/ratatui/ratatui/blob/images/examples/flex.gif?raw=true
+[gauge.gif]: https://github.com/ratatui/ratatui/blob/images/examples/gauge.gif?raw=true
+[hello_world.gif]: https://github.com/ratatui/ratatui/blob/images/examples/hello_world.gif?raw=true
+[hyperlink.gif]: https://github.com/ratatui/ratatui/blob/images/examples/hyperlink.gif?raw=true
+[inline.gif]: https://github.com/ratatui/ratatui/blob/images/examples/inline.gif?raw=true
+[layout.gif]: https://github.com/ratatui/ratatui/blob/images/examples/layout.gif?raw=true
+[list.gif]: https://github.com/ratatui/ratatui/blob/images/examples/list.gif?raw=true
+[line_gauge.gif]: https://github.com/ratatui/ratatui/blob/images/examples/line_gauge.gif?raw=true
+[minimal.gif]: https://github.com/ratatui/ratatui/blob/images/examples/minimal.gif?raw=true
+[modifiers.gif]: https://github.com/ratatui/ratatui/blob/images/examples/modifiers.gif?raw=true
+[panic.gif]: https://github.com/ratatui/ratatui/blob/images/examples/panic.gif?raw=true
+[paragraph.gif]: https://github.com/ratatui/ratatui/blob/images/examples/paragraph.gif?raw=true
+[popup.gif]: https://github.com/ratatui/ratatui/blob/images/examples/popup.gif?raw=true
+[ratatui-logo.gif]: https://github.com/ratatui/ratatui/blob/images/examples/ratatui-logo.gif?raw=true
+[scrollbar.gif]: https://github.com/ratatui/ratatui/blob/images/examples/scrollbar.gif?raw=true
+[sparkline.gif]: https://github.com/ratatui/ratatui/blob/images/examples/sparkline.gif?raw=true
 [table.gif]:  https://vhs.charm.sh/vhs-6njXBytDf0rwPufUtmSSpI.gif
-[tabs.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/tabs.gif?raw=true
-[tracing.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/tracing.gif?raw=true
-[user_input.gif]: https://github.com/ratatui-org/ratatui/blob/images/examples/user_input.gif?raw=true
+[tabs.gif]: https://github.com/ratatui/ratatui/blob/images/examples/tabs.gif?raw=true
+[tracing.gif]: https://github.com/ratatui/ratatui/blob/images/examples/tracing.gif?raw=true
+[user_input.gif]: https://github.com/ratatui/ratatui/blob/images/examples/user_input.gif?raw=true
 
 [alpha version of Ratatui]: https://crates.io/crates/ratatui/versions
-[BREAKING-CHANGES.md]: https://github.com/ratatui-org/ratatui/blob/main/BREAKING-CHANGES.md
+[BREAKING-CHANGES.md]: https://github.com/ratatui/ratatui/blob/main/BREAKING-CHANGES.md

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -26,9 +26,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 use std::{
     sync::{Arc, RwLock},
     time::Duration,
@@ -174,7 +174,7 @@ impl PullRequestsWidget {
         // messages to refresh on demand, or with an interval timer to refresh every N seconds
         self.set_loading_state(LoadingState::Loading);
         match octocrab::instance()
-            .pulls("ratatui-org", "ratatui")
+            .pulls("ratatui", "ratatui")
             .list()
             .sort(Sort::Updated)
             .direction(Direction::Descending)

--- a/examples/barchart-grouped.rs
+++ b/examples/barchart-grouped.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::iter::zip;
 

--- a/examples/barchart.rs
+++ b/examples/barchart.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use color_eyre::Result;
 use rand::{thread_rng, Rng};

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{
     error::Error,
@@ -183,7 +183,7 @@ fn render_styled_block(paragraph: &Paragraph, frame: &mut Frame, area: Rect) {
     frame.render_widget(paragraph.clone().block(block), area);
 }
 
-// Note: this currently renders incorrectly, see https://github.com/ratatui-org/ratatui/issues/349
+// Note: this currently renders incorrectly, see https://github.com/ratatui/ratatui/issues/349
 fn render_styled_title(paragraph: &Paragraph, frame: &mut Frame, area: Rect) {
     let block = Block::bordered()
         .title("Styled title")

--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{error::Error, io};
 

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{
     io::{self, stdout, Stdout},

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{
     error::Error,

--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 // This example shows all the colors supported by ratatui. It will render a grid of foreground
 // and background colors with their names and indexes.

--- a/examples/colors_rgb.rs
+++ b/examples/colors_rgb.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 // This example shows the full range of RGB colors that can be displayed in the terminal.
 //

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::io::{self, stdout};
 

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::io::{self, stdout};
 

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{error::Error, io, ops::ControlFlow, time::Duration};
 

--- a/examples/demo/main.rs
+++ b/examples/demo/main.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{error::Error, time::Duration};
 

--- a/examples/demo2/main.rs
+++ b/examples/demo2/main.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 #![allow(
     clippy::missing_errors_doc,

--- a/examples/demo2/tabs/weather.rs
+++ b/examples/demo2/tabs/weather.rs
@@ -88,7 +88,7 @@ fn render_simple_barchart(area: Rect, buf: &mut Buffer) {
             Bar::default()
                 .value(value)
                 // This doesn't actually render correctly as the text is too wide for the bar
-                // See https://github.com/ratatui-org/ratatui/issues/513 for more info
+                // See https://github.com/ratatui/ratatui/issues/513 for more info
                 // (the demo GIFs hack around this by hacking the calculation in bars.rs)
                 .text_value(format!("{value}°"))
                 .style(if value > 70 {

--- a/examples/docsrs.rs
+++ b/examples/docsrs.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::io::{self, stdout};
 

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{
     io::{self, stdout},

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{io::stdout, time::Duration};
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{
     io::{self, Stdout},

--- a/examples/hyperlink.rs
+++ b/examples/hyperlink.rs
@@ -12,9 +12,9 @@
 //! library you are using.
 //!
 //! [OSC 8]: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{
     io::{self, stdout, Stdout},
@@ -96,7 +96,7 @@ impl WidgetRef for Hyperlink<'_> {
     fn render_ref(&self, area: Rect, buffer: &mut Buffer) {
         self.text.render_ref(area, buffer);
 
-        // this is a hacky workaround for https://github.com/ratatui-org/ratatui/issues/902, a bug
+        // this is a hacky workaround for https://github.com/ratatui/ratatui/issues/902, a bug
         // in the terminal code that incorrectly calculates the width of ANSI escape sequences. It
         // works by rendering the hyperlink as a series of 2-character chunks, which is the
         // calculated width of the hyperlink text.

--- a/examples/inline.rs
+++ b/examples/inline.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{
     collections::{BTreeMap, VecDeque},

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{error::Error, io};
 

--- a/examples/line_gauge.rs
+++ b/examples/line_gauge.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{io::stdout, time::Duration};
 

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{error::Error, io};
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use ratatui::{
     backend::CrosstermBackend,
@@ -28,8 +28,8 @@ use ratatui::{
 /// this is not meant to be prescriptive. See the [examples] folder for more complete examples.
 /// In particular, the [hello-world] example is a good starting point.
 ///
-/// [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-/// [hello-world]: https://github.com/ratatui-org/ratatui/blob/main/examples/hello_world.rs
+/// [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+/// [hello-world]: https://github.com/ratatui/ratatui/blob/main/examples/hello_world.rs
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut terminal = Terminal::new(CrosstermBackend::new(std::io::stdout()))?;
     enable_raw_mode()?;

--- a/examples/modifiers.rs
+++ b/examples/modifiers.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 // This example is useful for testing how your terminal emulator handles different modifiers.
 // It will render a grid of combinations of foreground and background colors with all

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 //! How to use a panic hook to reset the terminal before printing the panic to
 //! the terminal.

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{
     io::{self},

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 // See also https://github.com/joshka/tui-popup and
 // https://github.com/sephiroth74/tui-confirm-dialog

--- a/examples/ratatui-logo.rs
+++ b/examples/ratatui-logo.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{
     io::{self, stdout},

--- a/examples/scrollbar.rs
+++ b/examples/scrollbar.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 #![warn(clippy::pedantic)]
 

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{
     error::Error,

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::{error::Error, io};
 

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use std::io::stdout;
 

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 // A simple example demonstrating how to use the [tracing] with Ratatui to log to a file.
 //

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -9,9 +9,9 @@
 //! See the [examples readme] for more information on finding examples that match the version of the
 //! library you are using.
 //!
-//! [Ratatui]: https://github.com/ratatui-org/ratatui
-//! [examples]: https://github.com/ratatui-org/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
+//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 // A simple example demonstrating how to handle user input. This is a bit out of the scope of
 // the library as it does not provide any input handling out of the box. However, it may helps

--- a/examples/vhs/generate.bash
+++ b/examples/vhs/generate.bash
@@ -30,7 +30,7 @@ for tape_path in examples/vhs/*.tape; do
     gif_file=${tape_file/.tape/.gif}        # replace the .tape suffix with .gif
     ~/go/bin/vhs $tape_path --quiet
     # this can be pasted into the examples README.md
-    echo "[${gif_file}]: https://github.com/ratatui-org/ratatui/blob/images/examples/${gif_file}?raw=true"
+    echo "[${gif_file}]: https://github.com/ratatui/ratatui/blob/images/examples/${gif_file}?raw=true"
 done
 git switch images
 git pull --rebase upstream images

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -96,10 +96,10 @@
 //! [Crossterm]: https://crates.io/crates/crossterm
 //! [Termion]: https://crates.io/crates/termion
 //! [Termwiz]: https://crates.io/crates/termwiz
-//! [Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples/README.md
+//! [Examples]: https://github.com/ratatui/ratatui/tree/main/examples/README.md
 //! [Backend Comparison]:
 //!     https://ratatui.rs/concepts/backends/comparison/
-//! [Ratatui Website]: https://ratatui-org.github.io/ratatui-book
+//! [Ratatui Website]: https://ratatui.rs
 use std::io;
 
 use strum::{Display, EnumString};

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -80,7 +80,7 @@ use crate::{
 /// [`Terminal`]: crate::terminal::Terminal
 /// [`backend`]: crate::backend
 /// [Crossterm]: https://crates.io/crates/crossterm
-/// [Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples/README.md
+/// [Examples]: https://github.com/ratatui/ratatui/tree/main/examples/README.md
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct CrosstermBackend<W: Write> {
     /// The writer used to send commands to the terminal.
@@ -107,7 +107,7 @@ where
     /// Gets the writer.
     #[instability::unstable(
         feature = "backend-writer",
-        issue = "https://github.com/ratatui-org/ratatui/pull/991"
+        issue = "https://github.com/ratatui/ratatui/pull/991"
     )]
     pub const fn writer(&self) -> &W {
         &self.writer
@@ -119,7 +119,7 @@ where
     /// way that the Terminal implements diffing Buffers.
     #[instability::unstable(
         feature = "backend-writer",
-        issue = "https://github.com/ratatui-org/ratatui/pull/991"
+        issue = "https://github.com/ratatui/ratatui/pull/991"
     )]
     pub fn writer_mut(&mut self) -> &mut W {
         &mut self.writer

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -90,7 +90,7 @@ where
     /// Gets the writer.
     #[instability::unstable(
         feature = "backend-writer",
-        issue = "https://github.com/ratatui-org/ratatui/pull/991"
+        issue = "https://github.com/ratatui/ratatui/pull/991"
     )]
     pub const fn writer(&self) -> &W {
         &self.writer
@@ -101,7 +101,7 @@ where
     /// way that the Terminal implements diffing Buffers.
     #[instability::unstable(
         feature = "backend-writer",
-        issue = "https://github.com/ratatui-org/ratatui/pull/991"
+        issue = "https://github.com/ratatui/ratatui/pull/991"
     )]
     pub fn writer_mut(&mut self) -> &mut W {
         &mut self.writer

--- a/src/backend/termwiz.rs
+++ b/src/backend/termwiz.rs
@@ -57,7 +57,7 @@ use crate::{
 /// [`Terminal`]: crate::terminal::Terminal
 /// [`BufferedTerminal`]: termwiz::terminal::buffered::BufferedTerminal
 /// [Termwiz]: https://crates.io/crates/termwiz
-/// [Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples/README.md
+/// [Examples]: https://github.com/ratatui/ratatui/tree/main/examples/README.md
 pub struct TermwizBackend {
     buffered_terminal: BufferedTerminal<SystemTerminal>,
 }

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -246,7 +246,7 @@ impl Buffer {
     ///
     /// Returns `None` if the given coordinates are outside of the Buffer's area.
     ///
-    /// Note that this is private because of <https://github.com/ratatui-org/ratatui/issues/1122>
+    /// Note that this is private because of <https://github.com/ratatui/ratatui/issues/1122>
     #[must_use]
     const fn index_of_opt(&self, position: Position) -> Option<usize> {
         let area = self.area;

--- a/src/buffer/cell.rs
+++ b/src/buffer/cell.rs
@@ -13,7 +13,7 @@ pub struct Cell {
     /// This is a [`CompactString`] which is a wrapper around [`String`] that uses a small inline
     /// buffer for short strings.
     ///
-    /// See <https://github.com/ratatui-org/ratatui/pull/601> for more information.
+    /// See <https://github.com/ratatui/ratatui/pull/601> for more information.
     symbol: CompactString,
 
     /// The foreground color of the cell.

--- a/src/layout/layout.rs
+++ b/src/layout/layout.rs
@@ -107,7 +107,7 @@ thread_local! {
 /// example](https://camo.githubusercontent.com/77d22f3313b782a81e5e033ef82814bb48d786d2598699c27f8e757ccee62021/68747470733a2f2f7668732e636861726d2e73682f7668732d315a4e6f4e4c4e6c4c746b4a58706767396e435635652e676966)
 ///
 /// [`cassowary-rs`]: https://crates.io/crates/cassowary
-/// [Examples]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+/// [Examples]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct Layout {
     direction: Direction,
@@ -1888,7 +1888,7 @@ mod tests {
             );
 
             // minimal bug from
-            // https://github.com/ratatui-org/ratatui/pull/404#issuecomment-1681850644
+            // https://github.com/ratatui/ratatui/pull/404#issuecomment-1681850644
             // TODO: check if this bug is now resolved?
             let layout = Layout::default()
                 .constraints([Min(1), Length(0), Min(1)])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! ![Demo](https://github.com/ratatui-org/ratatui/blob/87ae72dbc756067c97f6400d3e2a58eeb383776e/examples/demo2-destroy.gif?raw=true)
+//! ![Demo](https://github.com/ratatui/ratatui/blob/87ae72dbc756067c97f6400d3e2a58eeb383776e/examples/demo2-destroy.gif?raw=true)
 //!
 //! <div align="center">
 //!
@@ -259,21 +259,21 @@
 //! [Handling Events]: https://ratatui.rs/concepts/event-handling/
 //! [Layout]: https://ratatui.rs/how-to/layout/
 //! [Styling Text]: https://ratatui.rs/how-to/render/style-text/
-//! [templates]: https://github.com/ratatui-org/templates/
-//! [Examples]: https://github.com/ratatui-org/ratatui/tree/main/examples/README.md
-//! [Report a bug]: https://github.com/ratatui-org/ratatui/issues/new?labels=bug&projects=&template=bug_report.md
-//! [Request a Feature]: https://github.com/ratatui-org/ratatui/issues/new?labels=enhancement&projects=&template=feature_request.md
-//! [Create a Pull Request]: https://github.com/ratatui-org/ratatui/compare
+//! [templates]: https://github.com/ratatui/templates/
+//! [Examples]: https://github.com/ratatui/ratatui/tree/main/examples/README.md
+//! [Report a bug]: https://github.com/ratatui/ratatui/issues/new?labels=bug&projects=&template=bug_report.md
+//! [Request a Feature]: https://github.com/ratatui/ratatui/issues/new?labels=enhancement&projects=&template=feature_request.md
+//! [Create a Pull Request]: https://github.com/ratatui/ratatui/compare
 //! [git-cliff]: https://git-cliff.org
 //! [Conventional Commits]: https://www.conventionalcommits.org
 //! [API Docs]: https://docs.rs/ratatui
-//! [Changelog]: https://github.com/ratatui-org/ratatui/blob/main/CHANGELOG.md
-//! [Contributing]: https://github.com/ratatui-org/ratatui/blob/main/CONTRIBUTING.md
-//! [Breaking Changes]: https://github.com/ratatui-org/ratatui/blob/main/BREAKING-CHANGES.md
+//! [Changelog]: https://github.com/ratatui/ratatui/blob/main/CHANGELOG.md
+//! [Contributing]: https://github.com/ratatui/ratatui/blob/main/CONTRIBUTING.md
+//! [Breaking Changes]: https://github.com/ratatui/ratatui/blob/main/BREAKING-CHANGES.md
 //! [FOSDEM 2024 talk]: https://www.youtube.com/watch?v=NU0q6NOLJ20
-//! [docsrs-hello]: https://github.com/ratatui-org/ratatui/blob/c3c3c289b1eb8d562afb1931adb4dc719cd48490/examples/docsrs-hello.png?raw=true
-//! [docsrs-layout]: https://github.com/ratatui-org/ratatui/blob/c3c3c289b1eb8d562afb1931adb4dc719cd48490/examples/docsrs-layout.png?raw=true
-//! [docsrs-styling]: https://github.com/ratatui-org/ratatui/blob/c3c3c289b1eb8d562afb1931adb4dc719cd48490/examples/docsrs-styling.png?raw=true
+//! [docsrs-hello]: https://github.com/ratatui/ratatui/blob/c3c3c289b1eb8d562afb1931adb4dc719cd48490/examples/docsrs-hello.png?raw=true
+//! [docsrs-layout]: https://github.com/ratatui/ratatui/blob/c3c3c289b1eb8d562afb1931adb4dc719cd48490/examples/docsrs-layout.png?raw=true
+//! [docsrs-styling]: https://github.com/ratatui/ratatui/blob/c3c3c289b1eb8d562afb1931adb4dc719cd48490/examples/docsrs-styling.png?raw=true
 //! [`Frame`]: terminal::Frame
 //! [`render_widget`]: terminal::Frame::render_widget
 //! [`Widget`]: widgets::Widget
@@ -292,15 +292,15 @@
 //! [Termion]: https://crates.io/crates/termion
 //! [Termwiz]: https://crates.io/crates/termwiz
 //! [tui-rs]: https://crates.io/crates/tui
-//! [GitHub Sponsors]: https://github.com/sponsors/ratatui-org
+//! [GitHub Sponsors]: https://github.com/sponsors/ratatui
 //! [Crate Badge]: https://img.shields.io/crates/v/ratatui?logo=rust&style=flat-square&logoColor=E05D44&color=E05D44
 //! [License Badge]: https://img.shields.io/crates/l/ratatui?style=flat-square&color=1370D3
-//! [CI Badge]: https://img.shields.io/github/actions/workflow/status/ratatui-org/ratatui/ci.yml?style=flat-square&logo=github
-//! [CI Workflow]: https://github.com/ratatui-org/ratatui/actions/workflows/ci.yml
-//! [Codecov Badge]: https://img.shields.io/codecov/c/github/ratatui-org/ratatui?logo=codecov&style=flat-square&token=BAQ8SOKEST&color=C43AC3&logoColor=C43AC3
-//! [Codecov]: https://app.codecov.io/gh/ratatui-org/ratatui
-//! [Deps.rs Badge]: https://deps.rs/repo/github/ratatui-org/ratatui/status.svg?style=flat-square
-//! [Deps.rs]: https://deps.rs/repo/github/ratatui-org/ratatui
+//! [CI Badge]: https://img.shields.io/github/actions/workflow/status/ratatui/ratatui/ci.yml?style=flat-square&logo=github
+//! [CI Workflow]: https://github.com/ratatui/ratatui/actions/workflows/ci.yml
+//! [Codecov Badge]: https://img.shields.io/codecov/c/github/ratatui/ratatui?logo=codecov&style=flat-square&token=BAQ8SOKEST&color=C43AC3&logoColor=C43AC3
+//! [Codecov]: https://app.codecov.io/gh/ratatui/ratatui
+//! [Deps.rs Badge]: https://deps.rs/repo/github/ratatui/ratatui/status.svg?style=flat-square
+//! [Deps.rs]: https://deps.rs/repo/github/ratatui/ratatui
 //! [Discord Badge]: https://img.shields.io/discord/1070692720437383208?label=discord&logo=discord&style=flat-square&color=1370D3&logoColor=1370D3
 //! [Discord Server]: https://discord.gg/pMCEU9hNEj
 //! [Docs Badge]: https://img.shields.io/docsrs/ratatui?logo=rust&style=flat-square&logoColor=E05D44
@@ -308,13 +308,13 @@
 //! [Matrix]: https://matrix.to/#/#ratatui:matrix.org
 //! [Forum Badge]: https://img.shields.io/discourse/likes?server=https%3A%2F%2Fforum.ratatui.rs&style=flat-square&logo=discourse&label=forum&color=C43AC3
 //! [Forum]: https://forum.ratatui.rs
-//! [Sponsors Badge]: https://img.shields.io/github/sponsors/ratatui-org?logo=github&style=flat-square&color=1370D3
+//! [Sponsors Badge]: https://img.shields.io/github/sponsors/ratatui?logo=github&style=flat-square&color=1370D3
 
 // show the feature flags in the generated documentation
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/ratatui-org/ratatui/main/assets/logo.png",
-    html_favicon_url = "https://raw.githubusercontent.com/ratatui-org/ratatui/main/assets/favicon.ico"
+    html_logo_url = "https://raw.githubusercontent.com/ratatui/ratatui/main/assets/logo.png",
+    html_favicon_url = "https://raw.githubusercontent.com/ratatui/ratatui/main/assets/favicon.ico"
 )]
 
 /// re-export the `crossterm` crate so that users don't have to add it as a dependency

--- a/src/style/color.rs
+++ b/src/style/color.rs
@@ -113,7 +113,7 @@ pub enum Color {
     /// If the terminal does not support true color, code using the  [`TermwizBackend`] will
     /// fallback to the default text color. Crossterm and Termion do not have this capability and
     /// the display will be unpredictable (e.g. Terminal.app may display glitched blinking text).
-    /// See <https://github.com/ratatui-org/ratatui/issues/475> for an example of this problem.
+    /// See <https://github.com/ratatui/ratatui/issues/475> for an example of this problem.
     ///
     /// See also: <https://en.wikipedia.org/wiki/ANSI_escape_code#24-bit>
     ///

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -1193,7 +1193,7 @@ mod tests {
             assert_eq!(buf, Buffer::with_lines(["lo wo"]));
         }
 
-        /// Part of a regression test for <https://github.com/ratatui-org/ratatui/issues/1032> which
+        /// Part of a regression test for <https://github.com/ratatui/ratatui/issues/1032> which
         /// found panics with truncating lines that contained multi-byte characters.
         #[test]
         fn regression_1032() {
@@ -1209,7 +1209,7 @@ mod tests {
 
         /// Documentary test to highlight the crab emoji width / length discrepancy
         ///
-        /// Part of a regression test for <https://github.com/ratatui-org/ratatui/issues/1032> which
+        /// Part of a regression test for <https://github.com/ratatui/ratatui/issues/1032> which
         /// found panics with truncating lines that contained multi-byte characters.
         #[test]
         fn crab_emoji_width() {
@@ -1220,7 +1220,7 @@ mod tests {
             assert_eq!(crab.width(), 2); // display width
         }
 
-        /// Part of a regression test for <https://github.com/ratatui-org/ratatui/issues/1032> which
+        /// Part of a regression test for <https://github.com/ratatui/ratatui/issues/1032> which
         /// found panics with truncating lines that contained multi-byte characters.
         #[rstest]
         #[case::left_4(Alignment::Left, 4, "1234")]
@@ -1242,7 +1242,7 @@ mod tests {
             assert_eq!(buf, Buffer::with_lines([expected]));
         }
 
-        /// Part of a regression test for <https://github.com/ratatui-org/ratatui/issues/1032> which
+        /// Part of a regression test for <https://github.com/ratatui/ratatui/issues/1032> which
         /// found panics with truncating lines that contained multi-byte characters.
         ///
         /// centering is tricky because there's an ambiguity about whether to take one more char
@@ -1331,7 +1331,7 @@ mod tests {
             assert_eq!(buf, Buffer::with_lines([expected]));
         }
 
-        /// Part of a regression test for <https://github.com/ratatui-org/ratatui/issues/1032> which
+        /// Part of a regression test for <https://github.com/ratatui/ratatui/issues/1032> which
         /// found panics with truncating lines that contained multi-byte characters.
         ///
         /// Flag emoji are actually two independent characters, so they can be truncated in the
@@ -1345,7 +1345,7 @@ mod tests {
             assert_eq!(str.width(), 6); // flag is 2 display width
         }
 
-        /// Part of a regression test for <https://github.com/ratatui-org/ratatui/issues/1032> which
+        /// Part of a regression test for <https://github.com/ratatui/ratatui/issues/1032> which
         /// found panics with truncating lines that contained multi-byte characters.
         #[rstest]
         #[case::flag_1(1, " ")]

--- a/src/text/span.rs
+++ b/src/text/span.rs
@@ -569,7 +569,7 @@ mod tests {
         assert_eq!(Span::raw("").width(), 0);
         assert_eq!(Span::raw("test").width(), 4);
         assert_eq!(Span::raw("test content").width(), 12);
-        // Needs reconsideration: https://github.com/ratatui-org/ratatui/issues/1271
+        // Needs reconsideration: https://github.com/ratatui/ratatui/issues/1271
         assert_eq!(Span::raw("test\ncontent").width(), 12);
     }
 
@@ -786,7 +786,7 @@ mod tests {
         }
     }
 
-    /// Regression test for <https://github.com/ratatui-org/ratatui/issues/1160> One line contains
+    /// Regression test for <https://github.com/ratatui/ratatui/issues/1160> One line contains
     /// some Unicode Left-Right-Marks (U+200E)
     ///
     /// The issue was that a zero-width character at the end of the buffer causes the buffer bounds

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -68,7 +68,7 @@ use crate::{buffer::Buffer, layout::Rect, style::Style};
 /// internal widgets. In addition to the above benefit of rendering references to widgets, this also
 /// allows you to render boxed widgets. This is useful when you want to store a collection of
 /// widgets with different types. You can then iterate over the collection and render each widget.
-/// See <https://github.com/ratatui-org/ratatui/issues/1287> for more information.
+/// See <https://github.com/ratatui/ratatui/issues/1287> for more information.
 ///
 /// In general where you expect a widget to immutably work on its data, we recommended to implement
 /// `Widget` for a reference to the widget (`impl Widget for &MyWidget`). If you need to store state
@@ -245,7 +245,7 @@ pub trait StatefulWidget {
 ///
 /// This trait was introduced in Ratatui 0.26.0 and is implemented for all the internal widgets. It
 /// is currently marked as unstable as we are still evaluating the API and may make changes in the
-/// future. See <https://github.com/ratatui-org/ratatui/issues/1287> for more information.
+/// future. See <https://github.com/ratatui/ratatui/issues/1287> for more information.
 ///
 /// A blanket implementation of `Widget` for `&W` where `W` implements `WidgetRef` is provided.
 ///
@@ -368,7 +368,7 @@ impl<W: WidgetRef> WidgetRef for Option<W> {
 ///
 /// This trait was introduced in Ratatui 0.26.0 and is implemented for all the internal stateful
 /// widgets. It is currently marked as unstable as we are still evaluating the API and may make
-/// changes in the future. See <https://github.com/ratatui-org/ratatui/issues/1287> for more
+/// changes in the future. See <https://github.com/ratatui/ratatui/issues/1287> for more
 /// information.
 ///
 /// A blanket implementation of `StatefulWidget` for `&W` where `W` implements `StatefulWidgetRef`

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -288,7 +288,7 @@ impl<'a> Block<'a> {
     /// - [`Block::title_alignment`]
     /// - [`Block::title_position`]
     ///
-    /// [Block example]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md#block
+    /// [Block example]: https://github.com/ratatui/ratatui/blob/main/examples/README.md#block
     #[must_use = "method moves the value of self and returns the modified value"]
     pub fn title<T>(mut self, title: T) -> Self
     where
@@ -787,7 +787,7 @@ impl Block<'_> {
     /// Currently (due to the way lines are truncated), the right side of the leftmost title will
     /// be cut off if the block is too small to fit all titles. This is not ideal and should be
     /// the left side of that leftmost that is cut off. This is due to the line being truncated
-    /// incorrectly. See <https://github.com/ratatui-org/ratatui/issues/932>
+    /// incorrectly. See <https://github.com/ratatui/ratatui/issues/932>
     #[allow(clippy::similar_names)]
     fn render_right_titles(&self, position: Position, area: Rect, buf: &mut Buffer) {
         let titles = self.filtered_titles(position, Alignment::Right);
@@ -1381,7 +1381,7 @@ mod tests {
         }
     }
 
-    /// This is a regression test for bug <https://github.com/ratatui-org/ratatui/issues/929>
+    /// This is a regression test for bug <https://github.com/ratatui/ratatui/issues/929>
     #[test]
     fn render_right_aligned_empty_title() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 15, 3));

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -82,7 +82,7 @@ impl<'a> Axis<'a> {
     /// more than 3 labels is currently broken and the middle labels won't be in the correct
     /// position, see [issue 334].
     ///
-    /// [issue 334]: https://github.com/ratatui-org/ratatui/issues/334
+    /// [issue 334]: https://github.com/ratatui/ratatui/issues/334
     ///
     /// `labels` is a vector of any type that can be converted into a [`Line`] (e.g. `&str`,
     /// `String`, `&Line`, `Span`, ...). This allows you to style the labels using the methods

--- a/src/widgets/list/list.rs
+++ b/src/widgets/list/list.rs
@@ -28,7 +28,7 @@ use crate::{
 /// See the list in the [Examples] directory for a more in depth example of the various
 /// configuration options and for how to handle state.
 ///
-/// [Examples]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+/// [Examples]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 ///
 /// # Fluent setters
 ///

--- a/src/widgets/list/rendering.rs
+++ b/src/widgets/list/rendering.rs
@@ -1250,7 +1250,7 @@ mod tests {
     /// Regression test for a bug where highlight symbol being greater than width caused a panic due
     /// to subtraction with underflow.
     ///
-    /// See [#949](https://github.com/ratatui-org/ratatui/pull/949) for details
+    /// See [#949](https://github.com/ratatui/ratatui/pull/949) for details
     #[rstest]
     #[case::under(">>>>", "Item1", ">>>>Item1 ")] // enough space to render the highlight symbol
     #[case::exact(">>>>>", "Item1", ">>>>>Item1")] // exact space to render the highlight symbol

--- a/src/widgets/list/state.rs
+++ b/src/widgets/list/state.rs
@@ -15,7 +15,7 @@
 /// See the list in the [Examples] directory for a more in depth example of the various
 /// configuration options and for how to handle state.
 ///
-/// [Examples]: https://github.com/ratatui-org/ratatui/blob/main/examples/README.md
+/// [Examples]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 ///
 /// # Example
 ///

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -220,7 +220,7 @@ impl<'a> Paragraph<'a> {
     /// convention across the crate.
     ///
     /// For more information about future scrolling design and concerns, see [RFC: Design of
-    /// Scrollable Widgets](https://github.com/ratatui-org/ratatui/issues/174) on GitHub.
+    /// Scrollable Widgets](https://github.com/ratatui/ratatui/issues/174) on GitHub.
     #[must_use = "method moves the value of self and returns the modified value"]
     pub const fn scroll(mut self, offset: (Vertical, Horizontal)) -> Self {
         self.scroll = Position {
@@ -313,7 +313,7 @@ impl<'a> Paragraph<'a> {
     /// ```
     #[instability::unstable(
         feature = "rendered-line-info",
-        issue = "https://github.com/ratatui-org/ratatui/issues/293"
+        issue = "https://github.com/ratatui/ratatui/issues/293"
     )]
     pub fn line_count(&self, width: u16) -> usize {
         if width < 1 {
@@ -368,7 +368,7 @@ impl<'a> Paragraph<'a> {
     /// ```
     #[instability::unstable(
         feature = "rendered-line-info",
-        issue = "https://github.com/ratatui-org/ratatui/issues/293"
+        issue = "https://github.com/ratatui/ratatui/issues/293"
     )]
     pub fn line_width(&self) -> usize {
         let width = self.text.iter().map(Line::width).max().unwrap_or_default();
@@ -1128,7 +1128,7 @@ mod test {
         assert_eq!(p.alignment, Alignment::Right);
     }
 
-    /// Regression test for <https://github.com/ratatui-org/ratatui/issues/990>
+    /// Regression test for <https://github.com/ratatui/ratatui/issues/990>
     ///
     /// This test ensures that paragraphs with a block and styled text are rendered correctly.
     /// It has been simplified from the original issue but tests the same functionality.

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -1015,7 +1015,7 @@ mod tests {
         assert_eq!(buffer, Buffer::with_lines([expected]));
     }
 
-    /// Fixes <https://github.com/ratatui-org/ratatui/pull/959> which was a bug that would not
+    /// Fixes <https://github.com/ratatui/ratatui/pull/959> which was a bug that would not
     /// render a thumb when the viewport was very small in comparison to the content length.
     #[rstest]
     #[case::position_0("#----", 0, 100)]

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -30,7 +30,7 @@ use crate::{layout::Flex, prelude::*, style::Styled, widgets::Block};
 /// directory for a more in depth example of the various configuration options and for how to handle
 /// state.
 ///
-/// [Examples]: https://github.com/ratatui-org/ratatui/blob/master/examples/README.md
+/// [Examples]: https://github.com/ratatui/ratatui/blob/master/examples/README.md
 ///
 /// # Constructor methods
 ///
@@ -1280,7 +1280,7 @@ mod tests {
 
         /// Note that this includes a regression test for a bug where the table would not render the
         /// correct rows when there is no selection.
-        /// <https://github.com/ratatui-org/ratatui/issues/1179>
+        /// <https://github.com/ratatui/ratatui/issues/1179>
         #[rstest]
         #[case::no_selection(None, 50, ["50", "51", "52", "53", "54"])]
         #[case::selection_before_offset(20, 20, ["20", "21", "22", "23", "24"])]

--- a/src/widgets/table/table_state.rs
+++ b/src/widgets/table/table_state.rs
@@ -16,7 +16,7 @@
 /// [Examples] directory for a more in depth example of the various configuration options and for
 /// how to handle state.
 ///
-/// [Examples]: https://github.com/ratatui-org/ratatui/blob/master/examples/README.md
+/// [Examples]: https://github.com/ratatui/ratatui/blob/master/examples/README.md
 ///
 /// # Example
 ///

--- a/typos.toml
+++ b/typos.toml
@@ -5,5 +5,5 @@ ratatui = "ratatui"
 
 [type.md]
 extend-ignore-re = [
-  "\\[[[:xdigit:]]{7}\\]\\(https://github.com/ratatui-org/ratatui/commit/[[:xdigit:]]{40}\\)",
+  "\\[[[:xdigit:]]{7}\\]\\(https://github.com/ratatui/ratatui/commit/[[:xdigit:]]{40}\\)",
 ]


### PR DESCRIPTION
All urls updated to point at https://github.com/ratatui

To update your repository remotes, you can run the following commands:

```shell
git remote set-url origin https://github.com/ratatui/ratatui
```