### PR TITLE
fix: rust 1.84 clippy lints

### DIFF
--- a/ratatui-widgets/src/canvas/world.rs
+++ b/ratatui-widgets/src/canvas/world.rs
@@ -1,5 +1,5 @@
 /// [Source data](http://www.gnuplotting.org/plotting-the-world-revisited)
-pub const WORLD_HIGH_RESOLUTION: [(f64, f64); 5125] = [
+pub static WORLD_HIGH_RESOLUTION: [(f64, f64); 5125] = [
     (-163.7128, -78.5956),
     (-163.1058, -78.2233),
     (-161.2451, -78.3801),
@@ -5127,7 +5127,7 @@ pub const WORLD_HIGH_RESOLUTION: [(f64, f64); 5125] = [
     (180.0, -84.71338),
 ];
 
-pub const WORLD_LOW_RESOLUTION: [(f64, f64); 1166] = [
+pub static WORLD_LOW_RESOLUTION: [(f64, f64); 1166] = [
     (-92.32, 48.24),
     (-88.13, 48.92),
     (-83.11, 46.27),

--- a/ratatui-widgets/src/list/rendering.rs
+++ b/ratatui-widgets/src/list/rendering.rs
@@ -93,7 +93,7 @@ impl StatefulWidget for &List<'_> {
             let item_style = self.style.patch(item.style);
             buf.set_style(row_area, item_style);
 
-            let is_selected = state.selected.map_or(false, |s| s == i);
+            let is_selected = state.selected == Some(i);
 
             let item_area = if selection_spacing {
                 let highlight_symbol_width = self.highlight_symbol.unwrap_or("").width() as u16;


### PR DESCRIPTION
The canvas map constants are now statics instead.
Fixes https://rust-lang.github.io/rust-clippy/master/index.html\#large_const_arrays
