### PR TITLE
"Bell" function abstracts ^G

### DIFF
--- a/ratatui-core/src/backend.rs
+++ b/ratatui-core/src/backend.rs
@@ -370,6 +370,18 @@ pub trait Backend {
         region: std::ops::Range<u16>,
         line_count: u16,
     ) -> io::Result<()>;
+
+    /// Alert the user in the manner of the VT100 "Bell" function.
+    ///
+    /// The exact effect is implementation-defined, and returning Ok(())
+    /// does not guarantee anything happened.
+    /// This default implementation is "good enough" on all known terminals.
+    /// If a backend categorically does not support this, it should override
+    /// and return Err(Errorkind::Unsupported).
+    fn bell(&mut self) -> io::Result<()> {
+        print!("\x07"); // ASCII BEL to STDOUT
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/ratatui/examples/scrollbar.rs
+++ b/ratatui/examples/scrollbar.rs
@@ -78,6 +78,10 @@ impl App {
                                 .horizontal_scroll_state
                                 .position(self.horizontal_scroll);
                         }
+                        // If an unrecognized letter is entered, beep to alert.
+                        KeyCode::Char(_) => {
+                            let _ = terminal.bell();
+                        }
                         _ => {}
                     }
                 }

--- a/ratatui/src/terminal/terminal.rs
+++ b/ratatui/src/terminal/terminal.rs
@@ -820,6 +820,13 @@ where
         }
         Ok(())
     }
+
+    /// Alert the user in the manner of the VT100 "Bell" function.
+    /// Depending on the backend, the terminal app, and the user's settings,
+    /// this may play a beep, flash the screen, or do nothing at all.
+    pub fn bell(&mut self) -> io::Result<()> {
+        self.backend.bell()
+    }
 }
 
 fn compute_inline_size<B: Backend>(


### PR DESCRIPTION
Resolves #1522 . As discussed.

Adds a `bell()` to Terminal. Currently on all backends just prints a single `^G` (ASCII BEL) to stdout, but hypothetically on some future backend could do something different.

Things I'm not sure about:

- Right now, per types, it is possible for the bell to fail. I'm not sure this makes sense because it is documented that the bell function may do nothing at all while still returning success. I was thinking maybe if some future backend has the ability to fail and know it's failing it could return an error, but it's actually really irritating to have to `let _ =` the bell function to silence the error. I think maybe I should change the return type to plain `()`.
- Right now, per types, the bell function is &mut, even though the default implementation does not need &mut. This is because I don't know how to predict whether a future backend implementin gbell. might need &mut.
- I suborned the scrollbar example to test the bell function (whenever you press a key that doesn't do anything). However I don't know how to test whether the change works on all backends (I feel certain it must, but this should probably be tested anyway).