### PR TITLE
chore(ci): bump git-cliff-action to v4

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -33,7 +33,7 @@ jobs:
         run: cargo publish --allow-dirty --token ${{ secrets.CARGO_TOKEN }}
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
           args: --unreleased --tag ${{ env.NEXT_TAG }} --strip header

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
           args: --latest --strip header


### PR DESCRIPTION
See: https://github.com/orhun/git-cliff-action/releases/tag/v4.0.0

This also makes me think if we should track GitHub Actions dependencies via Dependabot as well.