### PR TITLE
docs: fix example link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ fn draw(frame: &mut Frame) {
 [Layout]: https://ratatui.rs/how-to/layout/
 [Styling Text]: https://ratatui.rs/how-to/render/style-text/
 [templates]: https://github.com/ratatui/templates/
-[Examples]: https://github.com/ratatui/ratatui/tree/main/examples/README.md
+[Examples]: https://github.com/ratatui/ratatui/blob/main/ratatui/examples/README.md
 [Report a bug]: https://github.com/ratatui/ratatui/issues/new?labels=bug&projects=&template=bug_report.md
 [Request a Feature]: https://github.com/ratatui/ratatui/issues/new?labels=enhancement&projects=&template=feature_request.md
 [Create a Pull Request]: https://github.com/ratatui/ratatui/compare


### PR DESCRIPTION
README.md contains a link to unexisting example directory like it was before on root bu nowt it's in `ratatui` directory. 

I'm new to this repo this is probably due to a recent change.