### PR TITLE
docs(examples): move widget-impl example to examples folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "advanced-widget-impl"
+version = "0.0.0"
+dependencies = [
+ "color-eyre",
+ "crossterm",
+ "ratatui",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/apps/advanced-widget-impl/Cargo.toml
+++ b/examples/apps/advanced-widget-impl/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "advanced-widget-impl"
+publish = false
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+color-eyre.workspace = true
+crossterm.workspace = true
+ratatui = { workspace = true, features = ["unstable-widget-ref"] }
+
+[lints]
+workspace = true

--- a/examples/apps/advanced-widget-impl/README.md
+++ b/examples/apps/advanced-widget-impl/README.md
@@ -1,0 +1,9 @@
+# Advanced Widget Implementation demo
+
+This example shows how to render the `Widget` trait in different ways.
+
+To run this demo:
+
+```shell
+cargo run -p advanced-widget-impl
+```

--- a/examples/apps/advanced-widget-impl/src/main.rs
+++ b/examples/apps/advanced-widget-impl/src/main.rs
@@ -1,21 +1,14 @@
-//! # [Ratatui] Widgets implementation examples
-//!
-//! This example demonstrates various ways to implement widget traits in Ratatui on a type, a
-//! reference, and a mutable reference. It also shows how to use the `WidgetRef` trait to render
-//! boxed widgets.
-//!
-//! The latest version of this example is available in the [examples] folder in the repository.
-//!
-//! Please note that the examples are designed to be run against the `main` branch of the Github
-//! repository. This means that you may not be able to compile with the latest release version on
-//! crates.io, or the one that you have installed locally.
-//!
-//! See the [examples readme] for more information on finding examples that match the version of the
-//! library you are using.
-//!
-//! [Ratatui]: https://github.com/ratatui/ratatui
-//! [examples]: https://github.com/ratatui/ratatui/blob/main/examples
-//! [examples readme]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
+/// A Ratatui example that demonstrates how to implement the `Widget` trait.
+///
+/// This example demonstrates various ways to implement `Widget` traits in Ratatui on a type, a
+/// reference, and a mutable reference. It also shows how to use the `WidgetRef` trait to
+/// render boxed widgets.
+///
+/// This example runs with the Ratatui library code in the branch that you are currently
+/// reading. See the [`latest`] branch for the code which works with the most recent Ratatui
+/// release.
+///
+/// [`latest`]: https://github.com/ratatui/ratatui/tree/latest
 use std::time::{Duration, Instant};
 
 use color_eyre::Result;
@@ -40,7 +33,6 @@ fn main() -> Result<()> {
 struct App {
     should_quit: bool,
     timer: Timer,
-    #[cfg(feature = "unstable-widget-ref")]
     boxed_squares: BoxedSquares,
     green_square: RightAlignedSquare,
 }
@@ -93,7 +85,6 @@ impl Widget for &mut App {
         self.timer.render(timer, buf);
 
         // render a boxed widget containing red and blue squares
-        #[cfg(feature = "unstable-widget-ref")]
         self.boxed_squares.render(squares, buf);
 
         // render a mutable reference to the green square widget

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -150,11 +150,6 @@ required-features = ["crossterm"]
 doc-scrape-examples = true
 
 [[example]]
-name = "widget_impl"
-required-features = ["crossterm", "unstable-widget-ref"]
-doc-scrape-examples = true
-
-[[example]]
 name = "widget-ref-container"
 required-features = ["crossterm", "unstable-widget-ref"]
 doc-scrape-examples = true


### PR DESCRIPTION
see #1512 

also renamed to `advanced-widget-impl` 