### PR TITLE
chore(xtask): check lints for only library targets

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,7 +6,7 @@
 
 use std::{fmt::Debug, io, process::Output, vec};
 
-use cargo_metadata::MetadataCommand;
+use cargo_metadata::{MetadataCommand, TargetKind};
 use clap::{Parser, Subcommand, ValueEnum};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
 use color_eyre::{eyre::Context, Result};
@@ -183,14 +183,14 @@ fn check() -> Result<()> {
 
 /// Run cargo-rdme to check if README.md is up-to-date with the library documentation
 fn check_readme() -> Result<()> {
-    for package in get_workspace_packages()? {
+    for package in get_workspace_packages(Some(TargetKind::Lib))? {
         run_cargo(vec!["rdme", "--workspace-project", &package, "--check"])?;
     }
     Ok(())
 }
 
 fn fix_readme() -> Result<()> {
-    for package in get_workspace_packages()? {
+    for package in get_workspace_packages(Some(TargetKind::Lib))? {
         run_cargo(vec!["rdme", "--workspace-project", &package])?;
     }
     Ok(())
@@ -250,21 +250,30 @@ fn fix_clippy() -> Result<()> {
 
 /// Check that docs build without errors using flags for docs.rs
 fn lint_docs() -> Result<()> {
-    for package in get_workspace_packages()? {
+    for package in get_workspace_packages(Some(TargetKind::Lib))? {
         run_cargo_nightly(vec!["docs-rs", "--package", &package])?;
     }
     Ok(())
 }
 
-fn get_workspace_packages() -> Result<Vec<String>> {
+/// Return the available packages in the workspace
+fn get_workspace_packages(target_filter: Option<TargetKind>) -> Result<Vec<String>> {
     let meta = MetadataCommand::new()
         .exec()
         .wrap_err("failed to get cargo metadata")?;
-    Ok(meta
-        .workspace_default_packages()
+    let packages = meta
+        .workspace_packages()
         .iter()
+        .filter(|v| {
+            if let Some(ref filter) = target_filter {
+                v.targets.iter().any(|t| t.kind.contains(filter))
+            } else {
+                true
+            }
+        })
         .map(|v| v.name.clone())
-        .collect())
+        .collect();
+    Ok(packages)
 }
 
 /// Lint formatting issues in the project


### PR DESCRIPTION
Fixes the CI.
Also makes it possible to filter workspace packages by their targets which might be useful in the future (e.g. when we want to retrieve all the binary targets / examples, etc.)