### PR TITLE
docs(table): fix incorrect backticks in `TableState` docs

### DIFF
--- a/src/widgets/table/table_state.rs
+++ b/src/widgets/table/table_state.rs
@@ -12,7 +12,7 @@
 /// [`offset`]: TableState::offset()
 /// [`selected`]: TableState::selected()
 ///
-/// See the `table`` example and the `recipe`` and `traceroute`` tabs in the demo2 example in the
+/// See the `table` example and the `recipe` and `traceroute` tabs in the demo2 example in the
 /// [Examples] directory for a more in depth example of the various configuration options and for
 /// how to handle state.
 ///


### PR DESCRIPTION
The part of the `TableState` docs that mention the examples, use an incorrect number of backticks.

Old:
![Old](https://github.com/user-attachments/assets/62d4e408-0a23-42fa-b129-304cf761a1dd)

New:
![New](https://github.com/user-attachments/assets/679e60bb-8538-45e5-9a77-749db6dcb5d3)
 