### PR TITLE
fix: avoid extra line break on whitespace only lines when wrapping paragraphs

### DIFF
--- a/ratatui-widgets/src/paragraph.rs
+++ b/ratatui-widgets/src/paragraph.rs
@@ -779,6 +779,34 @@ mod tests {
     }
 
     #[test]
+    fn test_render_wrapped_paragraph_with_whitespace_only_line() {
+        let text: Text = ["A", "  ", "B", "  a", "C"].into_iter().map(Line::from).collect();
+        let paragraph = Paragraph::new(text.clone()).wrap(Wrap { trim: false });
+        let trimmed_paragraph = Paragraph::new(text).wrap(Wrap { trim: true });
+
+        test_case(
+            &paragraph,
+            &Buffer::with_lines([
+                "A",
+                "  ",
+                "B",
+                "  a",
+                "C",
+            ]),
+        );
+        test_case(
+            &trimmed_paragraph,
+            &Buffer::with_lines([
+                "A",
+                "",
+                "B",
+                "a",
+                "C",
+            ]),
+        );
+    }
+
+    #[test]
     fn test_render_paragraph_with_line_truncation() {
         let text = "This is a long line of text that should be truncated.";
         let truncated_paragraph = Paragraph::new(text);

--- a/ratatui-widgets/src/reflow.rs
+++ b/ratatui-widgets/src/reflow.rs
@@ -167,6 +167,7 @@ where
         if pending_line.is_empty()
             && self.pending_word.is_empty()
             && !self.pending_whitespace.is_empty()
+            && self.trim
         {
             self.wrapped_lines.push_back(vec![]);
         }


### PR DESCRIPTION
Currently whitespace only lines produces an extra line break when trimming is disabled, because both the trimmed as well as the non-trimmed line get inserted. Fix this by only inserting the non-trimmed one.
