### PR TITLE
docs(examples): move widget-ref-container example to examples folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4114,6 +4114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "widget-ref-container"
+version = "0.0.0"
+dependencies = [
+ "color-eyre",
+ "crossterm",
+ "ratatui",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/README.md
+++ b/examples/README.md
@@ -125,3 +125,7 @@ Shows how to handle user input. [Source](./apps/user-input/).
 ## Weather demo
 
 Shows how to render weather data using barchart widget. [Source](./apps/weather/).
+
+## WidgetRef Container demo
+
+Shows how to use [`WidgetRef`](https://docs.rs/ratatui/latest/ratatui/widgets/trait.WidgetRef.html) to store widgets in a container. [Source](./apps/widget-ref-container/).

--- a/examples/apps/widget-ref-container/Cargo.toml
+++ b/examples/apps/widget-ref-container/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "widget-ref-container"
+publish = false
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+color-eyre.workspace = true
+crossterm.workspace = true
+ratatui = { workspace = true, features = ["unstable-widget-ref"] }
+
+[lints]
+workspace = true

--- a/examples/apps/widget-ref-container/README.md
+++ b/examples/apps/widget-ref-container/README.md
@@ -1,0 +1,9 @@
+# WidgetRef Container demo
+
+This example shows how to use [`WidgetRef`](https://docs.rs/ratatui/latest/ratatui/widgets/trait.WidgetRef.html) to store widgets in a container.
+
+To run this demo:
+
+```shell
+cargo run -p widget-ref-container
+```

--- a/examples/apps/widget-ref-container/src/main.rs
+++ b/examples/apps/widget-ref-container/src/main.rs
@@ -1,19 +1,15 @@
-//! An example of how to use [`WidgetRef`] to store heterogeneous widgets in a container.
-//!
-//! This example creates a `StackContainer` widget that can hold any number of widgets of different
-//! types. It creates two widgets, `Greeting` and `Farewell`, and stores them in a `StackContainer`
-//! with a vertical layout. The `StackContainer` widget renders each of its child widgets in the
-//! order they were added.
-//!
-//! `Greetings` and `Farewell` both implement the Widget trait on references to themselves, which
-//! triggers the blanket implementation of [`WidgetRef`] for them. This allows them to be stored in
-//! the `StackContainer` in a boxed form.
-//!
-//! This example runs with the Ratatui library code in the branch that you are currently reading.
-//! See the [`latest`] branch for the code which works with the most recent Ratatui release.
-//!
-//! [`latest`]: https://github.com/ratatui/ratatui/tree/latest
-
+/// An example of how to use [`WidgetRef`] to store heterogeneous widgets in a container.
+///
+/// This example creates a `StackContainer` widget that can hold any number of widgets of
+/// different types. It creates two widgets, `Greeting` and `Farewell`, and stores them in a
+/// `StackContainer` with a vertical layout. The `StackContainer` widget renders each of its
+/// child widgets in the order they were added.
+///
+/// This example runs with the Ratatui library code in the branch that you are currently
+/// reading. See the [`latest`] branch for the code which works with the most recent Ratatui
+/// release.
+///
+/// [`latest`]: https://github.com/ratatui/ratatui/tree/latest
 use std::iter::zip;
 
 use color_eyre::Result;

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -154,11 +154,6 @@ name = "widget_impl"
 required-features = ["crossterm", "unstable-widget-ref"]
 doc-scrape-examples = true
 
-[[example]]
-name = "widget-ref-container"
-required-features = ["crossterm", "unstable-widget-ref"]
-doc-scrape-examples = true
-
 [[test]]
 name = "state_serde"
 required-features = ["serde"]


### PR DESCRIPTION
see #1512 