### PR TITLE
fix(rect)!: Rect::area now returns u32 and Rect::new() no longer clamps area to u16::MAX

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -71,6 +71,13 @@ This is a quick summary of the sections below:
 
 ## v0.29.0 (Unreleased)
 
+### `Rect::area()` now returns u32 instead of u16 ([#1378])
+
+[#1378]: https://github.com/ratatui/ratatui/pull/1378
+
+This is likely to impact anything which relies on `Rect::area` maxing out at u16::MAX. It can now
+return up to u16::MAX * u16::MAX (2^32 - 2^17 + 1).
+
 ### `Line` now implements `From<Cow<str>` ([#1373])
 
 [#1373]: https://github.com/ratatui/ratatui/pull/1373

--- a/benches/main/buffer.rs
+++ b/benches/main/buffer.rs
@@ -8,12 +8,7 @@ use ratatui::{
 criterion::criterion_group!(benches, empty, filled, with_lines);
 
 const fn rect(size: u16) -> Rect {
-    Rect {
-        x: 0,
-        y: 0,
-        width: size,
-        height: size,
-    }
+    Rect::new(0, 0, size, size)
 }
 
 fn empty(c: &mut Criterion) {

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -48,7 +48,7 @@ struct App {
 }
 
 impl App {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             x: 0.0,
             y: 0.0,

--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -269,9 +269,10 @@ impl Buffer {
             return None;
         }
         // remove offset
-        let y = position.y - self.area.y;
-        let x = position.x - self.area.x;
-        Some((y * self.area.width + x) as usize)
+        let y = (position.y - self.area.y) as usize;
+        let x = (position.x - self.area.x) as usize;
+        let width = self.area.width as usize;
+        Some(y * width + x)
     }
 
     /// Returns the (global) coordinates of a cell given its index

--- a/src/layout/rect.rs
+++ b/src/layout/rect.rs
@@ -55,32 +55,41 @@ impl Rect {
         height: 0,
     };
 
-    /// Creates a new `Rect`, with width and height limited to keep the area under max `u16`. If
-    /// clipped, aspect ratio will be preserved.
-    pub fn new(x: u16, y: u16, width: u16, height: u16) -> Self {
-        let max_area = u16::MAX;
-        let (clipped_width, clipped_height) =
-            if u32::from(width) * u32::from(height) > u32::from(max_area) {
-                let aspect_ratio = f64::from(width) / f64::from(height);
-                let max_area_f = f64::from(max_area);
-                let height_f = (max_area_f / aspect_ratio).sqrt();
-                let width_f = height_f * aspect_ratio;
-                (width_f as u16, height_f as u16)
-            } else {
-                (width, height)
-            };
+    /// Creates a new `Rect`, with width and height limited to keep both bounds within `u16`.
+    ///
+    /// If the width or height would cause the right or bottom coordinate to be larger than the
+    /// maximum value of `u16`, the width or height will be clamped to keep the right or bottom
+    /// coordinate within `u16`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ratatui::layout::Rect;
+    ///
+    /// let rect = Rect::new(1, 2, 3, 4);
+    /// ```
+    pub const fn new(x: u16, y: u16, width: u16, height: u16) -> Self {
+        // these calculations avoid using min so that this function can be const
+        let max_width = u16::MAX - x;
+        let max_height = u16::MAX - y;
+        let width = if width > max_width { max_width } else { width };
+        let height = if height > max_height {
+            max_height
+        } else {
+            height
+        };
         Self {
             x,
             y,
-            width: clipped_width,
-            height: clipped_height,
+            width,
+            height,
         }
     }
 
     /// The area of the `Rect`. If the area is larger than the maximum value of `u16`, it will be
     /// clamped to `u16::MAX`.
-    pub const fn area(self) -> u16 {
-        self.width.saturating_mul(self.height)
+    pub const fn area(self) -> u32 {
+        (self.width as u32) * (self.height as u32)
     }
 
     /// Returns true if the `Rect` has no area.
@@ -357,6 +366,8 @@ impl From<(Position, Size)> for Rect {
 
 #[cfg(test)]
 mod tests {
+    use std::u16;
+
     use rstest::rstest;
 
     use super::*;
@@ -505,46 +516,28 @@ mod tests {
 
     #[test]
     fn size_truncation() {
-        for width in 256u16..300u16 {
-            for height in 256u16..300u16 {
-                let rect = Rect::new(0, 0, width, height);
-                rect.area(); // Should not panic.
-                assert!(rect.width < width || rect.height < height);
-                // The target dimensions are rounded down so the math will not be too precise
-                // but let's make sure the ratios don't diverge crazily.
-                assert!(
-                    (f64::from(rect.width) / f64::from(rect.height)
-                        - f64::from(width) / f64::from(height))
-                    .abs()
-                        < 1.0
-                );
+        assert_eq!(
+            Rect::new(u16::MAX - 100, u16::MAX - 1000, 200, 2000),
+            Rect {
+                x: u16::MAX - 100,
+                y: u16::MAX - 1000,
+                width: 100,
+                height: 1000
             }
-        }
-
-        // One dimension below 255, one above. Area above max u16.
-        let width = 900;
-        let height = 100;
-        let rect = Rect::new(0, 0, width, height);
-        assert_ne!(rect.width, 900);
-        assert_ne!(rect.height, 100);
-        assert!(rect.width < width || rect.height < height);
+        );
     }
 
     #[test]
     fn size_preservation() {
-        for width in 0..256u16 {
-            for height in 0..256u16 {
-                let rect = Rect::new(0, 0, width, height);
-                rect.area(); // Should not panic.
-                assert_eq!(rect.width, width);
-                assert_eq!(rect.height, height);
+        assert_eq!(
+            Rect::new(u16::MAX - 100, u16::MAX - 1000, 100, 1000),
+            Rect {
+                x: u16::MAX - 100,
+                y: u16::MAX - 1000,
+                width: 100,
+                height: 1000
             }
-        }
-
-        // One dimension below 255, one above. Area below max u16.
-        let rect = Rect::new(0, 0, 300, 100);
-        assert_eq!(rect.width, 300);
-        assert_eq!(rect.height, 100);
+        )
     }
 
     #[test]
@@ -555,7 +548,7 @@ mod tests {
             width: 10,
             height: 10,
         };
-        const _AREA: u16 = RECT.area();
+        const _AREA: u32 = RECT.area();
         const _LEFT: u16 = RECT.left();
         const _RIGHT: u16 = RECT.right();
         const _TOP: u16 = RECT.top();

--- a/src/layout/rect.rs
+++ b/src/layout/rect.rs
@@ -366,8 +366,6 @@ impl From<(Position, Size)> for Rect {
 
 #[cfg(test)]
 mod tests {
-    use std::u16;
-
     use rstest::rstest;
 
     use super::*;
@@ -537,7 +535,7 @@ mod tests {
                 width: 100,
                 height: 1000
             }
-        )
+        );
     }
 
     #[test]

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -1,20 +1,11 @@
 use std::error::Error;
 
 use ratatui::{
-    backend::{Backend, TestBackend},
+    backend::TestBackend,
     layout::Rect,
     widgets::{Block, Paragraph, Widget},
     Terminal, TerminalOptions, Viewport,
 };
-
-#[test]
-fn terminal_buffer_size_should_be_limited() {
-    let backend = TestBackend::new(400, 400);
-    let terminal = Terminal::new(backend).unwrap();
-    let size = terminal.backend().size().unwrap();
-    assert_eq!(size.width, 255);
-    assert_eq!(size.height, 255);
-}
 
 #[test]
 fn swap_buffer_clears_prev_buffer() {


### PR DESCRIPTION
This change fixes the unexpected behavior of the Rect::new() function to
be more intuitive. The Rect::new() function now clamps the width and
height of the rectangle to keep each bound within u16::MAX. The
Rect::area() function now returns a u32 instead of a u16 to allow for
larger areas to be calculated.

Previously, the Rect::new() function would clamp the total area of the
rectangle to u16::MAX, by preserving the aspect ratio of the rectangle.

BREAKING CHANGE: Rect::area() now returns a u32 instead of a u16.

Fixes: <https://github.com/ratatui/ratatui/issues/1375>

---

TODO

- [x] Rect::new() still needs to clamp the width and height so that the any index bounds computed from x and width / y and 
height fit inside the u16 bounds as otherwise this would lead to non-indexable positions (and generally more overflows).
- [x] Rect::area() should return u32
- [x] All multiplications not in examples / tests should be checked (and tests added) for overflow
- [x] Additions should be investigated as to whether they can also cause overflow, but testing should be a lower priority as any overflows in addition would have already had to be failing
