### PR TITLE
chore: remove the last prelude refs / glob imports from example code

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,15 +1,15 @@
 //! A prelude for conveniently writing applications using this library.
 //!
-//! We moved away from using the prelude module universally in Ratatui because it makes it harder to
-//! see which types are coming from the library and which are not and occasionally especially when
-//! reading source code in a non-IDE context (such as on GitHub or in a git diff). See [Issue #1150]
-//! for more information and links to user feedback. We have kept the prelude module in the library
-//! for backwards compatibility and for users who prefer to use it.
+//! The prelude module is no longer used universally in Ratatui, as it can make it harder to
+//! distinguish between library and non-library types, especially when viewing source code
+//! outside of an IDE (such as on GitHub or in a git diff). For more details and user feedback, 
+//! see [Issue #1150]. However, the prelude is still available for backward compatibility and for 
+//! those who prefer to use it.
 //!
 //! [Issue #1150]: https://github.com/ratatui/ratatui/issues/1150
 //!
 //! # Examples
-//!
+//! 
 //! ```rust,no_run
 //! use ratatui::prelude::*;
 //! ```

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,14 +2,14 @@
 //!
 //! The prelude module is no longer used universally in Ratatui, as it can make it harder to
 //! distinguish between library and non-library types, especially when viewing source code
-//! outside of an IDE (such as on GitHub or in a git diff). For more details and user feedback, 
-//! see [Issue #1150]. However, the prelude is still available for backward compatibility and for 
+//! outside of an IDE (such as on GitHub or in a git diff). For more details and user feedback,
+//! see [Issue #1150]. However, the prelude is still available for backward compatibility and for
 //! those who prefer to use it.
 //!
 //! [Issue #1150]: https://github.com/ratatui/ratatui/issues/1150
 //!
 //! # Examples
-//! 
+//!
 //! ```rust,no_run
 //! use ratatui::prelude::*;
 //! ```

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,15 @@
 //! A prelude for conveniently writing applications using this library.
 //!
+//! We moved away from using the prelude module universally in Ratatui because it makes it harder to
+//! see which types are coming from the library and which are not and occasionally especially when
+//! reading source code in a non-IDE context (such as on GitHub or in a git diff). See [Issue #1150]
+//! for more information and links to user feedback. We have kept the prelude module in the library
+//! for backwards compatibility and for users who prefer to use it.
+//!
+//! [Issue #1150]: https://github.com/ratatui/ratatui/issues/1150
+//!
+//! # Examples
+//!
 //! ```rust,no_run
 //! use ratatui::prelude::*;
 //! ```

--- a/src/style.rs
+++ b/src/style.rs
@@ -38,8 +38,7 @@
 //! - [`Span`]s can be styled again, which will merge the styles.
 //! - Many widget types can be styled directly rather than calling their `style()` method.
 //!
-//! See the [`Stylize`] and [`Styled`] traits for more information. These traits are re-exported in
-//! the [`prelude`] module for convenience.
+//! See the [`Stylize`] and [`Styled`] traits for more information.
 //!
 //! ## Example
 //!
@@ -72,7 +71,6 @@
 //! );
 //! ```
 //!
-//! [`prelude`]: crate::prelude
 //! [`Span`]: crate::text::Span
 
 use std::fmt;

--- a/src/widgets/table/table.rs
+++ b/src/widgets/table/table.rs
@@ -595,7 +595,7 @@ impl<'a> Table<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::{layout::Constraint, style::{Style, Stylize}, widgets::{Row, Table}};
     /// # let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// # let widths = [Constraint::Length(5), Constraint::Length(5)];
     /// let table = Table::new(rows, widths).row_highlight_style(Style::new().red().italic());
@@ -620,7 +620,7 @@ impl<'a> Table<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::{layout::Constraint, style::{Style, Stylize}, widgets::{Row, Table}};
     /// # let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// # let widths = [Constraint::Length(5), Constraint::Length(5)];
     /// let table = Table::new(rows, widths).column_highlight_style(Style::new().red().italic());
@@ -645,7 +645,7 @@ impl<'a> Table<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::{layout::Constraint, style::{Style, Stylize}, widgets::{Row, Table}};
     /// # let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// # let widths = [Constraint::Length(5), Constraint::Length(5)];
     /// let table = Table::new(rows, widths).cell_highlight_style(Style::new().red().italic());

--- a/src/widgets/table/table_state.rs
+++ b/src/widgets/table/table_state.rs
@@ -123,7 +123,7 @@ impl TableState {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::widgets::{TableState};
     /// let state = TableState::new().with_selected_column(Some(1));
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
@@ -142,7 +142,7 @@ impl TableState {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::widgets::{TableState};
     /// let state = TableState::new().with_selected_cell(Some((1, 5)));
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
@@ -212,7 +212,7 @@ impl TableState {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::widgets::{TableState};
     /// let state = TableState::new();
     /// assert_eq!(state.selected_column(), None);
     /// ```
@@ -227,7 +227,7 @@ impl TableState {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::widgets::{TableState};
     /// let state = TableState::new();
     /// assert_eq!(state.selected_cell(), None);
     /// ```
@@ -261,7 +261,7 @@ impl TableState {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::widgets::{TableState};
     /// let mut state = TableState::default();
     /// *state.selected_column_mut() = Some(1);
     /// ```
@@ -293,7 +293,7 @@ impl TableState {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::widgets::{TableState};
     /// let mut state = TableState::default();
     /// state.select_column(Some(1));
     /// ```
@@ -308,7 +308,7 @@ impl TableState {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::widgets::{TableState};
     /// let mut state = TableState::default();
     /// state.select_cell(Some((1, 5)));
     /// ```
@@ -349,7 +349,7 @@ impl TableState {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::widgets::{TableState};
     /// let mut state = TableState::default();
     /// state.select_next_column();
     /// ```
@@ -384,7 +384,7 @@ impl TableState {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::widgets::{TableState};
     /// let mut state = TableState::default();
     /// state.select_previous_column();
     /// ```
@@ -420,7 +420,7 @@ impl TableState {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::widgets::{TableState};
     /// let mut state = TableState::default();
     /// state.select_first_column();
     /// ```
@@ -453,7 +453,7 @@ impl TableState {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::widgets::{TableState};
     /// let mut state = TableState::default();
     /// state.select_last();
     /// ```
@@ -508,7 +508,7 @@ impl TableState {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::widgets::{TableState};
     /// let mut state = TableState::default();
     /// state.scroll_right_by(4);
     /// ```
@@ -526,7 +526,7 @@ impl TableState {
     /// # Examples
     ///
     /// ```rust
-    /// # use ratatui::{prelude::*, widgets::*};
+    /// # use ratatui::widgets::{TableState};
     /// let mut state = TableState::default();
     /// state.scroll_left_by(4);
     /// ```


### PR DESCRIPTION
Fixes: <https://github.com/ratatui/ratatui/issues/1150>
