### PR TITLE
chore: lock unicode-width version to 0.1.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ termwiz = { version = "0.22.0", optional = true }
 time = { version = "0.3.11", optional = true, features = ["local-offset"] }
 unicode-segmentation = "1.10"
 unicode-truncate = "1"
-unicode-width = "0.1.13"
+unicode-width = "=0.1.13"
 
 [target.'cfg(not(windows))'.dependencies]
 # termion is not supported on Windows


### PR DESCRIPTION
I'm not sure what is causing CI failures, but 0.1.14 contains breakig changes which we'll need to investigate.

Changes https://github.com/unicode-rs/unicode-width/compare/v0.1.13...v0.1.14

Fixes problems found in https://github.com/ratatui/ratatui/pull/1341


