### PR TITLE
fix(text): truncate based on alignment

### DIFF
--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -687,7 +687,7 @@ impl Widget for Line<'_> {
 
 impl WidgetRef for Line<'_> {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
-        self.render_with_alignment(area, buf, None)
+        self.render_with_alignment(area, buf, None);
     }
 }
 

--- a/src/text/line.rs
+++ b/src/text/line.rs
@@ -568,53 +568,6 @@ impl<'a> Line<'a> {
     pub fn push_span<T: Into<Span<'a>>>(&mut self, span: T) {
         self.spans.push(span.into());
     }
-
-    /// An internal implementation method for `WidgetRef::render_ref`
-    ///
-    /// Allows the parent widget to define a default alignment, to be
-    /// used if `Line::alignment` is `None`.
-    pub(crate) fn render_with_alignment(
-        &self,
-        area: Rect,
-        buf: &mut Buffer,
-        parent_alignment: Option<Alignment>,
-    ) {
-        let area = area.intersection(buf.area);
-        if area.is_empty() {
-            return;
-        }
-        let area = Rect { height: 1, ..area };
-        let line_width = self.width();
-        if line_width == 0 {
-            return;
-        }
-
-        buf.set_style(area, self.style);
-
-        let alignment = self.alignment.or(parent_alignment);
-
-        let area_width = usize::from(area.width);
-        let can_render_complete_line = line_width <= area_width;
-        if can_render_complete_line {
-            let indent_width = match alignment {
-                Some(Alignment::Center) => (area_width.saturating_sub(line_width)) / 2,
-                Some(Alignment::Right) => area_width.saturating_sub(line_width),
-                Some(Alignment::Left) | None => 0,
-            };
-            let indent_width = u16::try_from(indent_width).unwrap_or(u16::MAX);
-            let area = area.indent_x(indent_width);
-            render_spans(&self.spans, area, buf, 0);
-        } else {
-            // There is not enough space to render the whole line. As the right side is truncated by
-            // the area width, only truncate the left.
-            let skip_width = match alignment {
-                Some(Alignment::Center) => (line_width.saturating_sub(area_width)) / 2,
-                Some(Alignment::Right) => line_width.saturating_sub(area_width),
-                Some(Alignment::Left) | None => 0,
-            };
-            render_spans(&self.spans, area, buf, skip_width);
-        };
-    }
 }
 
 impl<'a> IntoIterator for Line<'a> {
@@ -735,6 +688,55 @@ impl Widget for Line<'_> {
 impl WidgetRef for Line<'_> {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         self.render_with_alignment(area, buf, None)
+    }
+}
+
+impl Line<'_> {
+    /// An internal implementation method for `WidgetRef::render_ref`
+    ///
+    /// Allows the parent widget to define a default alignment, to be
+    /// used if `Line::alignment` is `None`.
+    pub(crate) fn render_with_alignment(
+        &self,
+        area: Rect,
+        buf: &mut Buffer,
+        parent_alignment: Option<Alignment>,
+    ) {
+        let area = area.intersection(buf.area);
+        if area.is_empty() {
+            return;
+        }
+        let area = Rect { height: 1, ..area };
+        let line_width = self.width();
+        if line_width == 0 {
+            return;
+        }
+
+        buf.set_style(area, self.style);
+
+        let alignment = self.alignment.or(parent_alignment);
+
+        let area_width = usize::from(area.width);
+        let can_render_complete_line = line_width <= area_width;
+        if can_render_complete_line {
+            let indent_width = match alignment {
+                Some(Alignment::Center) => (area_width.saturating_sub(line_width)) / 2,
+                Some(Alignment::Right) => area_width.saturating_sub(line_width),
+                Some(Alignment::Left) | None => 0,
+            };
+            let indent_width = u16::try_from(indent_width).unwrap_or(u16::MAX);
+            let area = area.indent_x(indent_width);
+            render_spans(&self.spans, area, buf, 0);
+        } else {
+            // There is not enough space to render the whole line. As the right side is truncated by
+            // the area width, only truncate the left.
+            let skip_width = match alignment {
+                Some(Alignment::Center) => (line_width.saturating_sub(area_width)) / 2,
+                Some(Alignment::Right) => line_width.saturating_sub(area_width),
+                Some(Alignment::Left) | None => 0,
+            };
+            render_spans(&self.spans, area, buf, skip_width);
+        };
     }
 }
 


### PR DESCRIPTION
This is a follow-up PR to https://github.com/ratatui/ratatui/pull/987, which implemented alignment-aware truncation for the `Line` widget. However, the truncation only checked the `Line::alignment` field, and any alignment inherited from a parent's `Text::alignment` field would not be used.

This commit updates the truncation of `Line` to depend both on the individual `Line::alignment`, and on any alignment inherited from the parent's `Text::alignment`.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
