### PR TITLE
perf: remove various small allocations

### DIFF
--- a/src/buffer/buffer.rs
+++ b/src/buffer/buffer.rs
@@ -437,7 +437,7 @@ impl Buffer {
             // New index in content
             let k = ((y - area.y) * area.width + x - area.x) as usize;
             if i != k {
-                self.content[k] = self.content[i].clone();
+                self.content.swap(i, k);
                 self.content[i].reset();
             }
         }

--- a/src/widgets/list/list.rs
+++ b/src/widgets/list/list.rs
@@ -215,7 +215,13 @@ impl<'a> List<'a> {
         T: IntoIterator,
         T::Item: Into<ListItem<'a>>,
     {
-        self.items = items.into_iter().map(Into::into).collect();
+        // This should only allocate if the provided iterator does not fit.
+        // This is better than collecting it into a `Vec` as we can use the existing structure.
+        // Pushing in a for loop would also work, but extend makes use of size hints, and other
+        // optimizations which can improve performance depending on the exact type that is provided.
+        self.items.clear();
+        self.items.extend(items.into_iter().map(Into::into));
+
         self
     }
 

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -828,7 +828,7 @@ impl Table<'_> {
     /// Returns (x, width). When self.widths is empty, it is assumed `.widths()` has not been called
     /// and a default of equal widths is returned.
     fn get_columns_widths(&self, max_width: u16, selection_width: u16) -> Vec<(u16, u16)> {
-        let widths = if self.widths.is_empty() {
+        let widths: &[Constraint] = if self.widths.is_empty() {
             let col_count = self
                 .rows
                 .iter()
@@ -838,10 +838,11 @@ impl Table<'_> {
                 .max()
                 .unwrap_or(0);
             // Divide the space between each column equally
-            vec![Constraint::Length(max_width / col_count.max(1) as u16); col_count]
+            &vec![Constraint::Length(max_width / col_count.max(1) as u16); col_count]
         } else {
-            self.widths.clone()
+            &self.widths
         };
+
         // this will always allocate a selection area
         let [_selection_area, columns_area] =
             Layout::horizontal([Constraint::Length(selection_width), Constraint::Fill(0)])


### PR DESCRIPTION
Just a few minor allocation optimizations.

One thing to note is  in 0a8d59d19cdabeaeab49485d7bb82c766311af6d we can create a wrapper function with a generic and use that to remove an allocation in the case that a width is not provided by using `std::iter::repeat(val).take(col_count)`. Though in practice it worsened performance due to (I assume) branching.

To state the obvious, the changes here don't actually affect any of the benchmarks results, but are just small free optimizations.