### PR TITLE
feat(widgets): add the missing constructor to canvas types

### DIFF
--- a/ratatui-widgets/src/canvas/circle.rs
+++ b/ratatui-widgets/src/canvas/circle.rs
@@ -15,6 +15,18 @@ pub struct Circle {
     pub color: Color,
 }
 
+impl Circle {
+    /// Create a new circle with the given center, radius, and color
+    pub const fn new(x: f64, y: f64, radius: f64, color: Color) -> Self {
+        Self {
+            x,
+            y,
+            radius,
+            color,
+        }
+    }
+}
+
 impl Shape for Circle {
     fn draw(&self, painter: &mut Painter<'_, '_>) {
         for angle in 0..360 {

--- a/ratatui-widgets/src/canvas/points.rs
+++ b/ratatui-widgets/src/canvas/points.rs
@@ -11,6 +11,13 @@ pub struct Points<'a> {
     pub color: Color,
 }
 
+impl<'a> Points<'a> {
+    /// Create a new Points shape with the given coordinates and color
+    pub const fn new(coords: &'a [(f64, f64)], color: Color) -> Self {
+        Self { coords, color }
+    }
+}
+
 impl Shape for Points<'_> {
     fn draw(&self, painter: &mut Painter) {
         for (x, y) in self.coords {

--- a/ratatui-widgets/src/canvas/rectangle.rs
+++ b/ratatui-widgets/src/canvas/rectangle.rs
@@ -24,6 +24,19 @@ pub struct Rectangle {
     pub color: Color,
 }
 
+impl Rectangle {
+    /// Create a new rectangle with the given position, size, and color
+    pub const fn new(x: f64, y: f64, width: f64, height: f64, color: Color) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+            color,
+        }
+    }
+}
+
 impl Shape for Rectangle {
     fn draw(&self, painter: &mut Painter) {
         let lines: [Line; 4] = [


### PR DESCRIPTION
Allows constructing `Rectangle`, `Points` and `Circle` using the `new` method instead of initializing with the public fields directly.
