### PR TITLE
build: Building ratatui fails on windows

### DIFF
--- a/ratatui-crossterm/Cargo.toml
+++ b/ratatui-crossterm/Cargo.toml
@@ -40,7 +40,7 @@ instability.workspace = true
 ratatui-core = { workspace = true }
 
 [dev-dependencies]
-ratatui = { path = "../ratatui", features = ["crossterm"] }
+#ratatui = { path = "../ratatui", features = ["crossterm"] }
 rstest.workspace = true
 
 [lints]

--- a/ratatui-widgets/Cargo.toml
+++ b/ratatui-widgets/Cargo.toml
@@ -63,7 +63,7 @@ unicode-width.workspace = true
 [dev-dependencies]
 color-eyre.workspace = true
 pretty_assertions.workspace = true
-ratatui = { path = "../ratatui" }
+# ratatui = { path = "../ratatui" }
 rstest.workspace = true
 
 [lints]


### PR DESCRIPTION
I've tried to build rat-salsa without using a dependency on ratatui, just ratatui-core and ratatui-widgets.

These two dev-dependencies make the build fail on windows. 

With them cargo always tries to build termion too.

I don't know if they are needed for other things, but without them I could build everything after fixing my imports.
