### PR TITLE
perf(table): replace while loop with simple min operation

### DIFF
--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -910,6 +910,11 @@ impl Table<'_> {
     fn visible_rows(&self, state: &TableState, area: Rect) -> (usize, usize) {
         let last_row = self.rows.len().saturating_sub(1);
         let mut start = state.offset.min(last_row);
+
+        if let Some(selected) = state.selected {
+            start = start.min(selected);
+        }
+
         let mut end = start;
         let mut height = 0;
 
@@ -931,16 +936,6 @@ impl Table<'_> {
                 while height > area.height {
                     height = height.saturating_sub(self.rows[start].height_with_margin());
                     start += 1;
-                }
-            }
-
-            // scroll up until the selected row is visible
-            while selected < start {
-                start -= 1;
-                height = height.saturating_add(self.rows[start].height_with_margin());
-                while height > area.height {
-                    end -= 1;
-                    height = height.saturating_sub(self.rows[end].height_with_margin());
                 }
             }
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

While looking into the performance of table I noticed this. I changed it towards [the same approach used as in my table widget](https://github.com/EdJoPaTo/tui-rs-tree-widget/blob/6a5243243a7c4a608ef5f0b632b527baae649752/src/lib.rs#L208-L210).

It shouldn’t have much impact on small changes to offset / selection. Bigger changes upwards no longer require checking the height of many rows multiple times as the function has one less loop involved. The first loop still makes sure everything is correct.

This case might also exist in other widgets, haven’t checked so far.