### PR TITLE
Very basic support of block border merging

### DIFF
--- a/ratatui-core/src/buffer/cell.rs
+++ b/ratatui-core/src/buffer/cell.rs
@@ -1,6 +1,7 @@
 use compact_str::CompactString;
 
 use crate::style::{Color, Modifier, Style};
+use crate::symbols::merge::merge_symbol;
 
 /// A buffer cell
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -59,6 +60,19 @@ impl Cell {
     #[must_use]
     pub fn symbol(&self) -> &str {
         self.symbol.as_str()
+    }
+
+    /// Merge the symbol of the cell with the one already on the cell.
+    pub fn merge_symbol(&mut self, symbol: &str) -> &mut Self {
+        match merge_symbol(self.symbol.as_str(), symbol) {
+            None => {
+                self.symbol = CompactString::new(symbol);
+            }
+            Some(new_symbol) => {
+                self.symbol = CompactString::new(new_symbol);
+            }
+        }
+        self
     }
 
     /// Sets the symbol of the cell.

--- a/ratatui-core/src/symbols.rs
+++ b/ratatui-core/src/symbols.rs
@@ -9,5 +9,6 @@ pub mod braille;
 pub mod half_block;
 pub mod line;
 pub mod marker;
+pub mod merge;
 pub mod scrollbar;
 pub mod shade;

--- a/ratatui-core/src/symbols/merge.rs
+++ b/ratatui-core/src/symbols/merge.rs
@@ -1,0 +1,66 @@
+use super::line;
+
+/// Merge the two given symbols.
+/// Returns `None` if there is nothing to merge.
+/// Nothing to merge means you have to choose which one to display.
+///
+/// TODO : so much "if then else" are
+/// - bad pratice
+/// - bad performance
+/// - easy to achieve with macro (but not a good idea)
+/// - compiler optimized ?
+/// I didn't achieved it simply with a match case
+pub fn merge_symbol(first: &str, second: &str) -> Option<&'static str> {
+    if first == line::NORMAL.vertical {
+        if second == line::NORMAL.vertical {
+            None
+        } else if second == line::NORMAL.horizontal {
+            Some(line::NORMAL.cross)
+        } else if second == line::NORMAL.top_right {
+            Some(line::NORMAL.vertical_left)
+        } else if second == line::NORMAL.top_left {
+            Some(line::NORMAL.vertical_right)
+        } else if second == line::NORMAL.bottom_right {
+            Some(line::NORMAL.vertical_left)
+        } else if second == line::NORMAL.bottom_left {
+            Some(line::NORMAL.vertical_right)
+        } else if second == line::NORMAL.vertical_left {
+            None
+        } else if second == line::NORMAL.vertical_right {
+            None
+        } else if second == line::NORMAL.horizontal_down {
+            Some(line::NORMAL.cross)
+        } else if second == line::NORMAL.horizontal_up {
+            Some(line::NORMAL.cross)
+        } else {
+            None
+        }
+    } else if first == line::NORMAL.horizontal {
+        if second == line::NORMAL.vertical {
+            Some(line::NORMAL.cross)
+        } else if second == line::NORMAL.horizontal {
+            None
+        } else if second == line::NORMAL.top_right {
+            Some(line::NORMAL.horizontal_down)
+        } else if second == line::NORMAL.top_left {
+            Some(line::NORMAL.horizontal_down)
+        } else if second == line::NORMAL.bottom_right {
+            Some(line::NORMAL.horizontal_up)
+        } else if second == line::NORMAL.bottom_left {
+            Some(line::NORMAL.horizontal_up)
+        } else if second == line::NORMAL.vertical_left {
+            Some(line::NORMAL.cross)
+        } else if second == line::NORMAL.vertical_right {
+            Some(line::NORMAL.cross)
+        } else if second == line::NORMAL.horizontal_down {
+            None
+        } else if second == line::NORMAL.horizontal_up {
+            None
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+    // ... other cases
+}

--- a/ratatui-widgets/src/block.rs
+++ b/ratatui-widgets/src/block.rs
@@ -647,9 +647,9 @@ impl Block<'_> {
 
     fn render_left_side(&self, area: Rect, buf: &mut Buffer) {
         if self.borders.contains(Borders::LEFT) {
-            for y in area.top()..area.bottom() {
+            for y in area.top() + 1..area.bottom() - 1 {
                 buf[(area.left(), y)]
-                    .set_symbol(self.border_set.vertical_left)
+                    .merge_symbol(self.border_set.vertical_left)
                     .set_style(self.border_style);
             }
         }
@@ -657,9 +657,9 @@ impl Block<'_> {
 
     fn render_top_side(&self, area: Rect, buf: &mut Buffer) {
         if self.borders.contains(Borders::TOP) {
-            for x in area.left()..area.right() {
+            for x in area.left() + 1..area.right() - 1 {
                 buf[(x, area.top())]
-                    .set_symbol(self.border_set.horizontal_top)
+                    .merge_symbol(self.border_set.horizontal_top)
                     .set_style(self.border_style);
             }
         }
@@ -668,9 +668,9 @@ impl Block<'_> {
     fn render_right_side(&self, area: Rect, buf: &mut Buffer) {
         if self.borders.contains(Borders::RIGHT) {
             let x = area.right() - 1;
-            for y in area.top()..area.bottom() {
+            for y in area.top() + 1..area.bottom() - 1 {
                 buf[(x, y)]
-                    .set_symbol(self.border_set.vertical_right)
+                    .merge_symbol(self.border_set.vertical_right)
                     .set_style(self.border_style);
             }
         }
@@ -679,9 +679,9 @@ impl Block<'_> {
     fn render_bottom_side(&self, area: Rect, buf: &mut Buffer) {
         if self.borders.contains(Borders::BOTTOM) {
             let y = area.bottom() - 1;
-            for x in area.left()..area.right() {
+            for x in area.left() + 1..area.right() - 1 {
                 buf[(x, y)]
-                    .set_symbol(self.border_set.horizontal_bottom)
+                    .merge_symbol(self.border_set.horizontal_bottom)
                     .set_style(self.border_style);
             }
         }
@@ -690,7 +690,7 @@ impl Block<'_> {
     fn render_bottom_right_corner(&self, buf: &mut Buffer, area: Rect) {
         if self.borders.contains(Borders::RIGHT | Borders::BOTTOM) {
             buf[(area.right() - 1, area.bottom() - 1)]
-                .set_symbol(self.border_set.bottom_right)
+                .merge_symbol(self.border_set.bottom_right)
                 .set_style(self.border_style);
         }
     }
@@ -698,7 +698,7 @@ impl Block<'_> {
     fn render_top_right_corner(&self, buf: &mut Buffer, area: Rect) {
         if self.borders.contains(Borders::RIGHT | Borders::TOP) {
             buf[(area.right() - 1, area.top())]
-                .set_symbol(self.border_set.top_right)
+                .merge_symbol(self.border_set.top_right)
                 .set_style(self.border_style);
         }
     }
@@ -706,7 +706,7 @@ impl Block<'_> {
     fn render_bottom_left_corner(&self, buf: &mut Buffer, area: Rect) {
         if self.borders.contains(Borders::LEFT | Borders::BOTTOM) {
             buf[(area.left(), area.bottom() - 1)]
-                .set_symbol(self.border_set.bottom_left)
+                .merge_symbol(self.border_set.bottom_left)
                 .set_style(self.border_style);
         }
     }
@@ -714,7 +714,7 @@ impl Block<'_> {
     fn render_top_left_corner(&self, buf: &mut Buffer, area: Rect) {
         if self.borders.contains(Borders::LEFT | Borders::TOP) {
             buf[(area.left(), area.top())]
-                .set_symbol(self.border_set.top_left)
+                .merge_symbol(self.border_set.top_left)
                 .set_style(self.border_style);
         }
     }


### PR DESCRIPTION
## Description
This is a feature that has been proposed for the next release of ratatui (0.30.0) [here](https://ratatui.rs/highlights/v029/).
> Future versions will enhance border drawing by combining borders to handle overlaps better.

## Example of the Result (Before Left - After Right)
<p align="center">
  <img src="https://github.com/user-attachments/assets/a2e178b4-6e65-4706-a908-9c4507f49431" width="300"/>
  <img src="https://github.com/user-attachments/assets/54ccf026-35f0-4083-9bb9-a68f6458d55e" width="300"/>
</p>

## Remark 
- The code is very basic, not optimal and should not be merged like that. However, it has the merit to be simple so it may break nothing. 
- I don't know of any idea to achieve it a better way. Indeed, there is a lot of `if then else` in my code. I have only tackled a few cases. Those could be replaced by macros, but this is not a good idea I think. I was thinking of a big match case but this is not possible to compare &str.
- Is it always wanted to have this behavior ? You can without this behavior simulate some depth and the user could understand which block is before another one.

## Implementation details
### Functions implemented
The only thing implemented are the function :
```rust
pub fn merge_symbol(first: &str, second: &str) -> Option<&'static str>;
```
and the method for the `Cell` type :
```rust
    pub fn merge_symbol(&mut self, symbol: &str) -> &mut Self;
```
that is a drop-in replacement of the `set_symbol` method of `Cell`
```rust
    pub fn set_symbol(&mut self, symbol: &str) -> &mut Self;
```
### Line and Corner behavior
When the line is drawn for the border block, the last border character is also drawn. This poses a problem because it might merge with the corner in a wrong way.

There is 2 way to fix that :
- draw the line one pixel before and after to not merge with the corner (what I have done because it changes the less code)
- let the line merge and delete completely the call to draw the corner (it will merge into a corner by it self)

### `merge_symbol` returns an `Option`
 The merge function returns an Option if there is some merge to do or not.
 In a lot of cases, this will return None. It can be better for performance to have an early return for most of the cases. Especially if we call `merge_symbol` instead of `set_cell` all the time.

## Future Work
- Better way to handle cases
- handle all cases
- maybe use the `merge_symbol` instead for the `set_cell` function all the time