### PR TITLE
fix(block tests docs examples): mark title as deprecated

### DIFF
--- a/benches/main/block.rs
+++ b/benches/main/block.rs
@@ -2,10 +2,8 @@ use criterion::{criterion_group, BatchSize, Bencher, Criterion};
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
-    widgets::{
-        block::{Position, Title},
-        Block, Padding, Widget,
-    },
+    text::Line,
+    widgets::{Block, Padding, Widget},
 };
 
 /// Benchmark for rendering a block.
@@ -32,11 +30,7 @@ fn block(c: &mut Criterion) {
             &Block::bordered()
                 .padding(Padding::new(5, 5, 2, 2))
                 .title("test title")
-                .title(
-                    Title::from("bottom left title")
-                        .alignment(Alignment::Right)
-                        .position(Position::Bottom),
-                ),
+                .title_bottom(Line::from("bottom left title").alignment(Alignment::Right)),
             |b, block| render(b, block, buffer_size),
         );
     }

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -19,10 +19,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Layout, Rect},
     style::{Style, Stylize},
     text::Line,
-    widgets::{
-        block::{Position, Title},
-        Block, BorderType, Borders, Padding, Paragraph, Wrap,
-    },
+    widgets::{Block, BorderType, Borders, Padding, Paragraph, Wrap},
     DefaultTerminal, Frame,
 };
 
@@ -164,36 +161,12 @@ fn render_multiple_titles(paragraph: &Paragraph, frame: &mut Frame, area: Rect) 
 
 fn render_multiple_title_positions(paragraph: &Paragraph, frame: &mut Frame, area: Rect) {
     let block = Block::bordered()
-        .title(
-            Title::from("top left")
-                .position(Position::Top)
-                .alignment(Alignment::Left),
-        )
-        .title(
-            Title::from("top center")
-                .position(Position::Top)
-                .alignment(Alignment::Center),
-        )
-        .title(
-            Title::from("top right")
-                .position(Position::Top)
-                .alignment(Alignment::Right),
-        )
-        .title(
-            Title::from("bottom left")
-                .position(Position::Bottom)
-                .alignment(Alignment::Left),
-        )
-        .title(
-            Title::from("bottom center")
-                .position(Position::Bottom)
-                .alignment(Alignment::Center),
-        )
-        .title(
-            Title::from("bottom right")
-                .position(Position::Bottom)
-                .alignment(Alignment::Right),
-        );
+        .title_top(Line::from("top left").alignment(Alignment::Left))
+        .title_top(Line::from("top center").alignment(Alignment::Center))
+        .title_top(Line::from("top right").alignment(Alignment::Right))
+        .title_top(Line::from("bottom left").alignment(Alignment::Left))
+        .title_top(Line::from("bottom center").alignment(Alignment::Center))
+        .title_top(Line::from("bottom right").alignment(Alignment::Right));
     frame.render_widget(paragraph.clone().block(block), area);
 }
 

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -21,8 +21,8 @@ use ratatui::{
     layout::{Alignment, Constraint, Layout, Rect},
     style::{Color, Modifier, Style, Stylize},
     symbols::{self, Marker},
-    text::Span,
-    widgets::{block::Title, Axis, Block, Chart, Dataset, GraphType, LegendPosition},
+    text::{Line, Span},
+    widgets::{Axis, Block, Chart, Dataset, GraphType, LegendPosition},
     DefaultTerminal, Frame,
 };
 
@@ -197,11 +197,8 @@ fn render_barchart(frame: &mut Frame, bar_chart: Rect) {
 
     let chart = Chart::new(vec![dataset])
         .block(
-            Block::bordered().title(
-                Title::default()
-                    .content("Bar chart".cyan().bold())
-                    .alignment(Alignment::Center),
-            ),
+            Block::bordered()
+                .title(Line::from("Bar chart".cyan().bold()).alignment(Alignment::Center)),
         )
         .x_axis(
             Axis::default()
@@ -230,11 +227,8 @@ fn render_line_chart(frame: &mut Frame, area: Rect) {
 
     let chart = Chart::new(datasets)
         .block(
-            Block::bordered().title(
-                Title::default()
-                    .content("Line chart".cyan().bold())
-                    .alignment(Alignment::Center),
-            ),
+            Block::bordered()
+                .title(Line::from("Line chart".cyan().bold()).alignment(Alignment::Center)),
         )
         .x_axis(
             Axis::default()
@@ -280,11 +274,8 @@ fn render_scatter(frame: &mut Frame, area: Rect) {
 
     let chart = Chart::new(datasets)
         .block(
-            Block::bordered().title(
-                Title::default()
-                    .content("Scatter chart".cyan().bold())
-                    .alignment(Alignment::Center),
-            ),
+            Block::bordered()
+                .title(Line::from("Scatter chart".cyan().bold()).alignment(Alignment::Center)),
         )
         .x_axis(
             Axis::default()

--- a/examples/flex.rs
+++ b/examples/flex.rs
@@ -28,8 +28,8 @@ use ratatui::{
     symbols::{self, line},
     text::{Line, Text},
     widgets::{
-        block::Title, Block, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState,
-        StatefulWidget, Tabs, Widget,
+        Block, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget, Tabs,
+        Widget,
     },
     DefaultTerminal,
 };
@@ -273,7 +273,7 @@ impl App {
     fn tabs(self) -> impl Widget {
         let tab_titles = SelectedTab::iter().map(SelectedTab::to_tab_title);
         let block = Block::new()
-            .title(Title::from("Flex Layouts ".bold()))
+            .title(Line::from("Flex Layouts ".bold()))
             .title(" Use ◄ ► to change tab, ▲ ▼  to scroll, - + to change spacing ");
         Tabs::new(tab_titles)
             .block(block)

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -21,8 +21,8 @@ use ratatui::{
     crossterm::event::{self, Event, KeyCode, KeyEventKind},
     layout::{Alignment, Constraint, Layout, Rect},
     style::{palette::tailwind, Color, Style, Stylize},
-    text::Span,
-    widgets::{block::Title, Block, Borders, Gauge, Padding, Paragraph, Widget},
+    text::{Line, Span},
+    widgets::{Block, Borders, Gauge, Padding, Paragraph, Widget},
     DefaultTerminal,
 };
 
@@ -196,7 +196,7 @@ impl App {
 }
 
 fn title_block(title: &str) -> Block {
-    let title = Title::from(title).alignment(Alignment::Center);
+    let title = Line::from(title).alignment(Alignment::Center);
     Block::new()
         .borders(Borders::NONE)
         .padding(Padding::vertical(1))

--- a/examples/inline.rs
+++ b/examples/inline.rs
@@ -29,7 +29,7 @@ use ratatui::{
     style::{Color, Modifier, Style},
     symbols,
     text::{Line, Span},
-    widgets::{block, Block, Gauge, LineGauge, List, ListItem, Paragraph, Widget},
+    widgets::{Block, Gauge, LineGauge, List, ListItem, Paragraph, Widget},
     Frame, Terminal, TerminalOptions, Viewport,
 };
 
@@ -231,7 +231,7 @@ fn run(
 fn draw(frame: &mut Frame, downloads: &Downloads) {
     let area = frame.area();
 
-    let block = Block::new().title(block::Title::from("Progress").alignment(Alignment::Center));
+    let block = Block::new().title(Line::from("Progress").alignment(Alignment::Center));
     frame.render_widget(block, area);
 
     let vertical = Layout::vertical([Constraint::Length(2), Constraint::Length(4)]).margin(1);

--- a/examples/line_gauge.rs
+++ b/examples/line_gauge.rs
@@ -21,7 +21,8 @@ use ratatui::{
     crossterm::event::{self, Event, KeyCode, KeyEventKind},
     layout::{Alignment, Constraint, Layout, Rect},
     style::{palette::tailwind, Color, Style, Stylize},
-    widgets::{block::Title, Block, Borders, LineGauge, Padding, Paragraph, Widget},
+    text::Line,
+    widgets::{Block, Borders, LineGauge, Padding, Paragraph, Widget},
     DefaultTerminal,
 };
 
@@ -170,7 +171,7 @@ impl App {
 }
 
 fn title_block(title: &str) -> Block {
-    let title = Title::from(title).alignment(Alignment::Center);
+    let title = Line::from(title).alignment(Alignment::Center);
     Block::default()
         .title(title)
         .borders(Borders::NONE)

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -4,7 +4,7 @@
 //!
 //! In its simplest form, a `Block` is a [border](Borders) around another widget. It can have a
 //! [title](Block::title) and [padding](Block::padding).
-
+#![allow(deprecated)]
 use itertools::Itertools;
 use strum::{Display, EnumString};
 
@@ -354,6 +354,32 @@ impl<'a> Block<'a> {
         self
     }
 
+    /// Adds a title to a specific position
+    ///
+    /// You can provide any type that can be converted into [`Line`] including: strings, string
+    /// slices (`&str`), borrowed strings (`Cow<str>`), [spans](crate::text::Span), or vectors of
+    /// [spans](crate::text::Span) (`Vec<Span>`).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use ratatui::{ prelude::*, widgets::{*, block::title::Position},  };
+    /// Block::bordered()
+    ///     .title_at_position("Top", Position::Top) // By default in the left corner    
+    ///     .title_at_position("Bottom", Position::Bottom);    
+    /// // Renders
+    /// // ┌Top───────────────────────────────┐
+    /// // │                                  │
+    /// // └Bottom────────────────────────────┘
+    /// ```
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn title_at_position<T: Into<Line<'a>>>(self, title: T, position: Position) -> Self {
+        match position {
+            Position::Top => self.title_top(title),
+            Position::Bottom => self.title_bottom(title),
+        }
+    }
+
     /// Applies the style to all titles.
     ///
     /// This style will be applied to all titles of the block. If a title has a style set, it will
@@ -387,7 +413,7 @@ impl<'a> Block<'a> {
     /// Block::new()
     ///     .title_alignment(Alignment::Center)
     ///     // This title won't be aligned in the center
-    ///     .title(Title::from("right").alignment(Alignment::Right))
+    ///     .title(Line::from("right").alignment(Alignment::Right))
     ///     .title("foo")
     ///     .title("bar");
     /// ```
@@ -416,8 +442,8 @@ impl<'a> Block<'a> {
     ///
     /// Block::new()
     ///     .title_position(Position::Bottom)
-    ///     // This title won't be aligned in the center
-    ///     .title(Title::from("top").position(Position::Top))
+    ///     // This title won't be at the ottom
+    ///     .title_top(Line::from("top"))
     ///     .title("foo")
     ///     .title("bar");
     /// ```

--- a/src/widgets/block/title.rs
+++ b/src/widgets/block/title.rs
@@ -1,6 +1,6 @@
 //! This module holds the [`Title`] element and its related configuration types.
 //! A title is a piece of [`Block`](crate::widgets::Block) configuration.
-
+#![allow(deprecated)]
 use strum::{Display, EnumString};
 
 use crate::{layout::Alignment, text::Line};
@@ -47,6 +47,7 @@ use crate::{layout::Alignment, text::Line};
 ///     .alignment(Alignment::Right);
 /// ```
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[deprecated = "Title and Line can be used interchangeably, this struct is unnecessary. For specifying title position, use title_top, title_bottom and title_at_position functions."]
 pub struct Title<'a> {
     /// Title content
     pub content: Line<'a>,

--- a/src/widgets/sparkline.rs
+++ b/src/widgets/sparkline.rs
@@ -254,6 +254,7 @@ mod tests {
     #[test]
     fn it_does_not_panic_if_max_is_set_to_zero() {
         // see https://github.com/rust-lang/rust-clippy/issues/13191
+        #[allow(unknown_lints)]
         #[allow(clippy::unnecessary_min_or_max)]
         let widget = Sparkline::default().data(&[0, 1, 2]).max(0);
         let buffer = render(widget, 6);

--- a/tests/widgets_block.rs
+++ b/tests/widgets_block.rs
@@ -3,11 +3,8 @@ use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
     style::{Color, Style},
-    text::Span,
-    widgets::{
-        block::title::{Position, Title},
-        Block, Borders,
-    },
+    text::{Line, Span},
+    widgets::{Block, Borders},
     Terminal,
 };
 use rstest::rstest;
@@ -58,9 +55,9 @@ fn widgets_block_titles_overlap() {
     // Left overrides the center
     test_case(
         Block::new()
-            .title(Title::from("aaaaa").alignment(Alignment::Left))
-            .title(Title::from("bbb").alignment(Alignment::Center))
-            .title(Title::from("ccc").alignment(Alignment::Right)),
+            .title(Line::from("aaaaa").alignment(Alignment::Left))
+            .title(Line::from("bbb").alignment(Alignment::Center))
+            .title(Line::from("ccc").alignment(Alignment::Right)),
         Rect::new(0, 0, 10, 1),
         ["aaaaab ccc"],
     );
@@ -68,9 +65,9 @@ fn widgets_block_titles_overlap() {
     // Left alignment overrides the center alignment which overrides the right alignment
     test_case(
         Block::new()
-            .title(Title::from("aaaaa").alignment(Alignment::Left))
-            .title(Title::from("bbbbb").alignment(Alignment::Center))
-            .title(Title::from("ccccc").alignment(Alignment::Right)),
+            .title(Line::from("aaaaa").alignment(Alignment::Left))
+            .title(Line::from("bbbbb").alignment(Alignment::Center))
+            .title(Line::from("ccccc").alignment(Alignment::Right)),
         Rect::new(0, 0, 11, 1),
         ["aaaaabbbccc"],
     );
@@ -78,10 +75,10 @@ fn widgets_block_titles_overlap() {
     // Multiple left alignment overrides the center alignment and the right alignment
     test_case(
         Block::new()
-            .title(Title::from("aaaaa").alignment(Alignment::Left))
-            .title(Title::from("aaaaa").alignment(Alignment::Left))
-            .title(Title::from("bbbbb").alignment(Alignment::Center))
-            .title(Title::from("ccccc").alignment(Alignment::Right)),
+            .title(Line::from("aaaaa").alignment(Alignment::Left))
+            .title(Line::from("aaaaa").alignment(Alignment::Left))
+            .title(Line::from("bbbbb").alignment(Alignment::Center))
+            .title(Line::from("ccccc").alignment(Alignment::Right)),
         Rect::new(0, 0, 11, 1),
         ["aaaaabaaaaa"],
     );
@@ -89,8 +86,8 @@ fn widgets_block_titles_overlap() {
     // The right alignment doesn't override the center alignment, but pierces through it
     test_case(
         Block::new()
-            .title(Title::from("bbbbb").alignment(Alignment::Center))
-            .title(Title::from("ccccccccccc").alignment(Alignment::Right)),
+            .title(Line::from("bbbbb").alignment(Alignment::Center))
+            .title(Line::from("ccccccccccc").alignment(Alignment::Right)),
         Rect::new(0, 0, 11, 1),
         ["cccbbbbbccc"],
     );
@@ -275,7 +272,7 @@ fn widgets_block_title_alignment_top<'line, Lines>(
 
     let block1 = Block::new()
         .borders(borders)
-        .title(Title::from(Span::raw("Title")).alignment(alignment));
+        .title(Line::from(Span::raw("Title")).alignment(alignment));
 
     let block2 = Block::new()
         .borders(borders)
@@ -379,10 +376,8 @@ fn widgets_block_title_alignment_bottom<'line, Lines>(
     let backend = TestBackend::new(15, 3);
     let mut terminal = Terminal::new(backend).unwrap();
 
-    let title = Title::from(Span::styled("Title", Style::default()))
-        .alignment(alignment)
-        .position(Position::Bottom);
-    let block = Block::default().title(title).borders(borders);
+    let title = Line::from(Span::styled("Title", Style::default())).alignment(alignment);
+    let block = Block::default().title_bottom(title).borders(borders);
     let area = Rect::new(1, 0, 13, 3);
     terminal
         .draw(|frame| frame.render_widget(block, area))
@@ -391,84 +386,84 @@ fn widgets_block_title_alignment_bottom<'line, Lines>(
 }
 
 #[rstest]
-#[case::left_with_all_borders(Title::from("foo"), Title::from("bar"), Borders::ALL, [
+#[case::left_with_all_borders(Line::from("foo"), Line::from("bar"), Borders::ALL, [
     " ┌foo─bar────┐ ",
     " │           │ ",
     " └───────────┘ ",
 ])]
-#[case::left_without_top_border(Title::from("foo"), Title::from("bar"), Borders::LEFT | Borders::BOTTOM | Borders::RIGHT, [
+#[case::left_without_top_border(Line::from("foo"), Line::from("bar"), Borders::LEFT | Borders::BOTTOM | Borders::RIGHT, [
     " │foo bar    │ ",
     " │           │ ",
     " └───────────┘ ",
 ])]
-#[case::left_without_left_border(Title::from("foo"), Title::from("bar"), Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
+#[case::left_without_left_border(Line::from("foo"), Line::from("bar"), Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
     " foo─bar─────┐ ",
     "             │ ",
     " ────────────┘ ",
 ])]
-#[case::left_without_right_border(Title::from("foo"), Title::from("bar"), Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
+#[case::left_without_right_border(Line::from("foo"), Line::from("bar"), Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
     " ┌foo─bar───── ",
     " │             ",
     " └──────────── ",
 ])]
-#[case::left_without_borders(Title::from("foo"), Title::from("bar"), Borders::NONE, [
+#[case::left_without_borders(Line::from("foo"), Line::from("bar"), Borders::NONE, [
     " foo bar       ",
     "               ",
     "               ",
 ])]
-#[case::center_with_borders(Title::from("foo").alignment(Alignment::Center), Title::from("bar").alignment(Alignment::Center), Borders::ALL, [
+#[case::center_with_borders(Line::from("foo").alignment(Alignment::Center), Line::from("bar").alignment(Alignment::Center), Borders::ALL, [
     " ┌──foo─bar──┐ ",
     " │           │ ",
     " └───────────┘ ",
 ])]
-#[case::center_without_top_border(Title::from("foo").alignment(Alignment::Center), Title::from("bar").alignment(Alignment::Center), Borders::LEFT | Borders::BOTTOM | Borders::RIGHT, [
+#[case::center_without_top_border(Line::from("foo").alignment(Alignment::Center), Line::from("bar").alignment(Alignment::Center), Borders::LEFT | Borders::BOTTOM | Borders::RIGHT, [
     " │  foo bar  │ ",
     " │           │ ",
     " └───────────┘ ",
 ])]
-#[case::center_without_left_border(Title::from("foo").alignment(Alignment::Center), Title::from("bar").alignment(Alignment::Center), Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
+#[case::center_without_left_border(Line::from("foo").alignment(Alignment::Center), Line::from("bar").alignment(Alignment::Center), Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
     " ──foo─bar───┐ ",
     "             │ ",
     " ────────────┘ ",
 ])]
-#[case::center_without_right_border(Title::from("foo").alignment(Alignment::Center), Title::from("bar").alignment(Alignment::Center), Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
+#[case::center_without_right_border(Line::from("foo").alignment(Alignment::Center), Line::from("bar").alignment(Alignment::Center), Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
     " ┌──foo─bar─── ",
     " │             ",
     " └──────────── ",
 ])]
-#[case::center_without_borders(Title::from("foo").alignment(Alignment::Center), Title::from("bar").alignment(Alignment::Center), Borders::NONE, [
+#[case::center_without_borders(Line::from("foo").alignment(Alignment::Center), Line::from("bar").alignment(Alignment::Center), Borders::NONE, [
     "    foo bar    ",
     "               ",
     "               ",
 ])]
-#[case::right_with_all_borders(Title::from("foo").alignment(Alignment::Right), Title::from("bar").alignment(Alignment::Right), Borders::ALL, [
+#[case::right_with_all_borders(Line::from("foo").alignment(Alignment::Right), Line::from("bar").alignment(Alignment::Right), Borders::ALL, [
     " ┌────foo─bar┐ ",
     " │           │ ",
     " └───────────┘ ",
 ])]
-#[case::right_without_top_border(Title::from("foo").alignment(Alignment::Right), Title::from("bar").alignment(Alignment::Right), Borders::LEFT | Borders::BOTTOM | Borders::RIGHT, [
+#[case::right_without_top_border(Line::from("foo").alignment(Alignment::Right), Line::from("bar").alignment(Alignment::Right), Borders::LEFT | Borders::BOTTOM | Borders::RIGHT, [
     " │    foo bar│ ",
     " │           │ ",
     " └───────────┘ ",
 ])]
-#[case::right_without_left_border(Title::from("foo").alignment(Alignment::Right), Title::from("bar").alignment(Alignment::Right), Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
+#[case::right_without_left_border(Line::from("foo").alignment(Alignment::Right), Line::from("bar").alignment(Alignment::Right), Borders::TOP | Borders::RIGHT | Borders::BOTTOM, [
     " ─────foo─bar┐ ",
     "             │ ",
     " ────────────┘ ",
 ])]
-#[case::right_without_right_border(Title::from("foo").alignment(Alignment::Right), Title::from("bar").alignment(Alignment::Right), Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
+#[case::right_without_right_border(Line::from("foo").alignment(Alignment::Right), Line::from("bar").alignment(Alignment::Right), Borders::LEFT | Borders::TOP | Borders::BOTTOM, [
     " ┌─────foo─bar ",
     " │             ",
     " └──────────── ",
 ])]
-#[case::right_without_borders(Title::from("foo").alignment(Alignment::Right), Title::from("bar").alignment(Alignment::Right), Borders::NONE, [
+#[case::right_without_borders(Line::from("foo").alignment(Alignment::Right), Line::from("bar").alignment(Alignment::Right), Borders::NONE, [
     "       foo bar ",
     "               ",
     "               ",
 ])]
 fn widgets_block_multiple_titles<'line, Lines>(
-    #[case] title_a: Title,
-    #[case] title_b: Title,
+    #[case] title_a: Line,
+    #[case] title_b: Line,
     #[case] borders: Borders,
     #[case] expected: Lines,
 ) where


### PR DESCRIPTION
This PR marks title as deprecated, adds title_at_position function  and adapts code and function docs to not use Title. The title_at_position function is required as what used to be 
```rust
title(Title::from("foo").position(position))
```
would have to be 
```rust
match position { 
  TitlePosition::Top => title_top("foo"),
  TitlePosition::Bottom => title_bottom("foo"),
}
```
which is too  long compared to 
```rust
title_at_position("foo", position)
```