### PR TITLE
fix(demo): support tab key in demo2 example

### DIFF
--- a/examples/apps/demo2/src/app.rs
+++ b/examples/apps/demo2/src/app.rs
@@ -93,7 +93,7 @@ impl App {
         match key.code {
             KeyCode::Char('q') | KeyCode::Esc => self.mode = Mode::Quit,
             KeyCode::Char('h') | KeyCode::Left => self.prev_tab(),
-            KeyCode::Char('l') | KeyCode::Right => self.next_tab(),
+            KeyCode::Char('l') | KeyCode::Right | KeyCode::Tab => self.next_tab(),
             KeyCode::Char('k') | KeyCode::Up => self.prev(),
             KeyCode::Char('j') | KeyCode::Down => self.next(),
             KeyCode::Char('d') | KeyCode::Delete => self.destroy(),


### PR DESCRIPTION
see #1721

Not sure what caused this - it's been there for a while probably and we didn't realize it since we used `demo2-destroy` mostly.