### PR TITLE
chore(release): initialize release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,52 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Release unpublished packages.
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -24,7 +24,7 @@ body = """
 {%- if not version %}
 ## [unreleased]
 {% else -%}
-## [{{ version }}](https://github.com/ratatui/ratatui/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+## {{ package }} - [{{ version }}]({{ release_link }}) - {{ timestamp | date(format="%Y-%m-%d") }}
 {% endif -%}
 
 {% macro commit(commit) -%}
@@ -47,26 +47,16 @@ body = """
 {%- endfor -%}
 {%- endfor %}
 
-{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
-### New Contributors
-{%- endif %}\
-{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
-* @{{ contributor.username }} made their first contribution
-{%- if contributor.pr_number %} in \
-[#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
-{%- endif %}
-{%- endfor -%}
-
 {% if version %}
 {% if previous.version %}
-**Full Changelog**: {{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}
+**Full Changelog**: {{ release_link }}
 {% endif %}
 {% else -%}
   {% raw %}\n{% endraw %}
 {% endif %}
 
 {%- macro remote_url() -%}
-https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+https://github.com/{{ remote.owner }}/{{ remote.repo }}\
 {% endmacro %}
 """
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,5 @@
+[workspace]
+changelog_path = "./CHANGELOG.md"
+changelog_config = "cliff.toml"
+release_always = false
+semver_check = false


### PR DESCRIPTION
We are currently discussing this [on a livestream](https://www.youtube.com/watch?v=cxIumpVggnI).

There are still some required steps (such as [adding tokens](https://release-plz.ieni.dev/docs/github/quickstart) and updating workflow files accordingly) but this will probably give you an idea how adding release-plz looks like. You can test the changes by running `release-plz update` locally.

Related/unrelated to this PR, there are some specific stuff that I want to look into:

- [ ] Support `.env` in `release-plz` for testing (https://github.com/release-plz/release-plz/issues/1906)
- [ ] Support `remote.owner` (instead of `remote.github.owner`) in `git-cliff`
- [ ] Support `release_link` in `git-cliff`
- [ ] New contributors in `release-plz` (https://github.com/release-plz/release-plz/issues/1907)
- [ ] A subcommand for initializing `release-plz` with default values (https://github.com/release-plz/release-plz/issues/1908)
- [ ] Support `cliff.toml` in `release-plz` config (https://github.com/release-plz/release-plz/issues/1909)
- [ ] Reordering entries in CHANGELOG.md (`ratatui` should be first) (https://github.com/release-plz/release-plz/issues/1910)
  - e.g. `changelog_order=1` value in the `[[package]]` section


We need to test if the correct changelog section is set in the GitHub release when we create a release. Marco suggests that we should test it in a different repository.

**Q**: Do we want to have GitHub releases for each crate or e.g. a single release for `ratatui` and git tags for the rest? We can get some inspiration from [other projects](https://github.com/release-plz/action/network/dependents) that use `release-plz`.