### PR TITLE
refactor: Consistent result expected in layout tests

### DIFF
--- a/src/layout/layout.rs
+++ b/src/layout/layout.rs
@@ -1864,7 +1864,7 @@ mod tests {
                 ])
                 .split(target);
 
-            assert_eq!(target.height, chunks.iter().map(|r| r.height).sum::<u16>());
+            assert_eq!(chunks.iter().map(|r| r.height).sum::<u16>(), target.height);
             chunks.windows(2).for_each(|w| assert!(w[0].y <= w[1].y));
         }
 

--- a/src/layout/layout.rs
+++ b/src/layout/layout.rs
@@ -1957,7 +1957,7 @@ mod tests {
                 .iter()
                 .map(|r| r.width)
                 .collect::<Vec<u16>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
         }
 
         #[rstest]
@@ -1976,7 +1976,7 @@ mod tests {
                 .iter()
                 .map(|r| (r.x, r.width))
                 .collect::<Vec<(u16, u16)>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
         }
 
         #[rstest]
@@ -2007,7 +2007,7 @@ mod tests {
                 .iter()
                 .map(|r| r.width)
                 .collect::<Vec<u16>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
         }
 
         #[rstest]
@@ -2037,7 +2037,7 @@ mod tests {
                 .iter()
                 .map(|r| r.width)
                 .collect::<Vec<u16>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
 
             let rect = Rect::new(0, 0, 100, 1);
             let r = Layout::horizontal(&constraints)
@@ -2046,7 +2046,7 @@ mod tests {
                 .iter()
                 .map(|r| r.width)
                 .collect::<Vec<u16>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
 
             let rect = Rect::new(0, 0, 100, 1);
             let r = Layout::horizontal(&constraints)
@@ -2055,7 +2055,7 @@ mod tests {
                 .iter()
                 .map(|r| r.width)
                 .collect::<Vec<u16>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
 
             let rect = Rect::new(0, 0, 100, 1);
             let r = Layout::horizontal(&constraints)
@@ -2064,7 +2064,7 @@ mod tests {
                 .iter()
                 .map(|r| r.width)
                 .collect::<Vec<u16>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
 
             let rect = Rect::new(0, 0, 100, 1);
             let r = Layout::horizontal(&constraints)
@@ -2073,7 +2073,7 @@ mod tests {
                 .iter()
                 .map(|r| r.width)
                 .collect::<Vec<u16>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
         }
 
         #[rstest]
@@ -2087,7 +2087,7 @@ mod tests {
                 .iter()
                 .map(|r| r.width)
                 .collect::<Vec<u16>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
         }
 
         #[rstest]
@@ -2134,7 +2134,7 @@ mod tests {
                 .iter()
                 .map(|r| r.width)
                 .collect::<Vec<u16>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
         }
 
         #[rstest]
@@ -2151,7 +2151,7 @@ mod tests {
                 .iter()
                 .map(|r| r.width)
                 .collect::<Vec<u16>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
         }
 
         #[rstest]
@@ -2169,7 +2169,7 @@ mod tests {
                 .iter()
                 .map(|r| r.width)
                 .collect::<Vec<u16>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
         }
 
         #[rstest]
@@ -2233,7 +2233,7 @@ mod tests {
                 .iter()
                 .map(|r| (r.x, r.width))
                 .collect::<Vec<(u16, u16)>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
         }
 
         #[rstest]
@@ -2259,7 +2259,7 @@ mod tests {
                 .iter()
                 .map(|r| (r.x, r.width))
                 .collect::<Vec<(u16, u16)>>();
-            assert_eq!(expected, result);
+            assert_eq!(result, expected);
         }
 
         #[rstest]
@@ -2291,7 +2291,7 @@ mod tests {
                 .iter()
                 .map(|r| (r.x, r.width))
                 .collect::<Vec<(u16, u16)>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
         }
 
         #[rstest]
@@ -2315,7 +2315,7 @@ mod tests {
                 .iter()
                 .map(|r| (r.x, r.width))
                 .collect::<Vec<(u16, u16)>>();
-            assert_eq!(expected, r);
+            assert_eq!(r, expected);
         }
 
         #[rstest]
@@ -2340,7 +2340,7 @@ mod tests {
                 .iter()
                 .map(|r| (r.x, r.width))
                 .collect::<Vec<(u16, u16)>>();
-            assert_eq!(expected, result);
+            assert_eq!(result, expected);
         }
 
         #[rstest]
@@ -2383,7 +2383,7 @@ mod tests {
                 .iter()
                 .map(|r| (r.x, r.width))
                 .collect::<Vec<(u16, u16)>>();
-            assert_eq!(expected, result);
+            assert_eq!(result, expected);
         }
 
         #[rstest]
@@ -2403,7 +2403,7 @@ mod tests {
                 .iter()
                 .map(|r| (r.x, r.width))
                 .collect::<Vec<(u16, u16)>>();
-            assert_eq!(expected, result);
+            assert_eq!(result, expected);
         }
 
         #[rstest]
@@ -2427,7 +2427,7 @@ mod tests {
                 .iter()
                 .map(|r| (r.x, r.width))
                 .collect::<Vec<(u16, u16)>>();
-            assert_eq!(expected, result);
+            assert_eq!(result, expected);
         }
 
         #[rstest]
@@ -2453,7 +2453,7 @@ mod tests {
                 .iter()
                 .map(|r| (r.x, r.width))
                 .collect::<Vec<(u16, u16)>>();
-            assert_eq!(expected, result);
+            assert_eq!(result, expected);
         }
 
         #[rstest]
@@ -2479,7 +2479,7 @@ mod tests {
                 .iter()
                 .map(|r| (r.x, r.width))
                 .collect::<Vec<(u16, u16)>>();
-            assert_eq!(expected, result);
+            assert_eq!(result, expected);
         }
 
         #[rstest]
@@ -2500,7 +2500,7 @@ mod tests {
                 .iter()
                 .map(|r| (r.x, r.width))
                 .collect::<Vec<(u16, u16)>>();
-            assert_eq!(expected, result);
+            assert_eq!(result, expected);
         }
     }
 


### PR DESCRIPTION
Fixes #1399 
I've looked through all the `assert_eq` and made sure that they follow the `expected, result` pattern. I wasn't sure if it was desired to actually pass result and expected as variables to the assert_eq statements, so I've left everything that seems to have followed the pattern as is. 
