### PR TITLE
fix: correct clippy errors introduced by rust 1.86.0 update

### DIFF
--- a/examples/apps/colors-rgb/src/main.rs
+++ b/examples/apps/colors-rgb/src/main.rs
@@ -115,7 +115,7 @@ impl App {
             if let Event::Key(key) = event::read()? {
                 if key.kind == KeyEventKind::Press && key.code == KeyCode::Char('q') {
                     self.state = AppState::Quit;
-                };
+                }
             }
         }
         Ok(())

--- a/examples/apps/constraint-explorer/src/main.rs
+++ b/examples/apps/constraint-explorer/src/main.rs
@@ -142,7 +142,7 @@ impl App {
             | Constraint::Fill(v)
             | Constraint::Percentage(v) => *v = v.saturating_add(1),
             Constraint::Ratio(_n, d) => *d = d.saturating_add(1),
-        };
+        }
     }
 
     fn decrement_value(&mut self) {
@@ -156,7 +156,7 @@ impl App {
             | Constraint::Fill(v)
             | Constraint::Percentage(v) => *v = v.saturating_sub(1),
             Constraint::Ratio(_n, d) => *d = d.saturating_sub(1),
-        };
+        }
     }
 
     /// select the next block with wrap around
@@ -466,7 +466,7 @@ impl ConstraintBlock {
             } else {
                 main_color
             };
-            if let Some(last_row) = area.rows().last() {
+            if let Some(last_row) = area.rows().next_back() {
                 buf.set_style(last_row, border_color);
             }
         }

--- a/examples/apps/inline/src/main.rs
+++ b/examples/apps/inline/src/main.rs
@@ -107,7 +107,7 @@ fn input_handling(tx: mpsc::Sender<Event>) {
                     event::Event::Key(key) => tx.send(Event::Input(key)).unwrap(),
                     event::Event::Resize(_, _) => tx.send(Event::Resize).unwrap(),
                     _ => {}
-                };
+                }
             }
             if last_tick.elapsed() >= tick_rate {
                 tx.send(Event::Tick).unwrap();
@@ -212,9 +212,9 @@ fn run(
                             break;
                         }
                     }
-                };
+                }
             }
-        };
+        }
     }
     Ok(())
 }

--- a/examples/apps/input-form/src/main.rs
+++ b/examples/apps/input-form/src/main.rs
@@ -236,7 +236,7 @@ impl AgeField {
             KeyCode::Up | KeyCode::Char('k') => self.increment(),
             KeyCode::Down | KeyCode::Char('j') => self.decrement(),
             _ => {}
-        };
+        }
     }
 
     fn increment(&mut self) {

--- a/examples/apps/table/src/main.rs
+++ b/examples/apps/table/src/main.rs
@@ -80,14 +80,20 @@ impl Data {
         [&self.name, &self.address, &self.email]
     }
 
+    // https://github.com/rust-lang/rust/issues/139338
+    #[allow(clippy::missing_const_for_fn)]
     fn name(&self) -> &str {
         &self.name
     }
 
+    // https://github.com/rust-lang/rust/issues/139338
+    #[allow(clippy::missing_const_for_fn)]
     fn address(&self) -> &str {
         &self.address
     }
 
+    // https://github.com/rust-lang/rust/issues/139338
+    #[allow(clippy::missing_const_for_fn)]
     fn email(&self) -> &str {
         &self.email
     }

--- a/examples/apps/todo-list/src/main.rs
+++ b/examples/apps/todo-list/src/main.rs
@@ -105,7 +105,7 @@ impl App {
             terminal.draw(|frame| frame.render_widget(&mut self, frame.area()))?;
             if let Event::Key(key) = event::read()? {
                 self.handle_key(key);
-            };
+            }
         }
         Ok(())
     }

--- a/ratatui-core/src/buffer/buffer.rs
+++ b/ratatui-core/src/buffer/buffer.rs
@@ -102,6 +102,8 @@ impl Buffer {
     }
 
     /// Returns the content of the buffer as a slice
+    // https://github.com/rust-lang/rust/issues/139338
+    #[allow(clippy::missing_const_for_fn)]
     pub fn content(&self) -> &[Cell] {
         &self.content
     }

--- a/ratatui-core/src/terminal/terminal.rs
+++ b/ratatui-core/src/terminal/terminal.rs
@@ -245,7 +245,7 @@ where
             if area != self.last_known_area {
                 self.resize(area)?;
             }
-        };
+        }
         Ok(())
     }
 

--- a/ratatui-core/src/text/line.rs
+++ b/ratatui-core/src/text/line.rs
@@ -723,7 +723,7 @@ impl Line<'_> {
                 Some(Alignment::Left) | None => 0,
             };
             render_spans(&self.spans, area, buf, skip_width);
-        };
+        }
     }
 }
 

--- a/ratatui-termion/src/lib.rs
+++ b/ratatui-termion/src/lib.rs
@@ -151,7 +151,7 @@ where
             ClearType::BeforeCursor => write!(self.writer, "{}", termion::clear::BeforeCursor)?,
             ClearType::CurrentLine => write!(self.writer, "{}", termion::clear::CurrentLine)?,
             ClearType::UntilNewLine => write!(self.writer, "{}", termion::clear::UntilNewline)?,
-        };
+        }
         self.writer.flush()
     }
 

--- a/ratatui-widgets/src/chart.rs
+++ b/ratatui-widgets/src/chart.rs
@@ -211,7 +211,7 @@ impl LegendPosition {
         }
         if height_margin < 0 {
             return None;
-        };
+        }
 
         let (x, y) = match self {
             Self::TopRight => {

--- a/ratatui-widgets/src/scrollbar.rs
+++ b/ratatui-widgets/src/scrollbar.rs
@@ -585,9 +585,9 @@ impl Scrollbar<'_> {
     fn scrollbar_area(&self, area: Rect) -> Option<Rect> {
         match self.orientation {
             ScrollbarOrientation::VerticalLeft => area.columns().next(),
-            ScrollbarOrientation::VerticalRight => area.columns().last(),
+            ScrollbarOrientation::VerticalRight => area.columns().next_back(),
             ScrollbarOrientation::HorizontalTop => area.rows().next(),
-            ScrollbarOrientation::HorizontalBottom => area.rows().last(),
+            ScrollbarOrientation::HorizontalBottom => area.rows().next_back(),
         }
     }
 

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -859,7 +859,7 @@ impl Table<'_> {
                 };
                 buf.set_style(selection_area, row.style);
                 (&self.highlight_symbol).render(selection_area, buf);
-            };
+            }
             for ((x, width), cell) in columns_widths.iter().zip(row.cells.iter()) {
                 cell.render(
                     Rect::new(row_area.x + x, row_area.y, *width, row_area.height),


### PR DESCRIPTION
New version of rust (1.86.0) caused CI to fail.
