### PR TITLE
feat!(scrolling-regions): use terminal scrolling regions to stop Terminal::insert_before from flickering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,10 @@ macros = []
 ## enables conversions from colors in the [`palette`] crate to [`Color`](crate::style::Color).
 palette = ["dep:palette"]
 
+## Use terminal scrolling regions to make some operations less prone to
+## flickering. (i.e. Terminal::insert_before).
+scrolling-regions = []
+
 ## enables all widgets.
 all-widgets = ["widget-calendar"]
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -318,6 +318,25 @@ pub trait Backend {
 
     /// Flush any buffered content to the terminal screen.
     fn flush(&mut self) -> io::Result<()>;
+
+    /// Scroll the specified region of the screen up by the provided amount of lines.
+    ///
+    /// The position of the cursor afterwards is undefined.
+    ///
+    /// If the region includes row 0, then lines scrolled out of the top of region should be put
+    /// into the scrollback. Otherwise, they are just ovewritten. Empty lines are scrolled into the
+    /// bottom of the region.
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_up(&mut self, region: std::ops::Range<u16>, amount: u16) -> io::Result<()>;
+
+    /// Scroll the specified region of the screen down by the provided amount of lines.
+    ///
+    /// The position of the cursor afterwards is undefined.
+    ///
+    /// Scrollback will not be affected, even if the region includes row 0. Empty lines are
+    /// scrolled into the top of the region.
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_down(&mut self, region: std::ops::Range<u16>, amount: u16) -> io::Result<()>;
 }
 
 #[cfg(test)]

--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -271,6 +271,26 @@ where
     fn flush(&mut self) -> io::Result<()> {
         self.writer.flush()
     }
+
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_up(&mut self, region: std::ops::Range<u16>, amount: u16) -> io::Result<()> {
+        let start = region.start as u32 + 1;
+        let end = region.end as u32;
+        queue!(self.writer, Print(format!("\x1B[{start};{end}r")))?;
+        queue!(self.writer, crate::crossterm::terminal::ScrollUp(amount))?;
+        queue!(self.writer, Print(format!("\x1B[r")))?;
+        self.writer.flush()
+    }
+
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_down(&mut self, region: std::ops::Range<u16>, amount: u16) -> io::Result<()> {
+        let start = region.start as u32 + 1;
+        let end = region.end as u32;
+        queue!(self.writer, Print(format!("\x1B[{start};{end}r")))?;
+        queue!(self.writer, crate::crossterm::terminal::ScrollDown(amount))?;
+        queue!(self.writer, Print(format!("\x1B[r")))?;
+        self.writer.flush()
+    }
 }
 
 impl From<Color> for CColor {

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -231,6 +231,26 @@ where
     fn flush(&mut self) -> io::Result<()> {
         self.writer.flush()
     }
+
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_up(&mut self, region: std::ops::Range<u16>, amount: u16) -> io::Result<()> {
+        let start = region.start as u32 + 1;
+        let end = region.end as u32;
+        write!(self.writer, "\x1B[{start};{end}r")?;
+        write!(self.writer, "{}", termion::scroll::Up(amount))?;
+        write!(self.writer, "\x1B[r")?;
+        self.writer.flush()
+    }
+
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_down(&mut self, region: std::ops::Range<u16>, amount: u16) -> io::Result<()> {
+        let start = region.start as u32 + 1;
+        let end = region.end as u32;
+        write!(self.writer, "\x1B[{start};{end}r")?;
+        write!(self.writer, "{}", termion::scroll::Down(amount))?;
+        write!(self.writer, "\x1B[r")?;
+        self.writer.flush()
+    }
 }
 struct Fg(Color);
 

--- a/src/backend/termwiz.rs
+++ b/src/backend/termwiz.rs
@@ -249,6 +249,42 @@ impl Backend for TermwizBackend {
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
         Ok(())
     }
+
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_up(&mut self, region: std::ops::Range<u16>, amount: u16) -> io::Result<()> {
+        let (_, rows) = self.buffered_terminal.dimensions();
+        self.buffered_terminal.add_changes(vec![
+            Change::ScrollRegionUp {
+                first_row: region.start as usize,
+                region_size: region.len() as usize,
+                scroll_count: amount as usize,
+            },
+            Change::ScrollRegionUp {
+                first_row: 0,
+                region_size: rows,
+                scroll_count: 0,
+            },
+        ]);
+        Ok(())
+    }
+
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_down(&mut self, region: std::ops::Range<u16>, amount: u16) -> io::Result<()> {
+        let (_, rows) = self.buffered_terminal.dimensions();
+        self.buffered_terminal.add_changes(vec![
+            Change::ScrollRegionDown {
+                first_row: region.start as usize,
+                region_size: region.len() as usize,
+                scroll_count: amount as usize,
+            },
+            Change::ScrollRegionUp {
+                first_row: 0,
+                region_size: rows,
+                scroll_count: 0,
+            },
+        ]);
+        Ok(())
+    }
 }
 
 impl From<CellAttributes> for Style {

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -273,7 +273,7 @@ impl Backend for TestBackend {
     /// the cursor y position then that number of empty lines (at most the buffer's height in this
     /// case but this limit is instead replaced with scrolling in most backend implementations) will
     /// be added after the current position and the cursor will be moved to the last row.
-    fn append_lines(&mut self, n: u16) -> io::Result<()> {
+    fn append_lines(&mut self, line_count: u16) -> io::Result<()> {
         let Position { x: cur_x, y: cur_y } = self.get_cursor_position()?;
         let Rect { width, height, .. } = self.buffer.area;
 
@@ -283,10 +283,10 @@ impl Backend for TestBackend {
         let max_y = height.saturating_sub(1);
         let lines_after_cursor = max_y.saturating_sub(cur_y);
 
-        if n > lines_after_cursor {
+        if line_count > lines_after_cursor {
             // We need to insert blank lines at the bottom and scroll the lines from the top into
             // scrollback.
-            let scroll_by: usize = (n - lines_after_cursor).into();
+            let scroll_by: usize = (line_count - lines_after_cursor).into();
             let width: usize = self.buffer.area.width.into();
             let to_splice = self.buffer.content.len().min(width * scroll_by);
 
@@ -304,7 +304,7 @@ impl Backend for TestBackend {
             );
         }
 
-        let new_cursor_y = cur_y.saturating_add(n).min(max_y);
+        let new_cursor_y = cur_y.saturating_add(line_count).min(max_y);
         self.set_cursor_position(Position::new(new_cursor_x, new_cursor_y))?;
 
         Ok(())

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -300,7 +300,7 @@ impl Backend for TestBackend {
             }
 
             let new_scrollback_height = self.scrollback.area.height as usize + scroll_by;
-            if new_scrollback_height <= u16::MAX as usize {
+            if u16::try_from(new_scrollback_height).is_ok() {
                 self.scrollback.area.height = new_scrollback_height as u16;
             } else {
                 self.scrollback

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -358,8 +358,9 @@ fn append_to_scrollback(scrollback: &mut Buffer, cells: impl IntoIterator<Item =
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use itertools::Itertools as _;
+
+    use super::*;
 
     #[test]
     fn new() {

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -841,8 +841,6 @@ mod tests {
     fn append_lines_truncates_beyond_u16_max() -> io::Result<()> {
         let mut backend = TestBackend::new(10, 5);
 
-        //        backend.buffer = Buffer::empty(Rect::new(0, 0, 10, 5));
-
         // Fill the scrollback with 65535 + 10 lines.
         let row_count = u16::MAX as usize + 10;
         for row in 0..=row_count {

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -131,12 +131,12 @@ impl TestBackend {
     /// # Panics
     /// When the scrollback buffer is not equal, a panic occurs with a detailed error message
     /// showing the differences between the expected and actual buffers.
-    pub fn assert_empty_scrollback(&self, width: u16) {
+    pub fn assert_empty_scrollback(&self) {
         let expected = Buffer {
             area: Rect {
                 x: 0,
                 y: 0,
-                width,
+                width: self.scrollback.area.width,
                 height: 0,
             },
             content: vec![],
@@ -638,7 +638,7 @@ mod tests {
             "dddddddddd",
             "eeeeeeeeee",
         ]);
-        backend.assert_empty_scrollback(10);
+        backend.assert_empty_scrollback();
     }
 
     #[test]
@@ -701,7 +701,7 @@ mod tests {
             "dddddddddd",
             "eeeeeeeeee",
         ]);
-        backend.assert_empty_scrollback(10);
+        backend.assert_empty_scrollback();
     }
 
     #[test]

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -131,7 +131,7 @@ impl TestBackend {
     /// # Panics
     /// When the scrollback buffer is not equal, a panic occurs with a detailed error message
     /// showing the differences between the expected and actual buffers.
-    pub fn assert_empty_scrollback(&self) {
+    pub fn assert_scrollback_empty(&self) {
         let expected = Buffer {
             area: Rect {
                 x: 0,
@@ -638,7 +638,7 @@ mod tests {
             "dddddddddd",
             "eeeeeeeeee",
         ]);
-        backend.assert_empty_scrollback();
+        backend.assert_scrollback_empty();
     }
 
     #[test]
@@ -701,7 +701,7 @@ mod tests {
             "dddddddddd",
             "eeeeeeeeee",
         ]);
-        backend.assert_empty_scrollback();
+        backend.assert_scrollback_empty();
     }
 
     #[test]

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -86,6 +86,18 @@ impl TestBackend {
     }
 
     /// Returns a reference to the internal scrollback buffer of the `TestBackend`.
+    ///
+    /// The scrollback buffer represents the part of the screen that is currently hidden from view,
+    /// but that could be accessed by scrolling back in the terminal's history. This would normally
+    /// be done using the terminal's scrollbar or an equivalent keyboard shortcut.
+    ///
+    /// The scrollback buffer starts out empty. Lines are appeneded when they scroll off the top of
+    /// the main buffer. This happens when lines are appended to the bottom of the main buffer
+    /// using [`Backend::append_lines`].
+    ///
+    /// The scrollback buffer has a maximum height of [`u16::MAX`]. If lines are appended to the
+    /// bottom of the scrollback buffer when it is at its maximum height, a corresponding number of
+    /// lines will be removed from the top.
     pub const fn scrollback(&self) -> &Buffer {
         &self.scrollback
     }

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -835,7 +835,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
     fn append_lines_truncates_beyond_u16_max() -> io::Result<()> {
         let mut backend = TestBackend::new(10, 5);
 

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -133,11 +133,9 @@ impl TestBackend {
     ///
     /// When they are not equal, a panic occurs with a detailed error message showing the
     /// differences between the expected and actual buffers.
-    #[allow(deprecated)]
     #[track_caller]
     pub fn assert_scrollback(&self, expected: &Buffer) {
-        // TODO: use assert_eq!()
-        crate::assert_buffer_eq!(&self.scrollback, expected);
+        assert_eq!(&self.scrollback, expected)
     }
 
     /// Asserts that the `TestBackend`'s scrollback buffer is empty.
@@ -426,7 +424,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "buffer areas not equal"]
+    #[should_panic = "assertion `left == right` failed"]
     fn assert_scrollback_panics() {
         let backend = TestBackend::new(10, 2);
         backend.assert_scrollback_lines(["aaaaaaaaaa"; 2]);

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -213,7 +213,7 @@ fn append_to_scrollback(scrollback: &mut Buffer, cells: impl IntoIterator<Item =
         "count of appended cells not a multiple of scrollback buffer width"
     );
 
-    let new_scrollback_height = scrollback.area.height as usize + lines_appended as usize;
+    let new_scrollback_height = scrollback.area.height as usize + lines_appended;
     if u16::try_from(new_scrollback_height).is_ok() {
         scrollback.area.height = new_scrollback_height as u16;
     } else {

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -91,7 +91,7 @@ impl TestBackend {
     /// but that could be accessed by scrolling back in the terminal's history. This would normally
     /// be done using the terminal's scrollbar or an equivalent keyboard shortcut.
     ///
-    /// The scrollback buffer starts out empty. Lines are appeneded when they scroll off the top of
+    /// The scrollback buffer starts out empty. Lines are appended when they scroll off the top of
     /// the main buffer. This happens when lines are appended to the bottom of the main buffer
     /// using [`Backend::append_lines`].
     ///

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -135,7 +135,7 @@ impl TestBackend {
     /// differences between the expected and actual buffers.
     #[track_caller]
     pub fn assert_scrollback(&self, expected: &Buffer) {
-        assert_eq!(&self.scrollback, expected)
+        assert_eq!(&self.scrollback, expected);
     }
 
     /// Asserts that the `TestBackend`'s scrollback buffer is empty.

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -115,6 +115,7 @@ impl TestBackend {
     /// This is a shortcut for `assert_eq!(self.buffer(), &expected)`.
     ///
     /// # Panics
+    ///
     /// When they are not equal, a panic occurs with a detailed error message showing the
     /// differences between the expected and actual buffers.
     #[allow(deprecated)]
@@ -129,6 +130,7 @@ impl TestBackend {
     /// This is a shortcut for `assert_eq!(self.scrollback(), &expected)`.
     ///
     /// # Panics
+    ///
     /// When they are not equal, a panic occurs with a detailed error message showing the
     /// differences between the expected and actual buffers.
     #[allow(deprecated)]
@@ -141,6 +143,7 @@ impl TestBackend {
     /// Asserts that the `TestBackend`'s scrollback buffer is empty.
     ///
     /// # Panics
+    ///
     /// When the scrollback buffer is not equal, a panic occurs with a detailed error message
     /// showing the differences between the expected and actual buffers.
     pub fn assert_scrollback_empty(&self) {
@@ -159,6 +162,7 @@ impl TestBackend {
     /// This is a shortcut for `assert_eq!(self.buffer(), &Buffer::with_lines(expected))`.
     ///
     /// # Panics
+    ///
     /// When they are not equal, a panic occurs with a detailed error message showing the
     /// differences between the expected and actual buffers.
     #[track_caller]
@@ -175,6 +179,7 @@ impl TestBackend {
     /// This is a shortcut for `assert_eq!(self.scrollback(), &Buffer::with_lines(expected))`.
     ///
     /// # Panics
+    ///
     /// When they are not equal, a panic occurs with a detailed error message showing the
     /// differences between the expected and actual buffers.
     #[track_caller]
@@ -191,6 +196,7 @@ impl TestBackend {
     /// This is a shortcut for `assert_eq!(self.get_cursor_position().unwrap(), expected)`.
     ///
     /// # Panics
+    ///
     /// When they are not equal, a panic occurs with a detailed error message showing the
     /// differences between the expected and actual position.
     #[track_caller]

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -288,19 +288,19 @@ impl Backend for TestBackend {
             // scrollback.
             let scroll_by: usize = (line_count - lines_after_cursor).into();
             let width: usize = self.buffer.area.width.into();
-            let to_splice = self.buffer.content.len().min(width * scroll_by);
+            let cells_to_scrollback = self.buffer.content.len().min(width * scroll_by);
 
             append_to_scrollback(
                 &mut self.scrollback,
                 self.buffer.content.splice(
-                    0..to_splice,
-                    iter::repeat_with(Default::default).take(to_splice),
+                    0..cells_to_scrollback,
+                    iter::repeat_with(Default::default).take(cells_to_scrollback),
                 ),
             );
-            self.buffer.content.rotate_left(to_splice);
+            self.buffer.content.rotate_left(cells_to_scrollback);
             append_to_scrollback(
                 &mut self.scrollback,
-                iter::repeat_with(Default::default).take(width * scroll_by - to_splice),
+                iter::repeat_with(Default::default).take(width * scroll_by - cells_to_scrollback),
             );
         }
 

--- a/src/buffer/cell.rs
+++ b/src/buffer/cell.rs
@@ -159,7 +159,7 @@ impl Default for Cell {
 
 impl From<char> for Cell {
     fn from(ch: char) -> Self {
-        let mut cell = Cell::EMPTY;
+        let mut cell = Self::EMPTY;
         cell.set_char(ch);
         cell
     }

--- a/src/buffer/cell.rs
+++ b/src/buffer/cell.rs
@@ -157,6 +157,14 @@ impl Default for Cell {
     }
 }
 
+impl From<char> for Cell {
+    fn from(ch: char) -> Self {
+        let mut cell = Cell::EMPTY;
+        cell.set_char(ch);
+        cell
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/terminal/terminal.rs
+++ b/src/terminal/terminal.rs
@@ -614,7 +614,7 @@ where
             //     scroll_up = max(0, drawn_height + to_draw - screen_height)
             //
             // The second term of the max makes sense intuitively: We want to scroll up enough so
-            // that, after drawing, we have use the whole screen. This is easiest to see when
+            // that, after drawing, we have used the whole screen. This is easiest to see when
             // we're drawing a whole screen's worth from the buffer. Things get tricky when
             // `buffer_height` is less than `screen_height`.
             //

--- a/src/terminal/terminal.rs
+++ b/src/terminal/terminal.rs
@@ -642,7 +642,7 @@ where
             // with the viewport higher on the screen after this function than before it was
             // called.
             //
-            // In order to prove that our choice of `scroll_up` satisifies these constraints, we
+            // In order to prove that our choice of `scroll_up` satisfies these constraints, we
             // make use of two facts:
             //     (A) X <= Z and Y <= Z implies max(X, Y) <= Z for any X, Y, Z
             //     (B) X >= Z or Y >= Z implies max(X, Y) >= Z for any X, Y, Z

--- a/src/terminal/terminal.rs
+++ b/src/terminal/terminal.rs
@@ -618,15 +618,11 @@ where
             // we're drawing a whole screen's worth from the buffer. Things get tricky when
             // `buffer_height` is less than `screen_height`.
             //
-            // We choose `scroll_up` so that satisfies four different constraints:
+            // We choose `scroll_up` so that the following constraints are satisfied:
             //     (1) scroll_up >= 0
             //     (2) scroll_up <= drawn_height
             //     (3) drawn_height - scroll_up + to_draw <= screen_height
-            //     or, equivalently:
-            //         scroll_up >= drawn_height + to_draw - screen_height
             //     (4) drawn_height - scroll_up + to_draw >= screen_height - viewport_height
-            //     or, equivalently:
-            //         scroll_up <= drawn_height + to_draw - screen_height + viewport_height
             //
             // (1) says that we don't want to scroll down. That should never be necessary when
             // inserting data before the inline viewport.
@@ -642,58 +638,8 @@ where
             // with the viewport higher on the screen after this function than before it was
             // called.
             //
-            // In order to prove that our choice of `scroll_up` satisfies these constraints, we
-            // make use of two facts:
-            //     (A) X <= Z and Y <= Z implies max(X, Y) <= Z for any X, Y, Z
-            //     (B) X >= Z or Y >= Z implies max(X, Y) >= Z for any X, Y, Z
-            // In our case, since scroll_up = max(0, drawn_height + to_draw - screen_height), we
-            // use these variable assignments:
-            //     X = 0
-            //     Y = drawn_height + to_draw - screen_height
-            //
-            // (1) is satisfied because (using fact (B)):
-            //     X = 0 >= 0
-            //
-            // (2) is satisfied because (using fact (A)):
-            //     X = 0 <= drawn_height
-            //     and
-            //     Y = drawn_height + to_draw - screen_height
-            //     where
-            //     to_draw = min(buffer_height, screen_height)
-            //         <= screen_height
-            //     combined, implies
-            //     Y <= drawn_height + screen_height - screen_height
-            //         = drawn_height
-            //
-            // (3) is satisfied because (using fact (B)):
-            //     Y = drawn_height + to_draw - screen_height
-            //         >= drawn_height + to_draw - screen_height
-            //
-            // (4) is satistfied because (using fact (A)):
-            //     First we show for X:
-            //         Either (a) buffer_height >= screen_height or
-            //         (b) buffer_height < screen_height.
-            //         If (a):
-            //             to_draw = min(buffer_height, screen_height) = screen_height
-            //             implies
-            //             drawn_height + to_draw - screen_height + viewport_height
-            //                 = drawn_height + screen_height - screen_height + viewport_height
-            //                 = drawn_height + viewport_height >= 0 = X
-            //         If (b):
-            //             to_draw = min(buffer_height, screen_height) = buffer_height
-            //         And the loop invariant tells us:
-            //             buffer_height + viewport_height > screen_height
-            //         So
-            //             drawn_height + to_draw - screen_height + viewport_height
-            //                 = drawn_height + buffer_height - screen_height + viewport_height
-            //                 = drawn_height - screen_height + buffer_height + viewport_height
-            //                 > drawn_height - screen_height + screen_height
-            //                 = drawn_height
-            //                 >= 0 = X
-            //     Now we show for Y:
-            //         Y = drawn_height + to_draw - screen_height
-            //             <= drawn_height + to_draw - screen_height + viewport_height
-
+            // A proof that these constraints are satisified by this choice ofi `scroll_up` can be
+            // found in PR 1329: https://github.com/ratatui-org/ratatui/pull/1329
             let to_draw = buffer_height.min(screen_height);
             let scroll_up = 0.max(drawn_height + to_draw - screen_height);
             self.scroll_up(scroll_up as u16)?;

--- a/src/terminal/terminal.rs
+++ b/src/terminal/terminal.rs
@@ -522,7 +522,10 @@ where
     /// Scroll the whole screen up by the given number of lines.
     fn scroll_up(&mut self, lines_to_scroll: u16) -> io::Result<()> {
         if lines_to_scroll > 0 {
-            self.set_cursor_position(Position::new(0, self.last_known_area.height.saturating_sub(1)))?;
+            self.set_cursor_position(Position::new(
+                0,
+                self.last_known_area.height.saturating_sub(1),
+            ))?;
             self.backend.append_lines(lines_to_scroll)?;
         }
         Ok(())
@@ -605,7 +608,7 @@ where
             // progress. So we have:
             //
             //     to_draw = min(buffer_height, screen_height)
-            // 
+            //
             // We may need to scroll the screen up to make room to draw. However, we don't want to
             // scroll the screen up too much and end up with the viewport sitting in the middle of
             // the screen. Figuring out exactly how much to scroll by is a little tricky. It turns
@@ -697,11 +700,7 @@ where
             let to_draw = buffer_height.min(screen_height);
             let scroll_up = 0.max(drawn_height + to_draw - screen_height);
             self.scroll_up(scroll_up as u16)?;
-            buffer = self.draw_lines(
-                (drawn_height - scroll_up) as u16,
-                to_draw as u16,
-                buffer,
-            )?;
+            buffer = self.draw_lines((drawn_height - scroll_up) as u16, to_draw as u16, buffer)?;
             drawn_height += to_draw - scroll_up;
             buffer_height -= to_draw;
         }
@@ -709,7 +708,7 @@ where
         // There is now enough room on the screen for whatever remains of the buffer plus the
         // viewport. However, we may still need to scroll up some of the existing text first. It's
         // possible that by this point we've drained the buffer, but we may still need to scroll up
-        // to make room for the viewport. 
+        // to make room for the viewport.
         //
         // We want to scroll up the exact amount that will leave us completely filling the screen.
         // However, it's possible that the viewport didn't start on the bottom of the screen and

--- a/src/terminal/terminal.rs
+++ b/src/terminal/terminal.rs
@@ -506,13 +506,10 @@ where
         let width: usize = self.last_known_area.width.into();
         let (to_draw, remainder) = cells.split_at(width * lines_to_draw as usize);
         if lines_to_draw > 0 {
-            let iter = to_draw.iter().enumerate().map(|(i, c)| {
-                (
-                    (i % (width as usize)) as u16,
-                    y_offset + (i / (width as usize)) as u16,
-                    c,
-                )
-            });
+            let iter = to_draw
+                .iter()
+                .enumerate()
+                .map(|(i, c)| ((i % width) as u16, y_offset + (i / width) as u16, c));
             self.backend.draw(iter)?;
             self.backend.flush()?;
         }

--- a/src/terminal/terminal.rs
+++ b/src/terminal/terminal.rs
@@ -495,39 +495,6 @@ where
         self.backend.size()
     }
 
-    /// Draw lines at the given vertical offset. The slice of cells must contain enough cells
-    /// for the requested lines. A slice of the unused cells are returned.
-    fn draw_lines<'a>(
-        &mut self,
-        y_offset: u16,
-        lines_to_draw: u16,
-        cells: &'a [Cell],
-    ) -> io::Result<&'a [Cell]> {
-        let width: usize = self.last_known_area.width.into();
-        let (to_draw, remainder) = cells.split_at(width * lines_to_draw as usize);
-        if lines_to_draw > 0 {
-            let iter = to_draw
-                .iter()
-                .enumerate()
-                .map(|(i, c)| ((i % width) as u16, y_offset + (i / width) as u16, c));
-            self.backend.draw(iter)?;
-            self.backend.flush()?;
-        }
-        Ok(remainder)
-    }
-
-    /// Scroll the whole screen up by the given number of lines.
-    fn scroll_up(&mut self, lines_to_scroll: u16) -> io::Result<()> {
-        if lines_to_scroll > 0 {
-            self.set_cursor_position(Position::new(
-                0,
-                self.last_known_area.height.saturating_sub(1),
-            ))?;
-            self.backend.append_lines(lines_to_scroll)?;
-        }
-        Ok(())
-    }
-
     /// Insert some content before the current inline viewport. This has no effect when the
     /// viewport is not inline.
     ///
@@ -682,6 +649,39 @@ where
         // clear plus immediate scrolling causes some garbage to go into the scrollback.
         self.clear()?;
 
+        Ok(())
+    }
+
+    /// Draw lines at the given vertical offset. The slice of cells must contain enough cells
+    /// for the requested lines. A slice of the unused cells are returned.
+    fn draw_lines<'a>(
+        &mut self,
+        y_offset: u16,
+        lines_to_draw: u16,
+        cells: &'a [Cell],
+    ) -> io::Result<&'a [Cell]> {
+        let width: usize = self.last_known_area.width.into();
+        let (to_draw, remainder) = cells.split_at(width * lines_to_draw as usize);
+        if lines_to_draw > 0 {
+            let iter = to_draw
+                .iter()
+                .enumerate()
+                .map(|(i, c)| ((i % width) as u16, y_offset + (i / width) as u16, c));
+            self.backend.draw(iter)?;
+            self.backend.flush()?;
+        }
+        Ok(remainder)
+    }
+
+    /// Scroll the whole screen up by the given number of lines.
+    fn scroll_up(&mut self, lines_to_scroll: u16) -> io::Result<()> {
+        if lines_to_scroll > 0 {
+            self.set_cursor_position(Position::new(
+                0,
+                self.last_known_area.height.saturating_sub(1),
+            ))?;
+            self.backend.append_lines(lines_to_scroll)?;
+        }
         Ok(())
     }
 }

--- a/src/terminal/terminal.rs
+++ b/src/terminal/terminal.rs
@@ -638,7 +638,7 @@ where
             // with the viewport higher on the screen after this function than before it was
             // called.
             //
-            // A proof that these constraints are satisified by this choice ofi `scroll_up` can be
+            // A proof that these constraints are satisfied by this choice ofi `scroll_up` can be
             // found in PR 1329: https://github.com/ratatui-org/ratatui/pull/1329
             let to_draw = buffer_height.min(screen_height);
             let scroll_up = 0.max(drawn_height + to_draw - screen_height);

--- a/src/terminal/terminal.rs
+++ b/src/terminal/terminal.rs
@@ -638,7 +638,7 @@ where
             // with the viewport higher on the screen after this function than before it was
             // called.
             //
-            // A proof that these constraints are satisfied by this choice ofi `scroll_up` can be
+            // A proof that these constraints are satisfied by this choice of `scroll_up` can be
             // found in PR 1329: https://github.com/ratatui-org/ratatui/pull/1329
             let to_draw = buffer_height.min(screen_height);
             let scroll_up = 0.max(drawn_height + to_draw - screen_height);

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -216,7 +216,7 @@ fn terminal_insert_before_scrolls_on_many_inserts() -> Result<(), Box<dyn Error>
 }
 
 #[test]
-fn terminal_insert_before_lage_viewport() -> Result<(), Box<dyn Error>> {
+fn terminal_insert_before_large_viewport() -> Result<(), Box<dyn Error>> {
     // This test covers a bug previously present whereby doing an insert_before when the
     // viewport covered the entire screen would cause a panic.
 

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -110,6 +110,7 @@ fn terminal_insert_before_moves_viewport() -> Result<(), Box<dyn Error>> {
         "                    ",
         "                    ",
     ]);
+    terminal.backend().assert_empty_scrollback(20);
 
     Ok(())
 }
@@ -152,6 +153,9 @@ fn terminal_insert_before_scrolls_on_large_input() -> Result<(), Box<dyn Error>>
         "------ Line 5 ------",
         "[---- Viewport ----]",
     ]);
+    terminal
+        .backend()
+        .assert_scrollback_lines(["------ Line 1 ------"]);
 
     Ok(())
 }
@@ -204,6 +208,9 @@ fn terminal_insert_before_scrolls_on_many_inserts() -> Result<(), Box<dyn Error>
         "------ Line 5 ------",
         "[---- Viewport ----]",
     ]);
+    terminal
+        .backend()
+        .assert_scrollback_lines(["------ Line 1 ------"]);
 
     Ok(())
 }

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use ratatui::{
     backend::{Backend, TestBackend},
     layout::Rect,
-    widgets::{Block, Padding, Paragraph, Widget},
+    widgets::{Block, Paragraph, Widget},
     Terminal, TerminalOptions, Viewport,
 };
 

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -110,7 +110,7 @@ fn terminal_insert_before_moves_viewport() -> Result<(), Box<dyn Error>> {
         "                    ",
         "                    ",
     ]);
-    terminal.backend().assert_empty_scrollback();
+    terminal.backend().assert_scrollback_empty();
 
     Ok(())
 }

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use ratatui::{
     backend::{Backend, TestBackend},
     layout::Rect,
-    widgets::{Paragraph, Widget},
+    widgets::{Block, Padding, Paragraph, Widget},
     Terminal, TerminalOptions, Viewport,
 };
 
@@ -211,6 +211,74 @@ fn terminal_insert_before_scrolls_on_many_inserts() -> Result<(), Box<dyn Error>
     terminal
         .backend()
         .assert_scrollback_lines(["------ Line 1 ------"]);
+
+    Ok(())
+}
+
+#[test]
+fn terminal_insert_before_lage_viewport() -> Result<(), Box<dyn Error>> {
+    // This test covers a bug previously present whereby doing an insert_before when the
+    // viewport covered the entire screen would cause a panic.
+
+    let backend = TestBackend::new(20, 3);
+    let mut terminal = Terminal::with_options(
+        backend,
+        TerminalOptions {
+            viewport: Viewport::Inline(3),
+        },
+    )?;
+
+    terminal.insert_before(1, |buf| {
+        Paragraph::new(vec!["------ Line 1 ------".into()]).render(buf.area, buf);
+    })?;
+
+    terminal.insert_before(3, |buf| {
+        Paragraph::new(vec![
+            "------ Line 2 ------".into(),
+            "------ Line 3 ------".into(),
+            "------ Line 4 ------".into(),
+        ])
+        .render(buf.area, buf);
+    })?;
+
+    terminal.insert_before(7, |buf| {
+        Paragraph::new(vec![
+            "------ Line 5 ------".into(),
+            "------ Line 6 ------".into(),
+            "------ Line 7 ------".into(),
+            "------ Line 8 ------".into(),
+            "------ Line 9 ------".into(),
+            "----- Line 10 ------".into(),
+            "----- Line 11 ------".into(),
+        ])
+        .render(buf.area, buf);
+    })?;
+
+    terminal.draw(|f| {
+        let paragraph = Paragraph::new("Viewport")
+            .centered()
+            .block(Block::bordered());
+        f.render_widget(paragraph, f.area());
+    })?;
+
+    terminal.backend().assert_buffer_lines([
+        "┌──────────────────┐",
+        "│     Viewport     │",
+        "└──────────────────┘",
+    ]);
+    terminal.backend().assert_scrollback_lines([
+        "------ Line 1 ------",
+        "------ Line 2 ------",
+        "------ Line 3 ------",
+        "------ Line 4 ------",
+        "------ Line 5 ------",
+        "------ Line 6 ------",
+        "------ Line 7 ------",
+        "------ Line 8 ------",
+        "------ Line 9 ------",
+        "----- Line 10 ------",
+        "----- Line 11 ------",
+    ]);
 
     Ok(())
 }

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -110,7 +110,7 @@ fn terminal_insert_before_moves_viewport() -> Result<(), Box<dyn Error>> {
         "                    ",
         "                    ",
     ]);
-    terminal.backend().assert_empty_scrollback(20);
+    terminal.backend().assert_empty_scrollback();
 
     Ok(())
 }


### PR DESCRIPTION
The current implementation of `Terminal::insert_before` causes the viewport to flicker. This is described in #584 .

This PR removes that flickering by using terminal scrolling regions (sometimes called "scroll regions"). A terminal can have its scrolling region set to something other than the whole screen. When a scroll ANSI sequence is sent to the terminal and it has a non-default scrolling region, the terminal will scroll just inside of that region.

We use scrolling regions to implement insert_before. We create a region on the screen above the viewport, scroll that up to make room for the newly inserted lines, and then draw the new lines. We may need to repeat this process depending on how much space there is and how many lines we need to draw.

When the viewport takes up the entire screen, we take a modified approach. We create a scrolling region of just the top line (could be more) of the viewport, then use that to draw the lines we want to output. When we're done, we scroll it up by one line, into the scrollback history, and then redraw the top line from the viewport.

A final edge case is when the viewport hasn't yet reached the bottom of the screen. This case, we set up a different scrolling region, where the top is the top of the viewport, and the bottom is the viewport's bottom plus the number of lines we want to scroll by. We then scroll this region down to open up space above the viewport for drawing the inserted lines.

Regardless of what we do, we need to reset the scrolling region. This PR takes the approach of always resetting the scrolling region after every operation. So the `Backend` gets new `scroll_region_up` and `scroll_region_down` methods instead of `set_scrolling_region`, `scroll_up`, `scroll_down`, and `reset_scrolling_region` methods. We chose that approach for two reasons. First, we don't want Ratatui to have to remember that state and then reset the scrolling region when tearing down. Second, the pre-Windows-10 console code doesn't support scrolling regions per se, but it does support scrolling parts of the console.

This PR:
- Adds a new `scrolling-regions` feature.
- Adds two new `Backend` methods: `scroll_region_up` and `scroll_region_down`.
- Implements those `Backend` methods on all backends in the codebase.
- The crossterm and termion implementations use raw ANSI escape sequences. I'm trying to merge changes into those two projects separately to support these functions.
- Adds code to `Terminal::insert_before` to choose between `insert_before_scrolling_regions` and `insert_before_no_scrolling_regions`. The latter is the old implementation.
- Adds lots of tests to the `TestBackend` to for the scrolling-region-related `Backend` methods.
- Adds versions of terminal tests that show that `insert_before` doesn't clobber the viewport. This is a change in behavior from before.