### PR TITLE
fix: Make StatefulWidgetRef work with dyn States.

### DIFF
--- a/ratatui/src/widgets/stateful_widget_ref.rs
+++ b/ratatui/src/widgets/stateful_widget_ref.rs
@@ -119,4 +119,22 @@ mod tests {
         widget.render_ref(buf.area, &mut buf, &mut state);
         assert_eq!(buf, Buffer::with_lines(["Hello world         "]));
     }
+
+    #[rstest]
+    fn render_unsized_state_type(mut buf: Buffer) {
+        struct Bytes;
+
+        impl StatefulWidgetRef for Bytes {
+            /// state type is unsized
+            type State = [u8];
+            fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+                let slice = std::str::from_utf8(state).unwrap();
+                Line::from(format!("Bytes: {slice}")).render(area, buf);
+            }
+        }
+        let widget = Bytes;
+        let state = b"hello";
+        widget.render_ref(buf.area, &mut buf, &mut state.clone());
+        assert_eq!(buf, Buffer::with_lines(["Bytes: hello        "]));
+    }
 }

--- a/ratatui/src/widgets/stateful_widget_ref.rs
+++ b/ratatui/src/widgets/stateful_widget_ref.rs
@@ -61,7 +61,7 @@ pub trait StatefulWidgetRef {
     /// If you don't need this then you probably want to implement [`WidgetRef`] instead.
     ///
     /// [`WidgetRef`]: super::WidgetRef
-    type State;
+    type State: ?Sized;
     /// Draws the current state of the widget in the given buffer. That is the only method required
     /// to implement a custom stateful widget.
     fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State);

--- a/ratatui/tests/stateful_widget_ref_dyn.rs
+++ b/ratatui/tests/stateful_widget_ref_dyn.rs
@@ -1,15 +1,18 @@
 #![cfg(feature = "unstable-widget-ref")]
 
+use std::{
+    any::{type_name, Any},
+    cell::RefCell,
+};
+
+use pretty_assertions::assert_eq;
 use ratatui::widgets::StatefulWidgetRef;
-use ratatui_core::buffer::Buffer;
-use ratatui_core::layout::Rect;
-use ratatui_core::text::Line;
-use ratatui_core::widgets::Widget;
-use std::any::{type_name_of_val, Any};
-use std::cell::RefCell;
+use ratatui_core::{buffer::Buffer, layout::Rect, text::Line, widgets::Widget};
 
 trait AnyWindow: StatefulWidgetRef<State = dyn Any> {
-    fn type_name(&self) -> &str;
+    fn title(&self) -> &str {
+        type_name::<Self>()
+    }
 }
 
 struct Window1;
@@ -18,18 +21,14 @@ struct Window1State {
     pub value: u32,
 }
 
-impl AnyWindow for Window1 {
-    fn type_name(&self) -> &str {
-        type_name_of_val(&self)
-    }
-}
+impl AnyWindow for Window1 {}
 
 impl StatefulWidgetRef for Window1 {
     type State = dyn Any;
 
     fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let state = state.downcast_mut::<Window1State>().expect("window1 state");
-        Line::from(format!("u32: {}", state.value)).render(area, buf);
+        Line::from(format!("{}, u32: {}", self.title(), state.value)).render(area, buf);
     }
 }
 
@@ -39,60 +38,54 @@ struct Window2State {
     pub value: String,
 }
 
-impl AnyWindow for Window2 {
-    fn type_name(&self) -> &str {
-        type_name_of_val(&self)
-    }
-}
+impl AnyWindow for Window2 {}
 
 impl StatefulWidgetRef for Window2 {
     type State = dyn Any;
 
     fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let state = state.downcast_mut::<Window2State>().expect("window2 state");
-        Line::from(format!("String: {}", state.value)).render(area, buf);
+        Line::from(format!("{}, String: {}", self.title(), state.value)).render(area, buf);
     }
 }
 
+type BoxedWindow = Box<dyn AnyWindow>;
+type BoxedState = Box<RefCell<dyn Any>>;
+
 #[test]
 fn render_dyn_widgets() {
-    let mut windows: Vec<(Box<dyn AnyWindow>, Box<RefCell<dyn Any>>)> = Vec::new();
+    let windows: Vec<(BoxedWindow, BoxedState)> = vec![
+        (
+            Box::new(Window1),
+            Box::new(RefCell::new(Window1State { value: 32 })),
+        ),
+        (
+            Box::new(Window2),
+            Box::new(RefCell::new(Window2State {
+                value: "Some".to_string(),
+            })),
+        ),
+        (
+            Box::new(Window1),
+            Box::new(RefCell::new(Window1State { value: 42 })),
+        ),
+    ];
 
-    windows.push((
-        Box::new(Window1),
-        Box::new(RefCell::new(Window1State { value: 32 })),
-    ));
-    windows.push((
-        Box::new(Window2),
-        Box::new(RefCell::new(Window2State {
-            value: "Some".to_string(),
-        })),
-    ));
-    windows.push((
-        Box::new(Window1),
-        Box::new(RefCell::new(Window1State { value: 42 })),
-    ));
+    let mut buf = Buffer::empty(Rect::new(0, 0, 50, 3));
 
-    let mut buf = Buffer::empty(Rect::new(0, 0, 20, 5));
-
-    let mut area = Rect::new(0, 0, 20, 1);
-    for (w, s) in windows.iter() {
-        eprintln!("render {}", w.type_name());
+    let mut area = Rect::new(0, 0, 50, 1);
+    for (w, s) in &windows {
         let mut s = s.borrow_mut();
         w.render_ref(area, &mut buf, &mut *s);
         area.y += 1;
     }
 
-    let buf_string = buf
-        .content
-        .iter()
-        .map(|v| v.symbol())
-        .fold(String::new(), |mut v, w| {
-            v.push_str(w);
-            v
-        });
     assert_eq!(
-        buf_string,
-        "u32: 32             String: Some        u32: 42                                                     "
+        buf,
+        Buffer::with_lines([
+            "stateful_widget_ref_dyn::Window1, u32: 32         ",
+            "stateful_widget_ref_dyn::Window2, String: Some    ",
+            "stateful_widget_ref_dyn::Window1, u32: 42         ",
+        ])
     );
 }

--- a/ratatui/tests/stateful_widget_ref_dyn.rs
+++ b/ratatui/tests/stateful_widget_ref_dyn.rs
@@ -1,0 +1,98 @@
+#![cfg(feature = "unstable-widget-ref")]
+
+use ratatui::widgets::StatefulWidgetRef;
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use ratatui_core::text::Line;
+use ratatui_core::widgets::Widget;
+use std::any::{type_name_of_val, Any};
+use std::cell::RefCell;
+
+trait AnyWindow: StatefulWidgetRef<State = dyn Any> {
+    fn type_name(&self) -> &str;
+}
+
+struct Window1;
+
+struct Window1State {
+    pub value: u32,
+}
+
+impl AnyWindow for Window1 {
+    fn type_name(&self) -> &str {
+        type_name_of_val(&self)
+    }
+}
+
+impl StatefulWidgetRef for Window1 {
+    type State = dyn Any;
+
+    fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let state = state.downcast_mut::<Window1State>().expect("window1 state");
+        Line::from(format!("u32: {}", state.value)).render(area, buf);
+    }
+}
+
+struct Window2;
+
+struct Window2State {
+    pub value: String,
+}
+
+impl AnyWindow for Window2 {
+    fn type_name(&self) -> &str {
+        type_name_of_val(&self)
+    }
+}
+
+impl StatefulWidgetRef for Window2 {
+    type State = dyn Any;
+
+    fn render_ref(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let state = state.downcast_mut::<Window2State>().expect("window2 state");
+        Line::from(format!("String: {}", state.value)).render(area, buf);
+    }
+}
+
+#[test]
+fn render_dyn_widgets() {
+    let mut windows: Vec<(Box<dyn AnyWindow>, Box<RefCell<dyn Any>>)> = Vec::new();
+
+    windows.push((
+        Box::new(Window1),
+        Box::new(RefCell::new(Window1State { value: 32 })),
+    ));
+    windows.push((
+        Box::new(Window2),
+        Box::new(RefCell::new(Window2State {
+            value: "Some".to_string(),
+        })),
+    ));
+    windows.push((
+        Box::new(Window1),
+        Box::new(RefCell::new(Window1State { value: 42 })),
+    ));
+
+    let mut buf = Buffer::empty(Rect::new(0, 0, 20, 5));
+
+    let mut area = Rect::new(0, 0, 20, 1);
+    for (w, s) in windows.iter() {
+        eprintln!("render {}", w.type_name());
+        let mut s = s.borrow_mut();
+        w.render_ref(area, &mut buf, &mut *s);
+        area.y += 1;
+    }
+
+    let buf_string = buf
+        .content
+        .iter()
+        .map(|v| v.symbol())
+        .fold(String::new(), |mut v, w| {
+            v.push_str(w);
+            v
+        });
+    assert_eq!(
+        buf_string,
+        "u32: 32             String: Some        u32: 42                                                     "
+    );
+}


### PR DESCRIPTION
When I want to use Box<dyn StatefulWidgetRef> I have to give a type for state. 

To be able to store different widgets this would need to be something like `dyn Any` too, which is not possible now, but is possible with this fix.