### PR TITLE
fix: add key event handling in sparkline example

### DIFF
--- a/ratatui-widgets/examples/sparkline.rs
+++ b/ratatui-widgets/examples/sparkline.rs
@@ -36,7 +36,16 @@ fn main() -> Result<()> {
 fn run(mut terminal: DefaultTerminal) -> Result<()> {
     loop {
         terminal.draw(draw)?;
-        if event::poll(Duration::from_millis(16))? && matches!(event::read()?, Event::Key(_)) {
+        if event::poll(Duration::from_millis(16))?
+            && matches!(
+                event::read()?,
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char('q'),
+                    kind: KeyEventKind::Press,
+                    ..
+                })
+            )
+        {
             break Ok(());
         }
     }


### PR DESCRIPTION
sparkline example doesn't hold the terminal after `cargo run` without key event handling.