### PR TITLE
feat(scrollbar): support retrieving the current position of state

### DIFF
--- a/ratatui-widgets/src/scrollbar.rs
+++ b/ratatui-widgets/src/scrollbar.rs
@@ -494,6 +494,12 @@ impl ScrollbarState {
             }
         }
     }
+
+    /// Returns the current position within the scrollable content.
+    #[must_use = "returns the current position within the scrollable content"]
+    pub const fn get_position(&self) -> usize {
+        self.position
+    }
 }
 
 impl StatefulWidget for Scrollbar<'_> {


### PR DESCRIPTION
As of now it is possible to change the position of the Scrollbar but not possible to retrieve the position for further use. e.g.

```rust
let mut state = ScrollbarState::default();
state.next();
```

This commit adds a new method "`current_position`" (since `position` is already taken by the fluent setter) for that purpose:

```rust
let index = state.get_position(); // yay
```

See #1545 for the concrete usage of this.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
