### PR TITLE
test: Avoid unneeded allocations in assertions

### DIFF
--- a/src/style/stylize.rs
+++ b/src/style/stylize.rs
@@ -346,7 +346,7 @@ mod tests {
         // issue as above without the `Styled` trait impl for `String`
         let items = [String::from("a"), String::from("b")];
         let sss = items.iter().map(|s| format!("{s}{s}").red()).collect_vec();
-        assert_eq!(sss, vec![Span::from("aa").red(), Span::from("bb").red()]);
+        assert_eq!(sss, [Span::from("aa").red(), Span::from("bb").red()]);
     }
 
     #[test]

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -741,11 +741,11 @@ mod tests {
     #[test]
     fn raw_str() {
         let line = Line::raw("test content");
-        assert_eq!(line.spans, vec![Span::raw("test content")]);
+        assert_eq!(line.spans, [Span::raw("test content")]);
         assert_eq!(line.alignment, None);
 
         let line = Line::raw("a\nb");
-        assert_eq!(line.spans, vec![Span::raw("a"), Span::raw("b")]);
+        assert_eq!(line.spans, [Span::raw("a"), Span::raw("b")]);
         assert_eq!(line.alignment, None);
     }
 
@@ -754,7 +754,7 @@ mod tests {
         let style = Style::new().yellow();
         let content = "Hello, world!";
         let line = Line::styled(content, style);
-        assert_eq!(line.spans, vec![Span::raw(content)]);
+        assert_eq!(line.spans, [Span::raw(content)]);
         assert_eq!(line.style, style);
     }
 
@@ -763,7 +763,7 @@ mod tests {
         let style = Style::new().yellow();
         let content = String::from("Hello, world!");
         let line = Line::styled(content.clone(), style);
-        assert_eq!(line.spans, vec![Span::raw(content)]);
+        assert_eq!(line.spans, [Span::raw(content)]);
         assert_eq!(line.style, style);
     }
 
@@ -772,7 +772,7 @@ mod tests {
         let style = Style::new().yellow();
         let content = Cow::from("Hello, world!");
         let line = Line::styled(content.clone(), style);
-        assert_eq!(line.spans, vec![Span::raw(content)]);
+        assert_eq!(line.spans, [Span::raw(content)]);
         assert_eq!(line.style, style);
     }
 
@@ -861,28 +861,28 @@ mod tests {
     fn from_string() {
         let s = String::from("Hello, world!");
         let line = Line::from(s);
-        assert_eq!(line.spans, vec![Span::from("Hello, world!")]);
+        assert_eq!(line.spans, [Span::from("Hello, world!")]);
 
         let s = String::from("Hello\nworld!");
         let line = Line::from(s);
-        assert_eq!(line.spans, vec![Span::from("Hello"), Span::from("world!")]);
+        assert_eq!(line.spans, [Span::from("Hello"), Span::from("world!")]);
     }
 
     #[test]
     fn from_str() {
         let s = "Hello, world!";
         let line = Line::from(s);
-        assert_eq!(line.spans, vec![Span::from("Hello, world!")]);
+        assert_eq!(line.spans, [Span::from("Hello, world!")]);
 
         let s = "Hello\nworld!";
         let line = Line::from(s);
-        assert_eq!(line.spans, vec![Span::from("Hello"), Span::from("world!")]);
+        assert_eq!(line.spans, [Span::from("Hello"), Span::from("world!")]);
     }
 
     #[test]
     fn to_line() {
         let line = 42.to_line();
-        assert_eq!(vec![Span::from("42")], line.spans);
+        assert_eq!(line.spans, [Span::from("42")]);
     }
 
     #[test]
@@ -925,7 +925,7 @@ mod tests {
     fn from_span() {
         let span = Span::styled("Hello, world!", Style::default().fg(Color::Yellow));
         let line = Line::from(span.clone());
-        assert_eq!(line.spans, vec![span],);
+        assert_eq!(line.spans, [span]);
     }
 
     #[test]
@@ -969,14 +969,14 @@ mod tests {
     #[test]
     fn extend() {
         let mut line = Line::from("Hello, ");
-        line.extend(vec![Span::raw("world!")]);
-        assert_eq!(line.spans, vec![Span::raw("Hello, "), Span::raw("world!")]);
+        line.extend([Span::raw("world!")]);
+        assert_eq!(line.spans, [Span::raw("Hello, "), Span::raw("world!")]);
 
         let mut line = Line::from("Hello, ");
-        line.extend(vec![Span::raw("world! "), Span::raw("How are you?")]);
+        line.extend([Span::raw("world! "), Span::raw("How are you?")]);
         assert_eq!(
             line.spans,
-            vec![
+            [
                 Span::raw("Hello, "),
                 Span::raw("world! "),
                 Span::raw("How are you?")

--- a/src/text/masked.rs
+++ b/src/text/masked.rs
@@ -125,10 +125,10 @@ mod tests {
         let masked = Masked::new("12345", 'x');
 
         let text: Text = (&masked).into();
-        assert_eq!(text.lines, vec![Line::from("xxxxx")]);
+        assert_eq!(text.lines, [Line::from("xxxxx")]);
 
         let text: Text = masked.into();
-        assert_eq!(text.lines, vec![Line::from("xxxxx")]);
+        assert_eq!(text.lines, [Line::from("xxxxx")]);
     }
 
     #[test]

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -794,7 +794,7 @@ mod tests {
     #[test]
     fn from_line() {
         let text = Text::from(Line::from("The first line"));
-        assert_eq!(text.lines, vec![Line::from("The first line")]);
+        assert_eq!(text.lines, [Line::from("The first line")]);
     }
 
     #[rstest]
@@ -1042,7 +1042,7 @@ mod tests {
     fn push_line_empty() {
         let mut text = Text::default();
         text.push_line(Line::from("Hello, world!"));
-        assert_eq!(text.lines, vec![Line::from("Hello, world!")]);
+        assert_eq!(text.lines, [Line::from("Hello, world!")]);
     }
 
     #[test]
@@ -1064,7 +1064,7 @@ mod tests {
     fn push_span_empty() {
         let mut text = Text::default();
         text.push_span(Span::raw("Hello, world!"));
-        assert_eq!(text.lines, vec![Line::from(Span::raw("Hello, world!"))],);
+        assert_eq!(text.lines, [Line::from(Span::raw("Hello, world!"))]);
     }
 
     mod widget {

--- a/src/widgets/reflow.rs
+++ b/src/widgets/reflow.rs
@@ -500,7 +500,7 @@ mod test {
             .filter(|g| g.chars().any(|c| !c.is_whitespace()))
             .collect();
         assert_eq!(word_wrapper, expected);
-        assert_eq!(line_truncator, vec!["a"]);
+        assert_eq!(line_truncator, ["a"]);
     }
 
     #[test]
@@ -511,8 +511,8 @@ mod test {
                     両端点では、";
         let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, text, width);
         let (line_truncator, _, _) = run_composer(Composer::LineTruncator, text, width);
-        assert_eq!(word_wrapper, vec!["", "a", "a", "a", "a"]);
-        assert_eq!(line_truncator, vec!["", "a", "a"]);
+        assert_eq!(word_wrapper, ["", "a", "a", "a", "a"]);
+        assert_eq!(line_truncator, ["", "a", "a"]);
     }
 
     /// Tests `WordWrapper` with words some of which exceed line length and some not.
@@ -541,8 +541,8 @@ mod test {
         let (word_wrapper, word_wrapper_width, _) =
             run_composer(Composer::WordWrapper { trim: true }, text, width);
         let (line_truncator, _, _) = run_composer(Composer::LineTruncator, text, width);
-        assert_eq!(line_truncator, vec!["コンピュータ上で文字"]);
-        let wrapped = vec![
+        assert_eq!(line_truncator, ["コンピュータ上で文字"]);
+        let wrapped = [
             "コンピュータ上で文字",
             "を扱う場合、典型的に",
             "は文字による通信を行",
@@ -550,7 +550,7 @@ mod test {
             "は、",
         ];
         assert_eq!(word_wrapper, wrapped);
-        assert_eq!(word_wrapper_width, vec![width, width, width, width, 4]);
+        assert_eq!(word_wrapper_width, [width, width, width, width, 4]);
     }
 
     #[test]
@@ -559,8 +559,8 @@ mod test {
         let text = "AAAAAAAAAAAAAAAAAAAA    AAA";
         let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, text, width);
         let (line_truncator, _, _) = run_composer(Composer::LineTruncator, text, width);
-        assert_eq!(word_wrapper, vec!["AAAAAAAAAAAAAAAAAAAA", "AAA",]);
-        assert_eq!(line_truncator, vec!["AAAAAAAAAAAAAAAAAAAA"]);
+        assert_eq!(word_wrapper, ["AAAAAAAAAAAAAAAAAAAA", "AAA"]);
+        assert_eq!(line_truncator, ["AAAAAAAAAAAAAAAAAAAA"]);
     }
 
     /// Tests truncation of leading whitespace.
@@ -570,8 +570,8 @@ mod test {
         let text = "                                                                     ";
         let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, text, width);
         let (line_truncator, _, _) = run_composer(Composer::LineTruncator, text, width);
-        assert_eq!(word_wrapper, vec![""]);
-        assert_eq!(line_truncator, vec!["                    "]);
+        assert_eq!(word_wrapper, [""]);
+        assert_eq!(line_truncator, ["                    "]);
     }
 
     /// Tests an input starting with a letter, followed by spaces - some of the behaviour is
@@ -586,8 +586,8 @@ mod test {
         // after 20 of which a word break occurs (probably shouldn't). The second line break
         // discards all whitespace. The result should probably be vec!["a"] but it doesn't matter
         // that much.
-        assert_eq!(word_wrapper, vec!["a", ""]);
-        assert_eq!(line_truncator, vec!["a                   "]);
+        assert_eq!(word_wrapper, ["a", ""]);
+        assert_eq!(line_truncator, ["a                   "]);
     }
 
     #[test]
@@ -614,7 +614,7 @@ mod test {
             ]
         );
         // Odd-sized lines have a space in them.
-        assert_eq!(word_wrapper_width, vec![8, 20, 17, 17, 20, 4]);
+        assert_eq!(word_wrapper_width, [8, 20, 17, 17, 20, 4]);
     }
 
     /// Ensure words separated by nbsp are wrapped as if they were a single one.
@@ -624,15 +624,15 @@ mod test {
         let text = "AAAAAAAAAAAAAAA AAAA\u{00a0}AAA";
         let (word_wrapper, word_wrapper_widths, _) =
             run_composer(Composer::WordWrapper { trim: true }, text, width);
-        assert_eq!(word_wrapper, vec!["AAAAAAAAAAAAAAA", "AAAA\u{00a0}AAA",]);
-        assert_eq!(word_wrapper_widths, vec![15, 8]);
+        assert_eq!(word_wrapper, ["AAAAAAAAAAAAAAA", "AAAA\u{00a0}AAA"]);
+        assert_eq!(word_wrapper_widths, [15, 8]);
 
         // Ensure that if the character was a regular space, it would be wrapped differently.
         let text_space = text.replace('\u{00a0}', " ");
         let (word_wrapper_space, word_wrapper_widths, _) =
             run_composer(Composer::WordWrapper { trim: true }, text_space, width);
-        assert_eq!(word_wrapper_space, vec!["AAAAAAAAAAAAAAA AAAA", "AAA",]);
-        assert_eq!(word_wrapper_widths, vec![20, 3]);
+        assert_eq!(word_wrapper_space, ["AAAAAAAAAAAAAAA AAAA", "AAA"]);
+        assert_eq!(word_wrapper_widths, [20, 3]);
     }
 
     #[test]
@@ -640,7 +640,7 @@ mod test {
         let width = 20;
         let text = "AAAAAAAAAAAAAAAAAAAA    AAA";
         let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: false }, text, width);
-        assert_eq!(word_wrapper, vec!["AAAAAAAAAAAAAAAAAAAA", "   AAA",]);
+        assert_eq!(word_wrapper, ["AAAAAAAAAAAAAAAAAAAA", "   AAA"]);
     }
 
     #[test]
@@ -678,8 +678,8 @@ mod test {
         let line = "foo\u{200B}";
         let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, line, width);
         let (line_truncator, _, _) = run_composer(Composer::LineTruncator, line, width);
-        assert_eq!(word_wrapper, vec!["foo"]);
-        assert_eq!(line_truncator, vec!["foo\u{200B}"]);
+        assert_eq!(word_wrapper, ["foo"]);
+        assert_eq!(line_truncator, ["foo\u{200B}"]);
     }
 
     #[test]
@@ -716,6 +716,6 @@ mod test {
         let width = 3;
         let line = "foo\u{200b}bar";
         let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, line, width);
-        assert_eq!(word_wrapper, vec!["foo", "bar"]);
+        assert_eq!(word_wrapper, ["foo", "bar"]);
     }
 }

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -891,10 +891,10 @@ mod tests {
     #[test]
     fn default() {
         let table = Table::default();
-        assert_eq!(table.rows, vec![]);
+        assert_eq!(table.rows, []);
         assert_eq!(table.header, None);
         assert_eq!(table.footer, None);
-        assert_eq!(table.widths, vec![]);
+        assert_eq!(table.widths, []);
         assert_eq!(table.column_spacing, 1);
         assert_eq!(table.block, None);
         assert_eq!(table.style, Style::default());
@@ -1009,24 +1009,24 @@ mod tests {
     fn widths_conversions() {
         let array = [Constraint::Percentage(100)];
         let table = Table::new(Vec::<Row>::new(), array);
-        assert_eq!(table.widths, vec![Constraint::Percentage(100)], "array");
+        assert_eq!(table.widths, [Constraint::Percentage(100)], "array");
 
         let array_ref = &[Constraint::Percentage(100)];
         let table = Table::new(Vec::<Row>::new(), array_ref);
-        assert_eq!(table.widths, vec![Constraint::Percentage(100)], "array ref");
+        assert_eq!(table.widths, [Constraint::Percentage(100)], "array ref");
 
         let vec = vec![Constraint::Percentage(100)];
         let slice = vec.as_slice();
         let table = Table::new(Vec::<Row>::new(), slice);
-        assert_eq!(table.widths, vec![Constraint::Percentage(100)], "slice");
+        assert_eq!(table.widths, [Constraint::Percentage(100)], "slice");
 
         let vec = vec![Constraint::Percentage(100)];
         let table = Table::new(Vec::<Row>::new(), vec);
-        assert_eq!(table.widths, vec![Constraint::Percentage(100)], "vec");
+        assert_eq!(table.widths, [Constraint::Percentage(100)], "vec");
 
         let vec_ref = &vec![Constraint::Percentage(100)];
         let table = Table::new(Vec::<Row>::new(), vec_ref);
-        assert_eq!(table.widths, vec![Constraint::Percentage(100)], "vec ref");
+        assert_eq!(table.widths, [Constraint::Percentage(100)], "vec ref");
     }
 
     #[cfg(test)]


### PR DESCRIPTION
A vector can be compared to an array.