### PR TITLE
chore(widgets): enable calendar widget as default

### DIFF
--- a/ratatui-widgets/Cargo.toml
+++ b/ratatui-widgets/Cargo.toml
@@ -20,7 +20,7 @@ cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
+default = ["all-widgets"]
 
 ## enables serialization and deserialization of style and color types using the [`serde`] crate.
 ## This is useful if you want to save themes to a file.

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -58,7 +58,7 @@ all-widgets = ["widget-calendar"]
 #! Widgets that add dependencies are gated behind feature flags to prevent unused transitive
 #! dependencies. The available features are:
 ## enables the [`calendar`](widgets::calendar) widget module and adds a dependency on [`time`].
-widget-calendar = ["ratatui-widgets/calendar"]
+widget-calendar = ["ratatui-widgets/calendar", "dep:time"]
 
 #! The following optional features are only available for some backends:
 

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -26,7 +26,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 ## By default, we enable the crossterm backend as this is a reasonable choice for most applications
 ## as it is supported on Linux/Mac/Windows systems. We also enable the `underline-color` feature
 ## which allows you to set the underline color of text.
-default = ["crossterm", "underline-color"]
+default = ["crossterm", "underline-color", "all-widgets"]
 #! Generally an application will only use one backend, so you should only enable one of the following features:
 ## enables the [`CrosstermBackend`](backend::CrosstermBackend) backend and adds a dependency on [`crossterm`].
 crossterm = ["dep:ratatui-crossterm"]


### PR DESCRIPTION
We now expect that you disable the default features if you want less dependencies