### PR TITLE
fix(terminal): use the latest, resized area when clearing

### DIFF
--- a/src/terminal/terminal.rs
+++ b/src/terminal/terminal.rs
@@ -476,7 +476,8 @@ where
                     .set_cursor_position(self.viewport_area.as_position())?;
                 self.backend.clear_region(ClearType::AfterCursor)?;
             }
-            Viewport::Fixed(area) => {
+            Viewport::Fixed(_) => {
+                let area = self.viewport_area;
                 for y in area.top()..area.bottom() {
                     self.backend.set_cursor_position(Position { x: 0, y })?;
                     self.backend.clear_region(ClearType::AfterCursor)?;


### PR DESCRIPTION
This is the same mistake as 0f4823977894cef51d5ffafe6ae35ca7ad56e1ac

The code that comes after is still incorrect, clearing from the cursor to the bottom of the screen multiple times.
I'm using this in an alternate "Inline" implementation, as described in https://github.com/ratatui/ratatui/issues/1426#issuecomment-2420571210, for which the latter problem doesn't matter, except perhaps to reduce flickering very very slightly.
I hope this patch is acceptable as is.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
