### PR TITLE
build(deps): update compact_str requirement from 0.8.1 to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",

--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -45,7 +45,7 @@ serde = ["dep:serde", "bitflags/serde", "compact_str/serde"]
 [dependencies]
 anstyle = { version = "1", optional = true }
 bitflags = "2.3"
-compact_str = "0.8.0"
+compact_str = "0.9.0"
 document-features = { workspace = true, optional = true }
 hashbrown = "0.15.2"
 indoc.workspace = true


### PR DESCRIPTION
Looking at https://github.com/ParkMyCar/compact_str/blob/v0.9.0/CHANGELOG.md#090, there are a few API changes, but it doesn’t seem like anything there should be a problem given that `cargo test` still passes in `ratatui-core/`.