### PR TITLE
docs(backend): added link to stdio FAQ

### DIFF
--- a/src/backend/crossterm.rs
+++ b/src/backend/crossterm.rs
@@ -93,6 +93,11 @@ where
 {
     /// Creates a new `CrosstermBackend` with the given writer.
     ///
+    /// Most applications will use either [`stdout`](std::io::stdout) or
+    /// [`stderr`](std::io::stderr) as writer. See the [FAQ] to determine which one to use.
+    ///
+    /// [FAQ]: https://ratatui.rs/faq/#should-i-use-stdout-or-stderr
+    ///
     /// # Example
     ///
     /// ```rust,no_run

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -76,6 +76,11 @@ where
 {
     /// Creates a new Termion backend with the given writer.
     ///
+    /// Most applications will use either [`stdout`](std::io::stdout) or
+    /// [`stderr`](std::io::stderr) as writer. See the [FAQ] to determine which one to use.
+    ///
+    /// [FAQ]: https://ratatui.rs/faq/#should-i-use-stdout-or-stderr
+    ///
     /// # Example
     ///
     /// ```rust,no_run


### PR DESCRIPTION
Fixes https://github.com/ratatui/ratatui/issues/1348.

Simply adds a link to `stdout` vs `stderr` FAQ entry on ratatui.rs on the backend constructor.