### PR TITLE
docs(readme): correct examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ fn draw(frame: &mut Frame) {
 [Layout]: https://ratatui.rs/how-to/layout/
 [Styling Text]: https://ratatui.rs/how-to/render/style-text/
 [templates]: https://github.com/ratatui/templates/
-[Examples]: https://github.com/ratatui/ratatui/tree/main/examples/README.md
+[Examples]: https://github.com/ratatui/ratatui/tree/main/ratatui/examples/README.md
 [Report a bug]: https://github.com/ratatui/ratatui/issues/new?labels=bug&projects=&template=bug_report.md
 [Request a Feature]: https://github.com/ratatui/ratatui/issues/new?labels=enhancement&projects=&template=feature_request.md
 [Create a Pull Request]: https://github.com/ratatui/ratatui/compare

--- a/ratatui/src/backend.rs
+++ b/ratatui/src/backend.rs
@@ -96,7 +96,7 @@
 //! [Crossterm]: https://crates.io/crates/crossterm
 //! [Termion]: https://crates.io/crates/termion
 //! [Termwiz]: https://crates.io/crates/termwiz
-//! [Examples]: https://github.com/ratatui/ratatui/tree/main/examples/README.md
+//! [Examples]: https://github.com/ratatui/ratatui/tree/main/ratatui/examples/README.md
 //! [Backend Comparison]:
 //!     https://ratatui.rs/concepts/backends/comparison/
 //! [Ratatui Website]: https://ratatui.rs

--- a/ratatui/src/backend/crossterm.rs
+++ b/ratatui/src/backend/crossterm.rs
@@ -77,7 +77,7 @@ use crate::{
 /// [`Terminal`]: crate::terminal::Terminal
 /// [`backend`]: crate::backend
 /// [Crossterm]: https://crates.io/crates/crossterm
-/// [Examples]: https://github.com/ratatui/ratatui/tree/main/examples/README.md
+/// [Examples]: https://github.com/ratatui/ratatui/tree/main/ratatui/examples/README.md
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct CrosstermBackend<W: Write> {
     /// The writer used to send commands to the terminal.

--- a/ratatui/src/backend/termwiz.rs
+++ b/ratatui/src/backend/termwiz.rs
@@ -57,7 +57,7 @@ use crate::{
 /// [`Terminal`]: crate::terminal::Terminal
 /// [`BufferedTerminal`]: termwiz::terminal::buffered::BufferedTerminal
 /// [Termwiz]: https://crates.io/crates/termwiz
-/// [Examples]: https://github.com/ratatui/ratatui/tree/main/examples/README.md
+/// [Examples]: https://github.com/ratatui/ratatui/tree/main/ratatui/examples/README.md
 pub struct TermwizBackend {
     buffered_terminal: BufferedTerminal<SystemTerminal>,
 }

--- a/ratatui/src/lib.rs
+++ b/ratatui/src/lib.rs
@@ -279,7 +279,7 @@
 //! [Layout]: https://ratatui.rs/how-to/layout/
 //! [Styling Text]: https://ratatui.rs/how-to/render/style-text/
 //! [templates]: https://github.com/ratatui/templates/
-//! [Examples]: https://github.com/ratatui/ratatui/tree/main/examples/README.md
+//! [Examples]: https://github.com/ratatui/ratatui/tree/main/ratatui/examples/README.md
 //! [Report a bug]: https://github.com/ratatui/ratatui/issues/new?labels=bug&projects=&template=bug_report.md
 //! [Request a Feature]: https://github.com/ratatui/ratatui/issues/new?labels=enhancement&projects=&template=feature_request.md
 //! [Create a Pull Request]: https://github.com/ratatui/ratatui/compare


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

Hello, this PR just corrects the examples hyperlink.
The PR #1459 introduced the workspace directory, but it missed this link.

* Before: https://github.com/ratatui/ratatui/tree/main/examples/README.md
* After: https://github.com/ratatui/ratatui/tree/main/ratatui/examples/README.md

