### PR TITLE
chore: remove paste dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,12 +2121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pem"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,7 +2575,6 @@ dependencies = [
  "itertools 0.13.0",
  "lru",
  "palette",
- "paste",
  "pretty_assertions",
  "rstest",
  "serde",

--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -52,7 +52,6 @@ indoc.workspace = true
 itertools.workspace = true
 lru = "0.12.0"
 palette = { version = "0.7.6", optional = true }
-paste = "1.0.2"
 serde = { workspace = true, optional = true }
 strum.workspace = true
 thiserror = "2"


### PR DESCRIPTION
The paste crate is no longer maintained. Replaces the usages of this in
the Stylize declarative macros with hard coded values. These macros are
internal implementation deatil to ratatui and so the changes should have
no impact on users.

Fixes: https://github.com/ratatui/ratatui/issues/1712
