### PR TITLE
Drop unused font8x8 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,12 +1016,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
-name = "font8x8"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875488b8711a968268c7cf5d139578713097ca4635a76044e8fe8eedf831d07e"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2560,7 +2554,6 @@ dependencies = [
  "crossterm",
  "document-features",
  "fakeit",
- "font8x8",
  "futures",
  "indoc",
  "instability",

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -121,7 +121,6 @@ color-eyre = "0.6.2"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 crossterm = { version = "0.28.1", features = ["event-stream"] }
 fakeit = "1.1"
-font8x8 = "0.3.1"
 futures = "0.3.30"
 indoc = "2"
 pretty_assertions = "1.4.0"


### PR DESCRIPTION
The dependency was first introduced in https://github.com/ratatui/ratatui/pull/809, but I don't quite see why it was added. Don't see any code usage.