### PR TITLE
chore: sort dependencies in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,10 @@ rstest = "0.24.0"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 strum = { version = "0.26.3", features = ["derive"] }
+termion = "4.0.0"
 termwiz = { version = "0.22.0" }
 unicode-segmentation = "1.12.0"
 # See <https://github.com/ratatui/ratatui/issues/1271> for information about why we pin unicode-width
-termion = "4.0.0"
 unicode-width = "=0.2.0"
 
 # Improve benchmark consistency


### PR DESCRIPTION
Move `termion` up in the dependencies list in `Cargo.toml` so that they are sorted alphabetically and so that the `unicode-width` comment is directly above the `unicode-width` dependency.