### PR TITLE
fix: create `unstable-backend-writer` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,11 @@ underline-color = ["dep:crossterm"]
 #! The following features are unstable and may change in the future:
 
 ## Enable all unstable features.
-unstable = ["unstable-rendered-line-info", "unstable-widget-ref"]
+unstable = [
+  "unstable-rendered-line-info",
+  "unstable-widget-ref",
+  "unstable-backend-writer",
+]
 
 ## Enables the [`Paragraph::line_count`](widgets::Paragraph::line_count)
 ## [`Paragraph::line_width`](widgets::Paragraph::line_width) methods
@@ -167,6 +171,9 @@ unstable-rendered-line-info = []
 ## Enables the [`WidgetRef`](widgets::WidgetRef) and [`StatefulWidgetRef`](widgets::StatefulWidgetRef) traits which are experimental and may change in
 ## the future.
 unstable-widget-ref = []
+
+## Enables getting access to backends' writers.
+unstable-backend-writer = []
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
https://github.com/ratatui/ratatui/pull/991 created a new unstable feature, but forgot to add it to Cargo.toml, making it impossible to use on newer versions of rustc - this commit fixes it.
