### PR TITLE
refactor(no_std): Make usages of std explicit in ratatui-core.

### DIFF
--- a/ratatui-core/src/backend.rs
+++ b/ratatui-core/src/backend.rs
@@ -100,6 +100,7 @@
 //! [Examples]: https://github.com/ratatui/ratatui/tree/main/ratatui/examples/README.md
 //! [Backend Comparison]: https://ratatui.rs/concepts/backends/comparison/
 //! [Ratatui Website]: https://ratatui.rs
+use alloc::format;
 use core::ops;
 use std::io;
 
@@ -368,6 +369,8 @@ pub trait Backend {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use strum::ParseError;
 
     use super::*;

--- a/ratatui-core/src/backend/test.rs
+++ b/ratatui-core/src/backend/test.rs
@@ -1,6 +1,8 @@
 //! This module provides the `TestBackend` implementation for the [`Backend`] trait.
 //! It is used in the integration tests to verify the correctness of the library.
 
+use alloc::string::String;
+use alloc::vec;
 use core::fmt::{self, Write};
 use core::{iter, ops};
 use std::io;
@@ -448,6 +450,8 @@ fn append_to_scrollback(scrollback: &mut Buffer, cells: impl IntoIterator<Item =
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+
     use itertools::Itertools as _;
 
     use super::*;

--- a/ratatui-core/src/buffer/assert.rs
+++ b/ratatui-core/src/buffer/assert.rs
@@ -19,9 +19,9 @@ macro_rules! assert_buffer_eq {
                     .enumerate()
                     .map(|(i, (x, y, cell))| {
                         let expected_cell = &expected[(x, y)];
-                        format!("{i}: at ({x}, {y})\n  expected: {expected_cell:?}\n  actual:   {cell:?}")
+                        ::alloc::format!("{i}: at ({x}, {y})\n  expected: {expected_cell:?}\n  actual:   {cell:?}")
                     })
-                    .collect::<Vec<String>>()
+                    .collect::<::alloc::vec::Vec<::alloc::string::String>>()
                     .join("\n");
                 assert!(
                     nice_diff.is_empty(),

--- a/ratatui-core/src/buffer/buffer.rs
+++ b/ratatui-core/src/buffer/buffer.rs
@@ -1,3 +1,5 @@
+use alloc::vec;
+use alloc::vec::Vec;
 use core::ops::{Index, IndexMut};
 use core::{cmp, fmt};
 
@@ -638,7 +640,10 @@ impl fmt::Debug for Buffer {
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+    use alloc::string::ToString;
     use core::iter;
+    use std::{dbg, println};
 
     use itertools::Itertools;
     use rstest::{fixture, rstest};

--- a/ratatui-core/src/layout/alignment.rs
+++ b/ratatui-core/src/layout/alignment.rs
@@ -31,6 +31,8 @@ pub enum VerticalAlignment {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use strum::ParseError;
 
     use super::*;

--- a/ratatui-core/src/layout/constraint.rs
+++ b/ratatui-core/src/layout/constraint.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::fmt;
 
 use strum::EnumIs;
@@ -382,6 +383,9 @@ impl fmt::Display for Constraint {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+    use alloc::vec;
+
     use super::*;
 
     #[test]

--- a/ratatui-core/src/layout/direction.rs
+++ b/ratatui-core/src/layout/direction.rs
@@ -9,6 +9,8 @@ pub enum Direction {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use strum::ParseError;
 
     use super::*;

--- a/ratatui-core/src/layout/layout.rs
+++ b/ratatui-core/src/layout/layout.rs
@@ -1,7 +1,10 @@
+use alloc::format;
 use alloc::rc::Rc;
+use alloc::vec::Vec;
 use core::cell::RefCell;
 use core::iter;
 use core::num::NonZeroUsize;
+use std::{dbg, thread_local};
 
 use hashbrown::HashMap;
 use itertools::Itertools;
@@ -1172,6 +1175,10 @@ mod strengths {
 
 #[cfg(test)]
 mod tests {
+    use alloc::borrow::ToOwned;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
     use super::*;
 
     #[test]
@@ -1403,12 +1410,14 @@ mod tests {
     /// - underflow: constraint is for less than the full space
     /// - overflow: constraint is for more than the full space
     mod split {
+        use alloc::string::ToString;
         use core::ops::Range;
 
         use itertools::Itertools;
         use pretty_assertions::assert_eq;
         use rstest::rstest;
 
+        use super::*;
         use crate::buffer::Buffer;
         use crate::layout::Constraint::{self, *};
         use crate::layout::{Direction, Flex, Layout, Rect};

--- a/ratatui-core/src/layout/margin.rs
+++ b/ratatui-core/src/layout/margin.rs
@@ -24,6 +24,8 @@ impl fmt::Display for Margin {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use super::*;
 
     #[test]

--- a/ratatui-core/src/layout/position.rs
+++ b/ratatui-core/src/layout/position.rs
@@ -75,6 +75,8 @@ impl fmt::Display for Position {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use super::*;
 
     #[test]

--- a/ratatui-core/src/layout/rect.rs
+++ b/ratatui-core/src/layout/rect.rs
@@ -377,6 +377,10 @@ impl From<(Position, Size)> for Rect {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
     use rstest::rstest;
 
     use super::*;

--- a/ratatui-core/src/layout/size.rs
+++ b/ratatui-core/src/layout/size.rs
@@ -46,6 +46,8 @@ impl fmt::Display for Size {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use super::*;
 
     #[test]

--- a/ratatui-core/src/lib.rs
+++ b/ratatui-core/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 // show the feature flags in the generated documentation
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
@@ -41,6 +42,8 @@
 #![warn(clippy::std_instead_of_core)]
 #![warn(clippy::std_instead_of_alloc)]
 #![warn(clippy::alloc_instead_of_core)]
+
+extern crate std;
 
 extern crate alloc;
 

--- a/ratatui-core/src/style.rs
+++ b/ratatui-core/src/style.rs
@@ -632,6 +632,8 @@ impl From<(Color, Color, Modifier, Modifier)> for Style {
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+
     use rstest::rstest;
 
     use super::*;

--- a/ratatui-core/src/style/color.rs
+++ b/ratatui-core/src/style/color.rs
@@ -145,6 +145,8 @@ impl serde::Serialize for Color {
     where
         S: serde::Serializer,
     {
+        use alloc::string::ToString;
+
         serializer.serialize_str(&self.to_string())
     }
 }
@@ -206,6 +208,9 @@ impl<'de> serde::Deserialize<'de> for Color {
     where
         D: serde::Deserializer<'de>,
     {
+        use alloc::format;
+        use alloc::string::String;
+
         /// Colors are currently serialized with the `Display` implementation, so
         /// RGB values are serialized via hex, for example "#FFFFFF".
         ///
@@ -505,6 +510,8 @@ impl From<(u8, u8, u8, u8)> for Color {
 
 #[cfg(test)]
 mod tests {
+    use alloc::boxed::Box;
+    use alloc::format;
     use core::error::Error;
 
     #[cfg(feature = "palette")]

--- a/ratatui-core/src/style/stylize.rs
+++ b/ratatui-core/src/style/stylize.rs
@@ -1,4 +1,5 @@
 use alloc::borrow::Cow;
+use alloc::string::{String, ToString};
 use core::fmt;
 
 use crate::style::{Color, Modifier, Style};
@@ -369,6 +370,8 @@ styled!(usize);
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+
     use itertools::Itertools;
     use rstest::rstest;
 

--- a/ratatui-core/src/symbols/border.rs
+++ b/ratatui-core/src/symbols/border.rs
@@ -365,6 +365,9 @@ pub const EMPTY: Set = Set {
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+    use alloc::string::String;
+
     use indoc::{formatdoc, indoc};
 
     use super::*;

--- a/ratatui-core/src/symbols/line.rs
+++ b/ratatui-core/src/symbols/line.rs
@@ -167,6 +167,9 @@ pub const HEAVY_QUADRUPLE_DASHED: Set = Set {
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+    use alloc::string::String;
+
     use indoc::{formatdoc, indoc};
 
     use super::*;

--- a/ratatui-core/src/symbols/marker.rs
+++ b/ratatui-core/src/symbols/marker.rs
@@ -29,6 +29,8 @@ pub enum Marker {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use strum::ParseError;
 
     use super::*;

--- a/ratatui-core/src/terminal/terminal.rs
+++ b/ratatui-core/src/terminal/terminal.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{eprintln, io};
 
 use crate::backend::{Backend, ClearType};
 use crate::buffer::{Buffer, Cell};

--- a/ratatui-core/src/terminal/viewport.rs
+++ b/ratatui-core/src/terminal/viewport.rs
@@ -42,6 +42,8 @@ impl fmt::Display for Viewport {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use super::*;
 
     #[test]

--- a/ratatui-core/src/text/line.rs
+++ b/ratatui-core/src/text/line.rs
@@ -1,6 +1,9 @@
 #![deny(missing_docs)]
 #![warn(clippy::pedantic, clippy::nursery, clippy::arithmetic_side_effects)]
 use alloc::borrow::Cow;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
 use core::fmt;
 
 use unicode_truncate::UnicodeTruncateStr;
@@ -831,7 +834,9 @@ impl Styled for Line<'_> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
     use core::iter;
+    use std::dbg;
 
     use rstest::{fixture, rstest};
 

--- a/ratatui-core/src/text/masked.rs
+++ b/ratatui-core/src/text/masked.rs
@@ -88,6 +88,8 @@ impl<'a> From<Masked<'a>> for Text<'a> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+
     use super::*;
     use crate::text::Line;
 

--- a/ratatui-core/src/text/span.rs
+++ b/ratatui-core/src/text/span.rs
@@ -1,4 +1,5 @@
 use alloc::borrow::Cow;
+use alloc::string::ToString;
 use core::fmt;
 
 use unicode_segmentation::UnicodeSegmentation;
@@ -494,6 +495,9 @@ impl fmt::Display for Span<'_> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
+    use alloc::{format, vec};
+
     use rstest::{fixture, rstest};
 
     use super::*;

--- a/ratatui-core/src/text/text.rs
+++ b/ratatui-core/src/text/text.rs
@@ -1,5 +1,8 @@
 #![warn(missing_docs)]
-use alloc::borrow::Cow;
+use alloc::borrow::{Cow, ToOwned};
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
 use core::fmt;
 
 use crate::buffer::Buffer;
@@ -743,6 +746,7 @@ impl Styled for Text<'_> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
     use core::iter;
 
     use rstest::{fixture, rstest};

--- a/ratatui-core/src/widgets/stateful_widget.rs
+++ b/ratatui-core/src/widgets/stateful_widget.rs
@@ -130,6 +130,9 @@ pub trait StatefulWidget {
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+    use alloc::string::{String, ToString};
+
     use rstest::{fixture, rstest};
 
     use super::*;

--- a/ratatui-core/src/widgets/widget.rs
+++ b/ratatui-core/src/widgets/widget.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 use crate::buffer::Buffer;
 use crate::layout::Rect;
 use crate::style::Style;


### PR DESCRIPTION
### This commit does the following:

- Adds `#[no_std]` to `lib.rs`.
- Adds `extern crate std;` to `lib.rs`.
- Updates `ratatui-core` to explicitly `use` items from std and alloc.
- Prefers `use`-ing alloc over std when possible.

### Explanation:

This allows usages of `std` in `ratatui-core` to be clearly pointed out and dealt with individually.

Eventually, when `std` is to be feature gated, the associated commit will be much cleaner.