### PR TITLE
ci: run cargo-deny directly rather than via action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-deny
+      - run: cargo deny --log-level info --all-features check
 
   # Check for any unused dependencies in the codebase.
   # See <https://github.com/bnjbvr/cargo-machete/>


### PR DESCRIPTION
The cargo-deny action takes about 30s to run, because it downloads and
runs a docker image, but this should be generally closer to a 5-10
seconds when run directly. This is not a huge saving, but it allows other
CI jobs to start sooner and so to see results of CI quicker.

First test showed around 17s, but Iassume this will probably hit single
digit seconds as it is similar to the typos job.
