### PR TITLE
feat(nix-support): add basic .nix files to project root.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ Cargo.lock
 *.rs.rustfmt
 .gdb_history
 .idea/
+
+# Nix related artifacts
+flake.lock

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "Ratatui - A Rust crate for cooking up Terminal User Interfaces";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    rust-overlay,
+    flake-utils,
+    flake-parts,
+  } @ inputs:
+    flake-parts.lib.mkFlake {
+      inherit inputs;
+    } {
+      systems =
+        flake-utils.lib.allSystems;
+      perSystem = {
+        config,
+        self,
+        inputs,
+        pkgs,
+        system,
+        ...
+      }: let
+        overlays = [(import rust-overlay)];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+      in {
+        devShells.default = pkgs.callPackage ./shell.nix {};
+      };
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+{pkgs ? import <nixpkgs> {}, ...}:
+pkgs.mkShell {
+  buildInputs = with pkgs.buildPackages; [
+    pkg-config
+    rust-bin.stable.latest.default
+    llvmPackages_latest.bintools
+  ];
+
+  RUSTFLAGS = builtins.map (a: ''-L ${a}/lib'') [
+    pkgs.llvmPackages_latest.bintools
+  ];
+  RUSTC_VERSION = pkgs.lib.readFile ./rust-toolchain.toml;
+}


### PR DESCRIPTION
Nix and Nixos btw cannot find statically linked libraries, which is why a `cargo build` results in the following error `collect2: fatal error: cannot find 'ld'`.

To ease development under nixos one usually
adds flake.nix and shell.nix files to the repo root.

Then we are able to generate the appropiate developing environment by typing the following command:

```sh
nix develop
```

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
