### PR TITLE
chore: fix io_other_error clippy lints

### DIFF
--- a/ratatui-core/src/backend.rs
+++ b/ratatui-core/src/backend.rs
@@ -278,10 +278,9 @@ pub trait Backend {
             ClearType::AfterCursor
             | ClearType::BeforeCursor
             | ClearType::CurrentLine
-            | ClearType::UntilNewLine => Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!("clear_type [{clear_type:?}] not supported with this backend"),
-            )),
+            | ClearType::UntilNewLine => Err(io::Error::other(format!(
+                "clear_type [{clear_type:?}] not supported with this backend"
+            ))),
         }
     }
 

--- a/ratatui-crossterm/src/lib.rs
+++ b/ratatui-crossterm/src/lib.rs
@@ -230,7 +230,7 @@ where
     fn get_cursor_position(&mut self) -> io::Result<Position> {
         crossterm::cursor::position()
             .map(|(x, y)| Position { x, y })
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))
+            .map_err(io::Error::other)
     }
 
     fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {

--- a/ratatui-termwiz/src/lib.rs
+++ b/ratatui-termwiz/src/lib.rs
@@ -237,7 +237,7 @@ impl Backend for TermwizBackend {
             .buffered_terminal
             .terminal()
             .get_screen_size()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(io::Error::other)?;
         Ok(WindowSize {
             columns_rows: Size {
                 width: u16_max(cols),
@@ -251,9 +251,7 @@ impl Backend for TermwizBackend {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.buffered_terminal
-            .flush()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        self.buffered_terminal.flush().map_err(io::Error::other)?;
         Ok(())
     }
 


### PR DESCRIPTION
Pre-emptive fix for new lint to be added in 1.87 (currently in beta).
https://rust-lang.github.io/rust-clippy/master/index.html\#io_other_error
