### PR TITLE
fix: examples moving selection twice per key press

### DIFF
--- a/ratatui-widgets/examples/list.rs
+++ b/ratatui-widgets/examples/list.rs
@@ -16,7 +16,7 @@
 
 use color_eyre::Result;
 use ratatui::{
-    crossterm::event::{self, Event, KeyCode},
+    crossterm::event::{self, Event, KeyCode, KeyEventKind},
     layout::{Constraint, Layout, Rect},
     style::{Color, Modifier, Style, Stylize},
     text::{Line, Span},
@@ -39,11 +39,13 @@ fn run(mut terminal: DefaultTerminal) -> Result<()> {
     loop {
         terminal.draw(|frame| draw(frame, &mut list_state))?;
         if let Event::Key(key) = event::read()? {
-            match key.code {
-                KeyCode::Char('q') => break Ok(()),
-                KeyCode::Down | KeyCode::Char('j') => list_state.select_next(),
-                KeyCode::Up | KeyCode::Char('k') => list_state.select_previous(),
-                _ => {}
+            if key.kind == KeyEventKind::Press {
+                match key.code {
+                    KeyCode::Char('q') => break Ok(()),
+                    KeyCode::Down | KeyCode::Char('j') => list_state.select_next(),
+                    KeyCode::Up | KeyCode::Char('k') => list_state.select_previous(),
+                    _ => {}
+                }
             }
         }
     }

--- a/ratatui-widgets/examples/tabs.rs
+++ b/ratatui-widgets/examples/tabs.rs
@@ -16,7 +16,7 @@
 
 use color_eyre::Result;
 use ratatui::{
-    crossterm::event::{self, Event, KeyCode},
+    crossterm::event::{self, Event, KeyCode, KeyEventKind},
     layout::{Alignment, Constraint, Layout, Offset, Rect},
     style::{Color, Style, Stylize},
     symbols,
@@ -39,13 +39,15 @@ fn run(mut terminal: DefaultTerminal) -> Result<()> {
     loop {
         terminal.draw(|frame| draw(frame, selected_tab))?;
         if let Event::Key(key) = event::read()? {
-            match key.code {
-                KeyCode::Char('q') => break Ok(()),
-                KeyCode::Right | KeyCode::Char('l') | KeyCode::Tab => {
-                    selected_tab = (selected_tab + 1) % 3;
+            if key.kind == KeyEventKind::Press {
+                match key.code {
+                    KeyCode::Char('q') => break Ok(()),
+                    KeyCode::Right | KeyCode::Char('l') | KeyCode::Tab => {
+                        selected_tab = (selected_tab + 1) % 3;
+                    }
+                    KeyCode::Left | KeyCode::Char('h') => selected_tab = (selected_tab + 2) % 3,
+                    _ => {}
                 }
-                KeyCode::Left | KeyCode::Char('h') => selected_tab = (selected_tab + 2) % 3,
-                _ => {}
             }
         }
     }


### PR DESCRIPTION
This caused two movements for a single key event

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
