### PR TITLE
chore: remove PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,0 @@
-<!-- Please read CONTRIBUTING.md before submitting any pull request. -->


### PR DESCRIPTION
GitHub now automatically links to the Contributing docs for all first
time repo contributors on the PR page. This is just annoying to have to
manually choose not to use (or remove before merging).
