### PR TITLE
feat(bar)!: update label and text_value to accept Into<>

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -124,6 +124,37 @@ let crossterm_attribute = crossterm::style::types::Attribute::Bold;
 Similar conversions for `ContentStyle` -> `Style` and `Attributes` -> `Modifier` exist for
 Crossterm and the various Termion and Termwiz types as well.
 
+### `Bar::label()` and `BarGroup::label()` now accepts `Into<Line<'a>>`. ([#1471])
+
+[#1471]: https://github.com/ratatui/ratatui/pull/1471
+
+Previously `Bar::label()` and `BarGroup::label()` accepted `Line<'a>`, but they now accepts `Into<Line<'a>>`.
+
+for `Bar::label()`:
+
+```diff
+- Bar::default().label("foo".into());
++ Bar::default().label("foo");
+```
+
+for `BarGroup::label()`:
+
+```diff
+- BarGroup::default().label("bar".into());
++ BarGroup::default().label("bar");
+```
+
+### `Bar::text_value` now accepts `Into<String>` ([#1471])
+
+Previously `Bar::text_value` accepted `String`, but now it accepts `Into<String>`.
+
+for `Bar::text_value()`:
+
+```diff
+- Bar::default().text_value("foobar".into());
++ Bar::default().text_value("foobar");
+```
+
 ## [v0.29.0](https://github.com/ratatui/ratatui/releases/tag/v0.29.0)
 
 ### `Sparkline::data` takes `IntoIterator<Item = SparklineBar>` instead of `&[u64]` and is no longer const ([#1326])

--- a/ratatui-widgets/src/barchart.rs
+++ b/ratatui-widgets/src/barchart.rs
@@ -874,10 +874,10 @@ mod tests {
     #[test]
     fn test_empty_group() {
         let chart = BarChart::default()
-            .data(BarGroup::default().label("invisible".into()))
+            .data(BarGroup::default().label("invisible"))
             .data(
                 BarGroup::default()
-                    .label("G".into())
+                    .label("G")
                     .bars(&[Bar::default().value(1), Bar::default().value(2)]),
             );
 
@@ -894,12 +894,12 @@ mod tests {
 
     fn build_test_barchart<'a>() -> BarChart<'a> {
         BarChart::default()
-            .data(BarGroup::default().label("G1".into()).bars(&[
+            .data(BarGroup::default().label("G1").bars(&[
                 Bar::default().value(2),
                 Bar::default().value(3),
                 Bar::default().value(4),
             ]))
-            .data(BarGroup::default().label("G2".into()).bars(&[
+            .data(BarGroup::default().label("G2").bars(&[
                 Bar::default().value(3),
                 Bar::default().value(4),
                 Bar::default().value(5),
@@ -966,7 +966,7 @@ mod tests {
     fn test_horizontal_bars_label_width_greater_than_bar(bar_color: Option<Color>) {
         let mut bar = Bar::default()
             .value(2)
-            .text_value("label".into())
+            .text_value("label")
             .value_style(Style::default().red());
 
         if let Some(color) = bar_color {
@@ -1041,7 +1041,7 @@ mod tests {
         let chart: BarChart<'_> = BarChart::default()
             .data(
                 BarGroup::default()
-                    .label(Span::from("G1").red().into())
+                    .label(Span::from("G1").red())
                     .bars(&[Bar::default().value(2)]),
             )
             .group_gap(1)
@@ -1109,18 +1109,9 @@ mod tests {
     #[test]
     fn test_unicode_as_value() {
         let group = BarGroup::default().bars(&[
-            Bar::default()
-                .value(123)
-                .label("B1".into())
-                .text_value("写".into()),
-            Bar::default()
-                .value(321)
-                .label("B2".into())
-                .text_value("写".into()),
-            Bar::default()
-                .value(333)
-                .label("B2".into())
-                .text_value("写".into()),
+            Bar::default().value(123).label("B1").text_value("写"),
+            Bar::default().value(321).label("B2").text_value("写"),
+            Bar::default().value(333).label("B2").text_value("写"),
         ]);
         let chart = BarChart::default().data(group).bar_width(3).bar_gap(1);
 
@@ -1162,7 +1153,7 @@ mod tests {
             ("i", 8),
         ])
             .into();
-        group = group.label("Group".into());
+        group = group.label("Group");
 
         let chart = BarChart::default()
             .data(group)
@@ -1187,7 +1178,7 @@ mod tests {
             ("i", 8),
         ])
             .into();
-        group = group.label("Group".into());
+        group = group.label("Group");
 
         let chart = BarChart::default()
             .data(group)

--- a/ratatui-widgets/src/barchart/bar.rs
+++ b/ratatui-widgets/src/barchart/bar.rs
@@ -28,11 +28,11 @@ use unicode_width::UnicodeWidthStr;
 /// };
 ///
 /// Bar::default()
-///     .label("Bar 1".into())
+///     .label("Bar 1")
 ///     .value(10)
 ///     .red()
 ///     .value_style(Style::new().red().on_white())
-///     .text_value("10°C".to_string());
+///     .text_value("10°C");
 /// ```
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct Bar<'a> {
@@ -65,14 +65,35 @@ impl<'a> Bar<'a> {
 
     /// Set the label of the bar.
     ///
+    /// `label` can be a [`&str`], [`String`] or anything that can be converted into [`Line`].
+    ///
+    /// # Examples
+    ///
+    /// From [`&str`] and [`String`]:
+    ///
+    /// ```rust
+    /// use ratatui::widgets::Bar;
+    ///
+    /// Bar::default().label("label");
+    /// Bar::default().label(String::from("label"));
+    /// ```
+    ///
+    /// From a [`Line`] with red foreground color:
+    ///
+    /// ```rust
+    /// use ratatui::{style::Stylize, text::Line, widgets::Bar};
+    ///
+    /// Bar::default().label(Line::from("Line").red());
+    /// ```
+    ///
     /// For [`Vertical`](ratatui_core::layout::Direction::Vertical) bars,
     /// display the label **under** the bar.
     /// For [`Horizontal`](ratatui_core::layout::Direction::Horizontal) bars,
     /// display the label **in** the bar.
     /// See [`BarChart::direction`](crate::barchart::BarChart::direction) to set the direction.
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn label(mut self, label: Line<'a>) -> Self {
-        self.label = Some(label);
+    pub fn label<T: Into<Line<'a>>>(mut self, label: T) -> Self {
+        self.label = Some(label.into());
         self
     }
 
@@ -108,15 +129,28 @@ impl<'a> Bar<'a> {
 
     /// Set the text value printed in the bar.
     ///
+    /// `text_value` can be a [`&str`], `Number` or anything that can be converted into [`String`].
+    ///
     /// If `text_value` is not set, then the [`ToString`] representation of `value` will be shown on
     /// the bar.
+    ///
+    /// # Examples
+    ///
+    /// From [`&str`] and [`String`]:
+    ///
+    /// ```
+    /// use ratatui::widgets::Bar;
+    ///
+    /// Bar::default().text_value("label");
+    /// Bar::default().text_value(String::from("label"));
+    /// ```
     ///
     /// # See also
     ///
     /// [`Bar::value`] to set the value.
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn text_value(mut self, text_value: String) -> Self {
-        self.text_value = Some(text_value);
+    pub fn text_value<T: Into<String>>(mut self, text_value: T) -> Self {
+        self.text_value = Some(text_value.into());
         self
     }
 

--- a/ratatui-widgets/src/barchart/bar_group.rs
+++ b/ratatui-widgets/src/barchart/bar_group.rs
@@ -16,7 +16,7 @@ use crate::barchart::Bar;
 /// use ratatui::widgets::{Bar, BarGroup};
 ///
 /// BarGroup::default()
-///     .label("Group 1".into())
+///     .label("Group 1")
 ///     .bars(&[Bar::default().value(200), Bar::default().value(150)]);
 /// ```
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
@@ -29,9 +29,30 @@ pub struct BarGroup<'a> {
 
 impl<'a> BarGroup<'a> {
     /// Set the group label
+    ///
+    /// `label` can be a [`&str`], [`String`] or anything that can be converted into [`Line`].
+    ///
+    /// # Examples
+    ///
+    /// From [`&str`] and [`String`].
+    ///
+    /// ```rust
+    /// use ratatui::widgets::BarGroup;
+    ///
+    /// BarGroup::default().label("label");
+    /// BarGroup::default().label(String::from("label"));
+    /// ```
+    ///
+    /// From a [`Line`] with red foreground color:
+    ///
+    /// ```rust
+    /// use ratatui::{style::Stylize, text::Line, widgets::BarGroup};
+    ///
+    /// BarGroup::default().label(Line::from("Line").red());
+    /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn label(mut self, label: Line<'a>) -> Self {
-        self.label = Some(label);
+    pub fn label<T: Into<Line<'a>>>(mut self, label: T) -> Self {
+        self.label = Some(label.into());
         self
     }
 
@@ -77,7 +98,7 @@ impl<'a> From<&[(&'a str, u64)]> for BarGroup<'a> {
             label: None,
             bars: value
                 .iter()
-                .map(|&(text, v)| Bar::default().value(v).label(text.into()))
+                .map(|&(text, v)| Bar::default().value(v).label(text))
                 .collect(),
         }
     }

--- a/ratatui/benches/main/barchart.rs
+++ b/ratatui/benches/main/barchart.rs
@@ -15,7 +15,7 @@ fn barchart(c: &mut Criterion) {
         let data: Vec<Bar> = (0..data_count)
             .map(|i| {
                 Bar::default()
-                    .label(format!("B{i}").into())
+                    .label(format!("B{i}"))
                     .value(rng.gen_range(0..data_count))
             })
             .collect();

--- a/ratatui/examples/barchart-grouped.rs
+++ b/ratatui/examples/barchart-grouped.rs
@@ -189,7 +189,7 @@ impl Company {
     fn vertical_revenue_bar(&self, revenue: u32) -> Bar {
         let text_value = format!("{:.1}M", f64::from(revenue) / 1000.);
         Bar::default()
-            .label(self.short_name.into())
+            .label(self.short_name)
             .value(u64::from(revenue))
             .text_value(text_value)
             .style(self.color)

--- a/ratatui/examples/demo2/tabs/weather.rs
+++ b/ratatui/examples/demo2/tabs/weather.rs
@@ -101,7 +101,7 @@ fn render_simple_barchart(area: Rect, buf: &mut Buffer) {
                 } else {
                     Style::new().fg(Color::DarkGray).bg(Color::Yellow).bold()
                 })
-                .label(label.into())
+                .label(label)
         })
         .collect_vec();
     let group = BarGroup::default().bars(&data);
@@ -115,15 +115,15 @@ fn render_simple_barchart(area: Rect, buf: &mut Buffer) {
 fn render_horizontal_barchart(area: Rect, buf: &mut Buffer) {
     let bg = Color::Rgb(32, 48, 96);
     let data = [
-        Bar::default().text_value("Winter 37-51".into()).value(51),
-        Bar::default().text_value("Spring 40-65".into()).value(65),
-        Bar::default().text_value("Summer 54-77".into()).value(77),
+        Bar::default().text_value("Winter 37-51").value(51),
+        Bar::default().text_value("Spring 40-65").value(65),
+        Bar::default().text_value("Summer 54-77").value(77),
         Bar::default()
-            .text_value("Fall 41-71".into())
+            .text_value("Fall 41-71")
             .value(71)
             .value_style(Style::new().bold()), // current season
     ];
-    let group = BarGroup::default().label("GPU".into()).bars(&data);
+    let group = BarGroup::default().label("GPU").bars(&data);
     BarChart::default()
         .block(Block::new().padding(Padding::new(0, 0, 2, 0)))
         .direction(Direction::Horizontal)

--- a/ratatui/tests/widgets_barchart.rs
+++ b/ratatui/tests/widgets_barchart.rs
@@ -46,16 +46,16 @@ fn widgets_barchart_group() {
             let barchart = BarChart::default()
                 .block(Block::bordered())
                 .data(
-                    BarGroup::default().label("Mar".into()).bars(&[
+                    BarGroup::default().label("Mar").bars(&[
                         Bar::default()
                             .value(10)
-                            .label("C1".into())
+                            .label("C1")
                             .style(Style::default().fg(Color::Red))
                             .value_style(Style::default().fg(Color::Blue)),
                         Bar::default()
                             .value(20)
                             .style(Style::default().fg(Color::Green))
-                            .text_value("20M".to_string()),
+                            .text_value("20M"),
                     ]),
                 )
                 .data(&vec![("C1", 50), ("C2", 40)])


### PR DESCRIPTION
BREAKING CHANGE: label and text_value now accept `Into<>` types, which
breaks type inference.

```diff
- Bar::default().label("foo".into());
+ Bar::default().label("foo");
```

```diff
- Bar::default().text_value("bar".into());
+ Bar::default().text_value("bar");
```