### PR TITLE
fix(chart): fix issue with mispositioned x-axis labels

### DIFF
--- a/ratatui-widgets/examples/chart.rs
+++ b/ratatui-widgets/examples/chart.rs
@@ -80,6 +80,7 @@ pub fn render_chart(frame: &mut Frame, area: Rect) {
     let x_axis = Axis::default()
         .title("Hustle".blue())
         .bounds([0.0, 10.0])
+        .tick_marks(true)
         .labels([
             "0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%",
         ]);
@@ -87,6 +88,7 @@ pub fn render_chart(frame: &mut Frame, area: Rect) {
     let y_axis = Axis::default()
         .title("Profit".blue())
         .bounds([0.0, 10.0])
+        .tick_marks(true)
         .labels(["0", "5", "10"]);
 
     let chart = Chart::new(vec![dataset]).x_axis(x_axis).y_axis(y_axis);

--- a/ratatui-widgets/examples/chart.rs
+++ b/ratatui-widgets/examples/chart.rs
@@ -80,7 +80,9 @@ pub fn render_chart(frame: &mut Frame, area: Rect) {
     let x_axis = Axis::default()
         .title("Hustle".blue())
         .bounds([0.0, 10.0])
-        .labels(["0%", "50%", "100%"]);
+        .labels([
+            "0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%",
+        ]);
 
     let y_axis = Axis::default()
         .title("Profit".blue())

--- a/ratatui-widgets/examples/chart.rs
+++ b/ratatui-widgets/examples/chart.rs
@@ -89,8 +89,11 @@ pub fn render_chart(frame: &mut Frame, area: Rect) {
         .title("Profit".blue())
         .bounds([0.0, 10.0])
         .tick_marks(true)
-        .labels(["0", "5", "10"]);
+        .labels(["0", "2.5", "5", "7.5", "10"]);
 
-    let chart = Chart::new(vec![dataset]).x_axis(x_axis).y_axis(y_axis);
+    let chart = Chart::new(vec![dataset])
+        .x_axis(x_axis)
+        .y_axis(y_axis)
+        .show_grid(true);
     frame.render_widget(chart, area);
 }

--- a/ratatui-widgets/src/chart.rs
+++ b/ratatui-widgets/src/chart.rs
@@ -896,18 +896,19 @@ impl<'a> Chart<'a> {
         };
 
         let mut t = 0.0;
-        let fract = 1.0 / (labels_len - 1) as f64;
+        let fract = 1.0 / f64::from(labels_len - 1);
 
         Self::render_label(buf, labels.first().unwrap(), label_area, label_alignment);
 
-        for label in labels[1..labels.len() - 1].iter() {
+        for label in &labels[1..labels.len() - 1] {
             t += fract;
 
             // We use linear interpolation to find where the center of the next
             // label should be positioned under the x-axis.
             // We subtract 1 from the area's width to make sure there is at least
             // one space between labels.
-            let x = ((1.0 - t) * graph_area.left() as f64 + t * graph_area.right() as f64) as u16;
+            let x = ((1.0 - t) * f64::from(graph_area.left()) + t * f64::from(graph_area.right()))
+                as u16;
             let label_area = Rect::new(
                 x - width_between_ticks / 2,
                 y,

--- a/ratatui-widgets/src/chart.rs
+++ b/ratatui-widgets/src/chart.rs
@@ -947,9 +947,14 @@ impl<'a> Chart<'a> {
 
             ticks.push(x);
 
-            // We offset x by minus half the `width_per_tick` to find the left end of the label's
-            // bounding box.
-            let label_area = Rect::new(x - width_per_tick / 2, y, width_per_tick, 1);
+            // We offset x by minus half the minimum of the label's width and `width_per_tick` to
+            // find the left end of the label's bounding box. This way we can guarantee the label
+            // will be visually centered under the tick mark or truncated if too long.
+            let label_width = match u16::try_from(label.width()) {
+                Ok(w) => width_per_tick.min(w),
+                Err(_) => width_per_tick,
+            };
+            let label_area = Rect::new(x - label_width / 2, y, label_width, 1);
 
             Self::render_label(buf, label, label_area, Alignment::Center);
         }

--- a/ratatui-widgets/src/chart.rs
+++ b/ratatui-widgets/src/chart.rs
@@ -895,8 +895,7 @@ impl<'a> Chart<'a> {
         chart_area: Rect,
         graph_area: Rect,
     ) -> Option<Vec<u16>> {
-        // Linear interpolation returns a point situated at
-        // a percentage of a segment's endpoints.
+        // Linear interpolation returns a point situated at a percentage of a segment's endpoints.
         fn linear_interpolation(min: u16, max: u16, t: f64) -> u16 {
             ((1.0 - t) * f64::from(min) + t * f64::from(max)) as u16
         }
@@ -908,8 +907,8 @@ impl<'a> Chart<'a> {
             return None;
         }
 
-        // We subtract 1 from the width per tick to make sure there is always
-        // at least one space between labels.
+        // We subtract 1 from the width per tick to make sure there is always at least one space
+        // between labels.
         let width_per_tick = (graph_area.width / labels_len).saturating_sub(1);
 
         let mut ticks = Vec::with_capacity((labels_len - 1) as usize);
@@ -931,12 +930,10 @@ impl<'a> Chart<'a> {
         // The first label will be drawn in the space offered by y labels on the left
         Self::render_label(buf, labels.first().unwrap(), label_area, label_alignment);
 
-        // Finding positions for the labels by incrementing the
-        // `width_per_tick` each step is not a good solution because
-        // it accumulates rounding error at each iteration.
-        // A correct solution is to find the center position for the
-        // label box, i.e. where the tick mark should be, in terms
-        // of percentage of the graph area's width.
+        // Finding positions for the labels by incrementing the `width_per_tick` each step is not a
+        // good solution because it accumulates rounding error at each iteration. A correct solution
+        // is to find the center position for the label box, i.e. where the tick mark should be, in
+        // terms of percentage of the graph area's width.
         let width_percentage_increment = 1.0 / f64::from(labels_len - 1);
 
         for (i, label) in labels[1..labels.len() - 1].iter().enumerate() {
@@ -950,15 +947,15 @@ impl<'a> Chart<'a> {
 
             ticks.push(x);
 
-            // We offset x by minus half the `width_per_tick` to find the left end
-            // of the label's bounding box.
+            // We offset x by minus half the `width_per_tick` to find the left end of the label's
+            // bounding box.
             let label_area = Rect::new(x - width_per_tick / 2, y, width_per_tick, 1);
 
             Self::render_label(buf, label, label_area, Alignment::Center);
         }
 
-        // Leaving as much space as possible for the last tick, all while respecting
-        // the average tick bounding box proportions.
+        // Leaving as much space as possible for the last tick, all while respecting the average
+        // tick bounding box proportions.
         let x = ticks.last().unwrap() + width_per_tick.div_ceil(2).saturating_add(1);
         let label_area = Rect::new(x, y, graph_area.right().saturating_sub(x), 1);
         // The last label should be aligned Right to be at the edge of the graph area

--- a/ratatui/tests/widgets_chart.rs
+++ b/ratatui/tests/widgets_chart.rs
@@ -183,7 +183,7 @@ fn widgets_chart_handles_long_labels<'line, Lines>(
         "          ",
         "          ",
         "   ───────",
-        "AAA   B  C",
+        "AAA  B   C",
     ],
 )]
 #[case::center(


### PR DESCRIPTION
As promised in issue #334, here is a fix for the x-axis labels of the chart widget. I have also edited a related example to demonstrate the fix but I can drop this change if required.

The code is now using linear interpolation to position the center of the label rects under the x-axis.