### PR TITLE
perf(widgets): avoid unnecessary work when rendering paragraphs

### DIFF
--- a/ratatui-widgets/src/reflow.rs
+++ b/ratatui-widgets/src/reflow.rs
@@ -15,7 +15,7 @@ pub trait LineComposer<'a> {
 /// A line that has been wrapped to a certain width.
 pub struct WrappedLine<'lend, 'text> {
     /// One line reflowed to the correct width
-    pub line: &'lend [StyledGrapheme<'text>],
+    pub graphemes: &'lend [StyledGrapheme<'text>],
     /// The width of the line
     pub width: u16,
     /// Whether the line was aligned left or right
@@ -215,7 +215,7 @@ where
 
                 self.replace_current_line(line);
                 return Some(WrappedLine {
-                    line: &self.current_line,
+                    graphemes: &self.current_line,
                     width: line_width,
                     alignment: self.current_alignment,
                 });
@@ -321,7 +321,7 @@ where
             None
         } else {
             Some(WrappedLine {
-                line: &self.current_line,
+                graphemes: &self.current_line,
                 width: current_line_width,
                 alignment: current_alignment,
             })
@@ -385,12 +385,12 @@ mod tests {
         let mut widths = vec![];
         let mut alignments = vec![];
         while let Some(WrappedLine {
-            line: styled,
+            graphemes,
             width,
             alignment,
         }) = composer.next_line()
         {
-            let line = styled
+            let line = graphemes
                 .iter()
                 .map(|StyledGrapheme { symbol, .. }| *symbol)
                 .collect::<String>();

--- a/ratatui/benches/main/paragraph.rs
+++ b/ratatui/benches/main/paragraph.rs
@@ -8,7 +8,6 @@ use ratatui::{
 /// because the scroll offset is a u16, the maximum number of lines that can be scrolled is 65535.
 /// This is a limitation of the current implementation and may be fixed by changing the type of the
 /// scroll offset to a u32.
-const MAX_SCROLL_OFFSET: u16 = u16::MAX;
 const NO_WRAP_WIDTH: u16 = 200;
 const WRAP_WIDTH: u16 = 100;
 
@@ -17,9 +16,10 @@ const WRAP_WIDTH: u16 = 100;
 /// as well as comparing with the various settings on the scroll and wrap features.
 fn paragraph(c: &mut Criterion) {
     let mut group = c.benchmark_group("paragraph");
-    for line_count in [64, 2048, MAX_SCROLL_OFFSET] {
+    for line_count in [64, 2048, u16::MAX] {
         let lines = random_lines(line_count);
         let lines = lines.as_str();
+        let y_scroll = line_count - PARAGRAPH_DEFAULT_HEIGHT;
 
         // benchmark that measures the overhead of creating a paragraph separately from rendering
         group.bench_with_input(BenchmarkId::new("new", line_count), lines, |b, lines| {
@@ -36,14 +36,14 @@ fn paragraph(c: &mut Criterion) {
         // scroll the paragraph by half the number of lines and render
         group.bench_with_input(
             BenchmarkId::new("render_scroll_half", line_count),
-            &Paragraph::new(lines).scroll((0, line_count / 2)),
+            &Paragraph::new(lines).scroll((y_scroll / 2, 0)),
             |bencher, paragraph| render(bencher, paragraph, NO_WRAP_WIDTH),
         );
 
         // scroll the paragraph by the full number of lines and render
         group.bench_with_input(
             BenchmarkId::new("render_scroll_full", line_count),
-            &Paragraph::new(lines).scroll((0, line_count)),
+            &Paragraph::new(lines).scroll((y_scroll, 0)),
             |bencher, paragraph| render(bencher, paragraph, NO_WRAP_WIDTH),
         );
 
@@ -59,16 +59,18 @@ fn paragraph(c: &mut Criterion) {
             BenchmarkId::new("render_wrap_scroll_full", line_count),
             &Paragraph::new(lines)
                 .wrap(Wrap { trim: false })
-                .scroll((0, line_count)),
+                .scroll((y_scroll, 0)),
             |bencher, paragraph| render(bencher, paragraph, WRAP_WIDTH),
         );
     }
     group.finish();
 }
 
+const PARAGRAPH_DEFAULT_HEIGHT: u16 = 50;
+
 /// render the paragraph into a buffer with the given width
 fn render(bencher: &mut Bencher, paragraph: &Paragraph, width: u16) {
-    let mut buffer = Buffer::empty(Rect::new(0, 0, width, 50));
+    let mut buffer = Buffer::empty(Rect::new(0, 0, width, PARAGRAPH_DEFAULT_HEIGHT));
     // We use `iter_batched` to clone the value in the setup function.
     // See https://github.com/ratatui/ratatui/pull/377.
     bencher.iter_batched(

--- a/ratatui/benches/main/paragraph.rs
+++ b/ratatui/benches/main/paragraph.rs
@@ -10,6 +10,7 @@ use ratatui::{
 /// scroll offset to a u32.
 const NO_WRAP_WIDTH: u16 = 200;
 const WRAP_WIDTH: u16 = 100;
+const PARAGRAPH_DEFAULT_HEIGHT: u16 = 50;
 
 /// Benchmark for rendering a paragraph with a given number of lines. The design of this benchmark
 /// allows comparison of the performance of rendering a paragraph with different numbers of lines.
@@ -65,8 +66,6 @@ fn paragraph(c: &mut Criterion) {
     }
     group.finish();
 }
-
-const PARAGRAPH_DEFAULT_HEIGHT: u16 = 50;
 
 /// render the paragraph into a buffer with the given width
 fn render(bencher: &mut Bencher, paragraph: &Paragraph, width: u16) {


### PR DESCRIPTION
Hi,

Thanks for the great work on ratatui 🙏🏻 

### Context
_This PR introduces a slight change that I believe could end up significantly improving rendering times for paragraphs that do not depend on certain kinds of `LineComposer`s._

Currently all `LineComposer`s are considered to be state machines which means rendering a paragraph with a given Y offset requires computing the entire state up to Y before being able to render from Y onwards.

While this makes sense for Composers such as the `WordWrapper` (where one needs to consider all previous lines to determine where a given line will end up), it means it also penalizes Composers which can render a given line "statelessely" (such as the `LineTruncator`) which actually end up doing a lot of unnecessary work (and on the critical rendering path) when the offset gets high.

I came across this while experimenting with previews in [television](https://github.com/alexpasmantier/television) and noticed increased rendering lag as the preview offset got higher for large files.

#### Example
Below is an example of sampling the application and scrolling down a pretty large file in the preview pane while everything else remains static. Note how rendering the paragraph takes longer and longer (in proportion to the rest which I'm assuming shouldn't change much).


https://github.com/user-attachments/assets/1c6dc428-5351-4659-97c1-45fe7fb2ffb4



### Description of the PR

I tried to keep the PR as minimal as possible. The `LineComposer` trait was split into:
- `StatefulLineComposer`: e.g. `WordWrapper`
- `LineComposer`: e.g. `LineTruncator`

When rendering a paragraph, the behavior is now as follows:
- if the line composer is stateful, use the existing code to compute lines up to offset `y` and render from there on up to the area's height
- if the line composer is stateless, just skip ahead until `y` and render from there on up to the area's height


