### PR TITLE
chore(ci): install pre-built binaries for cargo-rdme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-      - run: cargo install cargo-rdme
+      - uses: taiki-e/install-action@cargo-rdme
       - run: cargo xtask check-readme
 
   # Run cargo rustdoc with the same options that would be used by docs.rs, taking into account the


### PR DESCRIPTION
`install-action` uses `cargo-binstall` to install the pre-built binaries of `cargo-rdme` (which was released in https://github.com/orium/cargo-rdme/releases/tag/v1.4.7).

This will make the `check-readme` step faster in CI (now takes only 10 seconds).