### PR TITLE
refactor: Remove `itertools` from dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ compact_str = "0.8.0"
 crossterm = { version = "0.28.1", optional = true }
 document-features = { version = "0.2.7", optional = true }
 instability = "0.3.1"
-itertools = "0.13"
 lru = "0.12.0"
 paste = "1.0.2"
 palette = { version = "0.7.6", optional = true }
@@ -55,6 +54,7 @@ fakeit = "1.1"
 font8x8 = "0.3.1"
 futures = "0.3.30"
 indoc = "2"
+itertools = "0.13"
 octocrab = "0.39.0"
 pretty_assertions = "1.4.0"
 rand = "0.8.5"

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -14,7 +14,6 @@
 //! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
 
 use color_eyre::Result;
-use itertools::Itertools;
 use ratatui::{
     crossterm::event::{self, Event, KeyCode, KeyEventKind},
     layout::{Alignment, Constraint, Layout, Rect},
@@ -90,7 +89,7 @@ fn calculate_layout(area: Rect) -> (Rect, Vec<Vec<Rect>>) {
                 .split(area)
                 .to_vec()
         })
-        .collect_vec();
+        .collect();
     (title_area, main_areas)
 }
 

--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -17,7 +17,6 @@
 // and background colors with their names and indexes.
 
 use color_eyre::Result;
-use itertools::Itertools;
 use ratatui::{
     crossterm::event::{self, Event, KeyCode, KeyEventKind},
     layout::{Alignment, Constraint, Layout, Rect},
@@ -107,7 +106,7 @@ fn render_fg_named_colors(frame: &mut Frame, bg: Color, area: Rect) {
                 .split(*area)
                 .to_vec()
         })
-        .collect_vec();
+        .collect::<Vec<_>>();
     for (i, &fg) in NAMED_COLORS.iter().enumerate() {
         let color_name = fg.to_string();
         let paragraph = Paragraph::new(color_name).fg(fg).bg(bg);
@@ -128,7 +127,7 @@ fn render_bg_named_colors(frame: &mut Frame, fg: Color, area: Rect) {
                 .split(*area)
                 .to_vec()
         })
-        .collect_vec();
+        .collect::<Vec<_>>();
     for (i, &bg) in NAMED_COLORS.iter().enumerate() {
         let color_name = bg.to_string();
         let paragraph = Paragraph::new(color_name).fg(fg).bg(bg);
@@ -199,7 +198,7 @@ fn render_indexed_colors(frame: &mut Frame, area: Rect) {
                 .split(area)
                 .to_vec()
         })
-        .collect_vec();
+        .collect::<Vec<_>>();
 
     for i in 16..=231 {
         let color = Color::Indexed(i);
@@ -236,7 +235,7 @@ fn render_indexed_grayscale(frame: &mut Frame, area: Rect) {
             .split(*area)
             .to_vec()
     })
-    .collect_vec();
+    .collect::<Vec<_>>();
 
     for i in 232..=255 {
         let color = Color::Indexed(i);

--- a/examples/constraint-explorer.rs
+++ b/examples/constraint-explorer.rs
@@ -307,7 +307,7 @@ impl App {
                         .bg(name.color())
                 })
                 .intersperse(Span::from(" "))
-                .collect_vec(),
+                .collect::<Vec<_>>(),
             )
             .centered(),
         )
@@ -346,13 +346,8 @@ impl App {
     }
 
     fn render_user_constraints_legend(&self, area: Rect, buf: &mut Buffer) {
-        let blocks = Layout::horizontal(
-            self.constraints
-                .iter()
-                .map(|_| Constraint::Fill(1))
-                .collect_vec(),
-        )
-        .split(area);
+        let blocks =
+            Layout::horizontal(self.constraints.iter().map(|_| Constraint::Fill(1))).split(area);
 
         for (i, (area, constraint)) in blocks.iter().zip(self.constraints.iter()).enumerate() {
             let selected = self.selected_index == i;

--- a/examples/demo2/app.rs
+++ b/examples/demo2/app.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use color_eyre::{eyre::Context, Result};
 use crossterm::event;
-use itertools::Itertools;
 use ratatui::{
     buffer::Buffer,
     crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind},
@@ -195,7 +194,7 @@ impl App {
                 let desc = Span::styled(format!(" {desc} "), THEME.key_binding.description);
                 [key, desc]
             })
-            .collect_vec();
+            .collect::<Vec<_>>();
         Line::from(spans)
             .centered()
             .style((Color::Indexed(236), Color::Indexed(232)))

--- a/examples/demo2/tabs/email.rs
+++ b/examples/demo2/tabs/email.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Layout, Margin, Rect},
@@ -96,13 +95,10 @@ fn render_inbox(selected_index: usize, area: Rect, buf: &mut Buffer) {
         .map(|e| e.from.width())
         .max()
         .unwrap_or_default();
-    let items = EMAILS
-        .iter()
-        .map(|e| {
-            let from = format!("{:width$}", e.from, width = from_width).into();
-            ListItem::new(Line::from(vec![from, " ".into(), e.subject.into()]))
-        })
-        .collect_vec();
+    let items = EMAILS.iter().map(|e| {
+        let from = format!("{:width$}", e.from, width = from_width).into();
+        ListItem::new(Line::from(vec![from, " ".into(), e.subject.into()]))
+    });
     let mut state = ListState::default().with_selected(Some(selected_index));
     StatefulWidget::render(
         List::new(items)
@@ -151,7 +147,7 @@ fn render_email(selected_index: usize, area: Rect, buf: &mut Buffer) {
         Paragraph::new(headers)
             .style(theme.body)
             .render(headers_area, buf);
-        let body = email.body.lines().map(Line::from).collect_vec();
+        let body = email.body.lines().map(Line::from).collect::<Vec<_>>();
         Paragraph::new(body)
             .style(theme.body)
             .render(body_area, buf);

--- a/examples/demo2/tabs/recipe.rs
+++ b/examples/demo2/tabs/recipe.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Constraint, Layout, Margin, Rect},
@@ -149,7 +148,7 @@ fn render_recipe(area: Rect, buf: &mut Buffer) {
     let lines = RECIPE
         .iter()
         .map(|(step, text)| Line::from(vec![step.white().bold(), text.gray()]))
-        .collect_vec();
+        .collect::<Vec<_>>();
     Paragraph::new(lines)
         .wrap(Wrap { trim: true })
         .block(Block::new().padding(Padding::new(0, 1, 0, 0)))

--- a/examples/demo2/tabs/traceroute.rs
+++ b/examples/demo2/tabs/traceroute.rs
@@ -52,10 +52,7 @@ impl Widget for TracerouteTab {
 
 fn render_hops(selected_row: usize, area: Rect, buf: &mut Buffer) {
     let mut state = TableState::default().with_selected(Some(selected_row));
-    let rows = HOPS
-        .iter()
-        .map(|hop| Row::new(vec![hop.host, hop.address]))
-        .collect_vec();
+    let rows = HOPS.iter().map(|hop| Row::new(vec![hop.host, hop.address]));
     let block = Block::new()
         .padding(Padding::new(1, 1, 1, 1))
         .title_alignment(Alignment::Center)

--- a/examples/demo2/tabs/weather.rs
+++ b/examples/demo2/tabs/weather.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use palette::Okhsv;
 use ratatui::{
     buffer::Buffer,
@@ -103,7 +102,7 @@ fn render_simple_barchart(area: Rect, buf: &mut Buffer) {
                 })
                 .label(label.into())
         })
-        .collect_vec();
+        .collect::<Vec<_>>();
     let group = BarGroup::default().bars(&data);
     BarChart::default()
         .data(group)

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -89,9 +89,9 @@ fn draw(frame: &mut Frame) {
             .iter()
             .copied()
             .take(5) // ignore Min(0)
-            .collect_vec()
+            .collect::<Vec<_>>()
         })
-        .collect_vec();
+        .collect::<Vec<_>>();
 
     // the examples are a cartesian product of the following constraints
     // e.g. Len/Len, Len/Min, Len/Max, Len/Perc, Len/Ratio, Min/Len, Min/Min, ...
@@ -150,7 +150,7 @@ fn draw(frame: &mut Frame) {
             .iter()
             .copied()
             .zip(examples_b.iter().copied())
-            .collect_vec();
+            .collect();
         render_example_combination(
             frame,
             example_areas[i],

--- a/examples/modifiers.rs
+++ b/examples/modifiers.rs
@@ -19,7 +19,6 @@
 
 use std::{error::Error, iter::once, result};
 
-use itertools::Itertools;
 use ratatui::{
     crossterm::event::{self, Event, KeyCode, KeyEventKind},
     layout::{Constraint, Layout},
@@ -66,7 +65,7 @@ fn draw(frame: &mut Frame) {
                 .split(*area)
                 .to_vec()
         })
-        .collect_vec();
+        .collect::<Vec<_>>();
 
     let colors = [
         Color::Black,
@@ -77,7 +76,7 @@ fn draw(frame: &mut Frame) {
     ];
     let all_modifiers = once(Modifier::empty())
         .chain(Modifier::all().iter())
-        .collect_vec();
+        .collect::<Vec<_>>();
     let mut index = 0;
     for bg in &colors {
         for fg in &colors {

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -294,7 +294,7 @@ fn generate_fake_names() -> Vec<Data> {
             }
         })
         .sorted_by(|a, b| a.name.cmp(&b.name))
-        .collect_vec()
+        .collect()
 }
 
 fn constraint_len_calculator(items: &[Data]) -> (u16, u16, u16) {

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -618,7 +618,6 @@ impl fmt::Debug for Buffer {
 mod tests {
     use std::iter;
 
-    use itertools::Itertools;
     use rstest::{fixture, rstest};
 
     use super::*;
@@ -924,7 +923,7 @@ mod tests {
             .content
             .iter()
             .map(Cell::symbol)
-            .join("");
+            .fold(String::new(), |acc, x| acc + x);
         assert_eq!(actual_contents, expected);
 
         let actual_styles = small_one_line_buffer.content.iter().map(|c| c.fg);

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -925,20 +925,16 @@ mod tests {
             .iter()
             .map(Cell::symbol)
             .join("");
-        let actual_styles = small_one_line_buffer
-            .content
-            .iter()
-            .map(|c| c.fg)
-            .collect_vec();
+        assert_eq!(actual_contents, expected);
+
+        let actual_styles = small_one_line_buffer.content.iter().map(|c| c.fg);
 
         // set_line only sets the style for non-empty cells (unlike Line::render which sets the
         // style for all cells)
         let expected_styles = iter::repeat(color)
             .take(content.len().min(5))
-            .chain(iter::repeat(Color::default()).take(5_usize.saturating_sub(content.len())))
-            .collect_vec();
-        assert_eq!(actual_contents, expected);
-        assert_eq!(actual_styles, expected_styles);
+            .chain(iter::repeat(Color::default()).take(5_usize.saturating_sub(content.len())));
+        assert!(actual_styles.eq(expected_styles));
     }
 
     #[test]

--- a/src/layout/constraint.rs
+++ b/src/layout/constraint.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 
-use itertools::Itertools;
 use strum::EnumIs;
 
 /// A constraint that defines the size of a layout element.
@@ -229,7 +228,7 @@ impl Constraint {
     where
         T: IntoIterator<Item = u16>,
     {
-        lengths.into_iter().map(Self::Length).collect_vec()
+        lengths.into_iter().map(Self::Length).collect()
     }
 
     /// Convert an iterator of ratios into a vector of constraints
@@ -246,10 +245,7 @@ impl Constraint {
     where
         T: IntoIterator<Item = (u32, u32)>,
     {
-        ratios
-            .into_iter()
-            .map(|(n, d)| Self::Ratio(n, d))
-            .collect_vec()
+        ratios.into_iter().map(|(n, d)| Self::Ratio(n, d)).collect()
     }
 
     /// Convert an iterator of percentages into a vector of constraints
@@ -266,7 +262,7 @@ impl Constraint {
     where
         T: IntoIterator<Item = u16>,
     {
-        percentages.into_iter().map(Self::Percentage).collect_vec()
+        percentages.into_iter().map(Self::Percentage).collect()
     }
 
     /// Convert an iterator of maxes into a vector of constraints
@@ -283,7 +279,7 @@ impl Constraint {
     where
         T: IntoIterator<Item = u16>,
     {
-        maxes.into_iter().map(Self::Max).collect_vec()
+        maxes.into_iter().map(Self::Max).collect()
     }
 
     /// Convert an iterator of mins into a vector of constraints
@@ -300,7 +296,7 @@ impl Constraint {
     where
         T: IntoIterator<Item = u16>,
     {
-        mins.into_iter().map(Self::Min).collect_vec()
+        mins.into_iter().map(Self::Min).collect()
     }
 
     /// Convert an iterator of proportional factors into a vector of constraints
@@ -317,10 +313,7 @@ impl Constraint {
     where
         T: IntoIterator<Item = u16>,
     {
-        proportional_factors
-            .into_iter()
-            .map(Self::Fill)
-            .collect_vec()
+        proportional_factors.into_iter().map(Self::Fill).collect()
     }
 }
 

--- a/src/style/stylize.rs
+++ b/src/style/stylize.rs
@@ -230,8 +230,6 @@ impl Styled for String {
 
 #[cfg(test)]
 mod tests {
-    use itertools::Itertools;
-
     use super::*;
 
     #[test]
@@ -345,8 +343,8 @@ mod tests {
         // format!() is used to create a temporary String inside a closure, which suffers the same
         // issue as above without the `Styled` trait impl for `String`
         let items = [String::from("a"), String::from("b")];
-        let sss = items.iter().map(|s| format!("{s}{s}").red()).collect_vec();
-        assert_eq!(sss, vec![Span::from("aa").red(), Span::from("bb").red()]);
+        let sss = items.iter().map(|s| format!("{s}{s}").red());
+        assert!(sss.eq([Span::from("aa").red(), Span::from("bb").red()]));
     }
 
     #[test]

--- a/src/text/text.rs
+++ b/src/text/text.rs
@@ -1,8 +1,6 @@
 #![warn(missing_docs)]
 use std::{borrow::Cow, fmt};
 
-use itertools::{Itertools, Position};
-
 use crate::{prelude::*, style::Styled};
 
 /// A string split over one or more lines.
@@ -632,12 +630,11 @@ impl<T: fmt::Display> ToText for T {
 
 impl fmt::Display for Text<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (position, line) in self.iter().with_position() {
-            if position == Position::Last || position == Position::Only {
-                write!(f, "{line}")?;
-            } else {
+        if let Some((last, rest)) = self.lines.split_last() {
+            for line in rest {
                 writeln!(f, "{line}")?;
             }
+            last.fmt(f)?;
         }
         Ok(())
     }

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -5,7 +5,6 @@
 //! In its simplest form, a `Block` is a [border](Borders) around another widget. It can have a
 //! [title](Block::title) and [padding](Block::padding).
 
-use itertools::Itertools;
 use strum::{Display, EnumString};
 
 use crate::{prelude::*, style::Styled, symbols::border, widgets::Borders};
@@ -827,7 +826,7 @@ impl Block<'_> {
     fn render_center_titles(&self, position: Position, area: Rect, buf: &mut Buffer) {
         let titles = self
             .filtered_titles(position, Alignment::Center)
-            .collect_vec();
+            .collect::<Vec<_>>();
         let total_width = titles
             .iter()
             .map(|title| title.content.width() as u16 + 1) // space between titles

--- a/src/widgets/canvas.rs
+++ b/src/widgets/canvas.rs
@@ -21,8 +21,6 @@ mod world;
 
 use std::{fmt, iter::zip};
 
-use itertools::Itertools;
-
 pub use self::{
     circle::Circle,
     line::Line,
@@ -281,11 +279,7 @@ impl Grid for HalfBlockGrid {
 
         // first we join each adjacent row together to get an iterator that contains vertical pairs
         // of pixels, with the lower row being the first element in the pair
-        let vertical_color_pairs = self
-            .pixels
-            .iter()
-            .tuples()
-            .flat_map(|(upper_row, lower_row)| zip(upper_row, lower_row));
+        let vertical_color_pairs = self.pixels.chunks_exact(2).flat_map(|s| zip(&s[0], &s[1]));
 
         // then we work out what character to print for each pair of pixels
         let string = vertical_color_pairs

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-
 #[allow(unused_imports)] // `Cell` is used in the doc comment but not the code
 use super::Cell;
 use super::{HighlightSpacing, Row, TableState};
@@ -276,7 +274,7 @@ impl<'a> Table<'a> {
         C: IntoIterator,
         C::Item: Into<Constraint>,
     {
-        let widths = widths.into_iter().map(Into::into).collect_vec();
+        let widths = widths.into_iter().map(Into::into).collect::<Vec<_>>();
         ensure_percentages_less_than_100(&widths);
 
         let rows = rows.into_iter().map(Into::into).collect();
@@ -390,7 +388,7 @@ impl<'a> Table<'a> {
         I: IntoIterator,
         I::Item: Into<Constraint>,
     {
-        let widths = widths.into_iter().map(Into::into).collect_vec();
+        let widths = widths.into_iter().map(Into::into).collect::<Vec<_>>();
         ensure_percentages_less_than_100(&widths);
         self.widths = widths;
         self


### PR DESCRIPTION
Trying to reduce the dependencies of Rustlings. Everyone who uses Ratatui profits :)