### PR TITLE
docs(core): remove link to Paragraph widget

### DIFF
--- a/ratatui-core/src/text/text.rs
+++ b/ratatui-core/src/text/text.rs
@@ -191,7 +191,6 @@ use crate::{
 /// # }
 /// ```
 ///
-/// [`Paragraph`]: crate::widgets::Paragraph
 /// [`Stylize`]: crate::style::Stylize
 #[derive(Default, Clone, Eq, PartialEq, Hash)]
 pub struct Text<'a> {


### PR DESCRIPTION
fixes the CI

We can't link to `widgets` from `core`... this was left over during the modularization probably.