### PR TITLE
fix: allow to resize fixed viewports

### DIFF
--- a/src/terminal/terminal.rs
+++ b/src/terminal/terminal.rs
@@ -219,7 +219,7 @@ where
                 )?
                 .0
             }
-            Viewport::Fixed(area) => area,
+            Viewport::Fixed(_) => area,
         };
         self.set_viewport_area(next_area);
         self.clear()?;


### PR DESCRIPTION
Calling `Terminal::resize()` on a fixed viewport silently does nothing, because the inner `area` variable shadows the `area` parameter specified by user - this feels like a bug, because resizing fixed frames comes handy and I think it should be allowed.