### PR TITLE
fix(scrollbar): check for area.is_empty() before rendering 

### DIFF
--- a/ratatui-widgets/src/scrollbar.rs
+++ b/ratatui-widgets/src/scrollbar.rs
@@ -500,19 +500,17 @@ impl StatefulWidget for Scrollbar<'_> {
     type State = ScrollbarState;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
-        if state.content_length == 0
-            || area.is_empty()
-            || self.track_length_excluding_arrow_heads(area) == 0
-        {
+        if state.content_length == 0 || self.track_length_excluding_arrow_heads(area) == 0 {
             return;
         }
 
-        let mut bar = self.bar_symbols(area, state);
-        let area = self.scrollbar_area(area);
-        for x in area.left()..area.right() {
-            for y in area.top()..area.bottom() {
-                if let Some(Some((symbol, style))) = bar.next() {
-                    buf.set_string(x, y, symbol, style);
+        if let Some(area) = self.scrollbar_area(area) {
+            let mut bar = self.bar_symbols(area, state);
+            for x in area.left()..area.right() {
+                for y in area.top()..area.bottom() {
+                    if let Some(Some((symbol, style))) = bar.next() {
+                        buf.set_string(x, y, symbol, style);
+                    }
                 }
             }
         }
@@ -584,14 +582,13 @@ impl Scrollbar<'_> {
         (thumb_start, thumb_length, track_end_length)
     }
 
-    fn scrollbar_area(&self, area: Rect) -> Rect {
+    fn scrollbar_area(&self, area: Rect) -> Option<Rect> {
         match self.orientation {
             ScrollbarOrientation::VerticalLeft => area.columns().next(),
             ScrollbarOrientation::VerticalRight => area.columns().last(),
             ScrollbarOrientation::HorizontalTop => area.rows().next(),
             ScrollbarOrientation::HorizontalBottom => area.rows().last(),
         }
-        .expect("Scrollbar area is empty") // this should never happen as we check for empty area
     }
 
     /// Calculates length of the track excluding the arrow heads

--- a/ratatui-widgets/src/scrollbar.rs
+++ b/ratatui-widgets/src/scrollbar.rs
@@ -505,12 +505,11 @@ impl StatefulWidget for Scrollbar<'_> {
         }
 
         if let Some(area) = self.scrollbar_area(area) {
-            let mut bar = self.bar_symbols(area, state);
-            for x in area.left()..area.right() {
-                for y in area.top()..area.bottom() {
-                    if let Some(Some((symbol, style))) = bar.next() {
-                        buf.set_string(x, y, symbol, style);
-                    }
+            let areas = area.columns().flat_map(Rect::rows);
+            let bar_symbols = self.bar_symbols(area, state);
+            for (area, bar) in areas.zip(bar_symbols) {
+                if let Some((symbol, style)) = bar {
+                    buf.set_string(area.x, area.y, symbol, style);
                 }
             }
         }

--- a/ratatui-widgets/src/scrollbar.rs
+++ b/ratatui-widgets/src/scrollbar.rs
@@ -500,12 +500,15 @@ impl StatefulWidget for Scrollbar<'_> {
     type State = ScrollbarState;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
-        if state.content_length == 0 || self.track_length_excluding_arrow_heads(area) == 0 {
+        if state.content_length == 0
+            || area.is_empty()
+            || self.track_length_excluding_arrow_heads(area) == 0
+        {
             return;
         }
 
         let mut bar = self.bar_symbols(area, state);
-        let area = self.scollbar_area(area);
+        let area = self.scrollbar_area(area);
         for x in area.left()..area.right() {
             for y in area.top()..area.bottom() {
                 if let Some(Some((symbol, style))) = bar.next() {
@@ -581,7 +584,7 @@ impl Scrollbar<'_> {
         (thumb_start, thumb_length, track_end_length)
     }
 
-    fn scollbar_area(&self, area: Rect) -> Rect {
+    fn scrollbar_area(&self, area: Rect) -> Rect {
         match self.orientation {
             ScrollbarOrientation::VerticalLeft => area.columns().next(),
             ScrollbarOrientation::VerticalRight => area.columns().last(),
@@ -1064,5 +1067,21 @@ mod tests {
             .viewport_content_length(2);
         scrollbar_no_arrows.render(buffer.area, &mut buffer, &mut state);
         assert_eq!(buffer, Buffer::with_lines([expected]));
+    }
+
+    #[rstest]
+    #[case::scrollbar_height_0(10, 0)]
+    #[case::scrollbar_width_0(0, 10)]
+    fn do_not_render_with_empty_area(#[case] width: u16, #[case] height: u16) {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(Some("<"))
+            .end_symbol(Some(">"))
+            .track_symbol(Some("-"))
+            .thumb_symbol("#");
+        let zero_width_area = Rect::new(0, 0, width, height);
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 10));
+
+        let mut state = ScrollbarState::new(10);
+        scrollbar.render(zero_width_area, &mut buffer, &mut state);
     }
 }


### PR DESCRIPTION
This adds the `area.is_empty()` back into the scrollbar render method. Without it, the widget panics if the height is 0.
To reproduce this error, you can open the scrollbar demo2 in `/examples` (on the main branch) and continuously reduce the vertical height of your terminal window until it panics.

I also added a test, but I wasn't sure how to write the test correctly, currently there is no assert statement and the test suite will simply panic if the call to `is_empty()` is removed. 
You can also see that in the test, the buffer has a non-zero area. If the buffer area is 0, I don't think this error occurs. 

I was thinking, might make more sense if `scrollbar_area` returned a result instead of exiting with expect? 

Happy to make any changes.

