### PR TITLE
fix(buffer): buffer::get_pos() now correctly handles index > u16::MAX

### DIFF
--- a/src/style/color.rs
+++ b/src/style/color.rs
@@ -480,6 +480,7 @@ mod tests {
 
     #[cfg(feature = "palette")]
     use palette::{Hsl, Hsluv};
+    #[cfg(feature = "palette")]
     use rstest::rstest;
     #[cfg(feature = "serde")]
     use serde::de::{Deserialize, IntoDeserializer};


### PR DESCRIPTION
Previously this function wrapped the index pass u16::MAX which caused
problems rendering.

Fixes: <https://github.com/ratatui/ratatui/issues/1441>
