### PR TITLE
chore: use expect() instead of allow() for lint overrides

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -15,6 +15,7 @@ This is a quick summary of the sections below:
   - `FrameExt` trait for `unstable-widget-ref` feature
   - `List::highlight_symbol` now accepts `Into<Line>` instead of `&str`
   - 'layout::Alignment' is renamed to 'layout::HorizontalAlignment'
+  - The MSRV is now 1.81.0
 - [v0.29.0](#v0290)
   - `Sparkline::data` takes `IntoIterator<Item = SparklineBar>` instead of `&[u64]` and is no longer const
   - Removed public fields from `Rect` iterators
@@ -78,6 +79,13 @@ This is a quick summary of the sections below:
   - `List` no longer ignores empty strings
 
 ## Unreleased (0.30.0)
+
+## The MSRV is now 1.81.0 ([#1786])
+
+[#1786]: https://github.com/ratatui/ratatui/pull/1786
+
+The minimum supported Rust version (MSRV) is now 1.81.0. This is due to the use of `#[expect]` in
+the codebase, which is only available in Rust 1.81.0 and later.
 
 ### `layout::Alignment` is renamed to `layout::HorizontalAlignment` ([#1735])
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ readme = "README.md"
 license = "MIT"
 exclude = ["assets/*", ".github", "Makefile.toml", "CONTRIBUTING.md", "*.log", "tags"]
 edition = "2021"
-rust-version = "1.74.0"
+rust-version = "1.81.0"
 
 [workspace.dependencies]
 bitflags = "2.9.0"

--- a/examples/apps/colors-rgb/src/main.rs
+++ b/examples/apps/colors-rgb/src/main.rs
@@ -174,7 +174,7 @@ impl FpsWidget {
     /// This updates the fps once a second, but only if the widget has rendered at least 2 frames
     /// since the last calculation. This avoids noise in the fps calculation when rendering on slow
     /// machines that can't render at least 2 frames per second.
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     fn calculate_fps(&mut self) {
         self.frame_count += 1;
         let elapsed = self.last_instant.elapsed();
@@ -216,7 +216,7 @@ impl ColorsWidget {
     ///
     /// This is called once per frame to setup the colors to render. It caches the colors so that
     /// they don't need to be recalculated every frame.
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     fn setup_colors(&mut self, size: Rect) {
         let Rect { width, height, .. } = size;
         // double the height because each screen row has two rows of half block pixels

--- a/examples/apps/constraint-explorer/src/main.rs
+++ b/examples/apps/constraint-explorer/src/main.rs
@@ -277,7 +277,7 @@ impl App {
     }
 
     fn swap_legend() -> impl Widget {
-        #[allow(unstable_name_collisions)]
+        #[expect(unstable_name_collisions)]
         Paragraph::new(
             Line::from(
                 [

--- a/examples/apps/constraints/src/main.rs
+++ b/examples/apps/constraints/src/main.rs
@@ -192,7 +192,7 @@ impl App {
     ///
     /// This function renders the demo content into a separate buffer and then splices the buffer
     /// into the main buffer. This is done to make it possible to handle scrolling easily.
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn render_demo(self, area: Rect, buf: &mut Buffer) {
         // render demo content into a separate buffer so all examples fit we add an extra
         // area.height to make sure the last example is fully visible even when the scroll offset is
@@ -247,7 +247,7 @@ impl SelectedTab {
     }
 
     const fn get_example_count(self) -> u16 {
-        #[allow(clippy::match_same_arms)]
+        #[expect(clippy::match_same_arms)]
         match self {
             Self::Length => 4,
             Self::Percentage => 5,

--- a/examples/apps/custom-widget/src/main.rs
+++ b/examples/apps/custom-widget/src/main.rs
@@ -99,7 +99,7 @@ impl<'a> Button<'a> {
 }
 
 impl Widget for Button<'_> {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn render(self, area: Rect, buf: &mut Buffer) {
         let (background, text, shadow, highlight) = self.colors();
         buf.set_style(area, Style::new().bg(background).fg(text));

--- a/examples/apps/demo/src/ui.rs
+++ b/examples/apps/demo/src/ui.rs
@@ -95,7 +95,7 @@ fn draw_gauges(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_widget(line_gauge, chunks[2]);
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn draw_charts(frame: &mut Frame, app: &mut App, area: Rect) {
     let constraints = if app.show_chart {
         vec![Constraint::Percentage(50), Constraint::Percentage(50)]

--- a/examples/apps/demo2/src/colors.rs
+++ b/examples/apps/demo2/src/colors.rs
@@ -12,7 +12,7 @@ use ratatui::widgets::Widget;
 pub struct RgbSwatch;
 
 impl Widget for RgbSwatch {
-    #[allow(clippy::cast_precision_loss, clippy::similar_names)]
+    #[expect(clippy::cast_precision_loss, clippy::similar_names)]
     fn render(self, area: Rect, buf: &mut Buffer) {
         for (yi, y) in (area.top()..area.bottom()).enumerate() {
             let value = f32::from(area.height) - yi as f32;

--- a/examples/apps/demo2/src/destroy.rs
+++ b/examples/apps/demo2/src/destroy.rs
@@ -32,7 +32,7 @@ pub fn destroy(frame: &mut Frame<'_>) {
 ///
 /// Each pick some random pixels and move them each down one row. This is a very inefficient way to
 /// do this, but it works well enough for this demo.
-#[allow(
+#[expect(
     clippy::cast_possible_truncation,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss
@@ -74,7 +74,7 @@ fn drip(frame_count: usize, area: Rect, buf: &mut Buffer) {
 }
 
 /// draw some text fading in and out from black to red and back
-#[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+#[expect(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
 fn text(frame_count: usize, area: Rect, buf: &mut Buffer) {
     let sub_frame = frame_count.saturating_sub(TEXT_DELAY);
     if sub_frame == 0 {
@@ -126,7 +126,7 @@ fn blend(mask_color: Color, cell_color: Color, percentage: f64) -> Color {
     let green = f64::from(mask_green).mul_add(percentage, f64::from(cell_green) * remain);
     let blue = f64::from(mask_blue).mul_add(percentage, f64::from(cell_blue) * remain);
 
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     Color::Rgb(red as u8, green as u8, blue as u8)
 }
 

--- a/examples/apps/demo2/src/tabs/recipe.rs
+++ b/examples/apps/demo2/src/tabs/recipe.rs
@@ -17,7 +17,7 @@ struct Ingredient {
 }
 
 impl Ingredient {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn height(&self) -> u16 {
         self.name.lines().count() as u16
     }

--- a/examples/apps/demo2/src/tabs/weather.rs
+++ b/examples/apps/demo2/src/tabs/weather.rs
@@ -130,14 +130,14 @@ fn render_horizontal_barchart(area: Rect, buf: &mut Buffer) {
         .render(area, buf);
 }
 
-#[allow(clippy::cast_precision_loss)]
+#[expect(clippy::cast_precision_loss)]
 pub fn render_gauge(progress: usize, area: Rect, buf: &mut Buffer) {
     let percent = (progress * 3).min(100) as f64;
 
     render_line_gauge(percent, area, buf);
 }
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 fn render_line_gauge(percent: f64, area: Rect, buf: &mut Buffer) {
     // cycle color hue based on the percent for a neat effect yellow -> red
     let hue = 90.0 - (percent as f32 * 0.6);

--- a/examples/apps/flex/src/main.rs
+++ b/examples/apps/flex/src/main.rs
@@ -293,7 +293,7 @@ impl App {
     /// into the main buffer. This is done to make it possible to handle scrolling easily.
     ///
     /// Returns bool indicating whether scroll was needed
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn render_demo(self, area: Rect, buf: &mut Buffer) -> bool {
         // render demo content into a separate buffer so all examples fit we add an extra
         // area.height to make sure the last example is fully visible even when the scroll offset is
@@ -510,7 +510,7 @@ const fn color_for_constraint(constraint: Constraint) -> Color {
     }
 }
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 fn get_description_height(s: &str) -> u16 {
     if s.is_empty() {
         0

--- a/examples/apps/gauge/src/main.rs
+++ b/examples/apps/gauge/src/main.rs
@@ -103,7 +103,7 @@ impl App {
 }
 
 impl Widget for &App {
-    #[allow(clippy::similar_names)]
+    #[expect(clippy::similar_names)]
     fn render(self, area: Rect, buf: &mut Buffer) {
         use Constraint::{Length, Min, Ratio};
         let layout = Layout::vertical([Length(2), Min(0), Length(1)]);

--- a/examples/apps/inline/src/main.rs
+++ b/examples/apps/inline/src/main.rs
@@ -117,7 +117,7 @@ fn input_handling(tx: mpsc::Sender<Event>) {
     });
 }
 
-#[allow(clippy::cast_precision_loss, clippy::needless_pass_by_value)]
+#[expect(clippy::cast_precision_loss, clippy::needless_pass_by_value)]
 fn workers(tx: mpsc::Sender<Event>) -> Vec<Worker> {
     (0..4)
         .map(|id| {
@@ -157,7 +157,7 @@ fn downloads() -> Downloads {
     }
 }
 
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 fn run(
     terminal: &mut Terminal<impl Backend>,
     workers: Vec<Worker>,
@@ -232,7 +232,7 @@ fn draw(frame: &mut Frame, downloads: &Downloads) {
 
     // total progress
     let done = NUM_DOWNLOADS - downloads.pending.len() - downloads.in_progress.len();
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     let progress = LineGauge::default()
         .filled_style(Style::default().fg(Color::Blue))
         .label(format!("{done}/{NUM_DOWNLOADS}"))
@@ -262,7 +262,7 @@ fn draw(frame: &mut Frame, downloads: &Downloads) {
     let list = List::new(items);
     frame.render_widget(list, list_area);
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     for (i, (_, download)) in downloads.in_progress.iter().enumerate() {
         let gauge = Gauge::default()
             .gauge_style(Style::default().fg(Color::Yellow))

--- a/examples/apps/scrollbar/src/main.rs
+++ b/examples/apps/scrollbar/src/main.rs
@@ -79,7 +79,7 @@ impl App {
         }
     }
 
-    #[allow(clippy::too_many_lines, clippy::cast_possible_truncation)]
+    #[expect(clippy::too_many_lines, clippy::cast_possible_truncation)]
     fn draw(&mut self, frame: &mut Frame) {
         let area = frame.area();
 

--- a/examples/apps/table/src/main.rs
+++ b/examples/apps/table/src/main.rs
@@ -338,7 +338,7 @@ fn constraint_len_calculator(items: &[Data]) -> (u16, u16, u16) {
         .max()
         .unwrap_or(0);
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     (name_len as u16, address_len as u16, email_len as u16)
 }
 

--- a/examples/apps/user-input/src/main.rs
+++ b/examples/apps/user-input/src/main.rs
@@ -204,7 +204,7 @@ impl App {
 
             // Make the cursor visible and ask ratatui to put it at the specified coordinates after
             // rendering
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             InputMode::Editing => frame.set_cursor_position(Position::new(
                 // Draw the cursor at the current position in the input field.
                 // This position can be controlled via the left and right arrow key

--- a/ratatui-core/src/backend/test.rs
+++ b/ratatui-core/src/backend/test.rs
@@ -137,7 +137,7 @@ impl TestBackend {
     ///
     /// When they are not equal, a panic occurs with a detailed error message showing the
     /// differences between the expected and actual buffers.
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     #[track_caller]
     pub fn assert_buffer(&self, expected: &Buffer) {
         // TODO: use assert_eq!()

--- a/ratatui-core/src/buffer/assert.rs
+++ b/ratatui-core/src/buffer/assert.rs
@@ -38,7 +38,7 @@ macro_rules! assert_buffer_eq {
     };
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cfg(test)]
 mod tests {
     use crate::buffer::Buffer;

--- a/ratatui-core/src/layout/constraint.rs
+++ b/ratatui-core/src/layout/constraint.rs
@@ -460,7 +460,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     fn apply() {
         assert_eq!(Constraint::Percentage(0).apply(100), 0);
         assert_eq!(Constraint::Percentage(50).apply(100), 50);

--- a/ratatui-core/src/layout/flex.rs
+++ b/ratatui-core/src/layout/flex.rs
@@ -1,6 +1,6 @@
 use strum::{Display, EnumIs, EnumString};
 
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 use crate::layout::Constraint;
 
 /// Defines the options for layout flex justify content in a container.

--- a/ratatui-core/src/layout/layout.rs
+++ b/ratatui-core/src/layout/layout.rs
@@ -1006,7 +1006,7 @@ fn changes_to_rects(
 
 /// please leave this here as it's useful for debugging unit tests when we make any changes to
 /// layout code - we should replace this with tracing in the future.
-#[allow(dead_code)]
+#[expect(dead_code)]
 fn debug_elements(elements: &[Element], changes: &HashMap<Variable, f64>) {
     let variables = format!(
         "{:?}",
@@ -1035,7 +1035,7 @@ impl From<(Variable, Variable)> for Element {
 }
 
 impl Element {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     fn new() -> Self {
         Self {
             start: Variable::new(),
@@ -1177,7 +1177,6 @@ mod tests {
     #[test]
     // The compiler will optimize out the comparisons, but this ensures that the constants are
     // defined in the correct order of priority.
-    #[allow(clippy::assertions_on_constants)]
     pub fn strength_is_valid() {
         use strengths::*;
         assert!(SPACER_SIZE_EQ > MAX_SIZE_LE);
@@ -1228,7 +1227,7 @@ mod tests {
         assert_eq!(layout.constraints, [Constraint::Min(0)]);
 
         // array_ref
-        #[allow(clippy::needless_borrows_for_generic_args)] // backwards compatibility test
+        #[expect(clippy::needless_borrows_for_generic_args)] // backwards compatibility test
         let layout = Layout::new(Direction::Horizontal, &[Constraint::Min(0)]);
         assert_eq!(layout.direction, Direction::Horizontal);
         assert_eq!(layout.constraints, [Constraint::Min(0)]);
@@ -1239,7 +1238,7 @@ mod tests {
         assert_eq!(layout.constraints, [Constraint::Min(0)]);
 
         // vec_ref
-        #[allow(clippy::needless_borrows_for_generic_args)] // backwards compatibility test
+        #[expect(clippy::needless_borrows_for_generic_args)] // backwards compatibility test
         let layout = Layout::new(Direction::Horizontal, &(vec![Constraint::Min(0)]));
         assert_eq!(layout.direction, Direction::Horizontal);
         assert_eq!(layout.constraints, [Constraint::Min(0)]);
@@ -1281,11 +1280,6 @@ mod tests {
     /// The purpose of this test is to ensure that layout can be constructed with any type that
     /// implements `IntoIterator<Item = AsRef<Constraint>>`.
     #[test]
-    #[allow(
-        clippy::needless_borrow,
-        clippy::unnecessary_to_owned,
-        clippy::useless_asref
-    )]
     fn constraints() {
         const CONSTRAINTS: [Constraint; 2] = [Constraint::Min(0), Constraint::Max(10)];
         let fixed_size_array = CONSTRAINTS;

--- a/ratatui-core/src/symbols/border.rs
+++ b/ratatui-core/src/symbols/border.rs
@@ -235,7 +235,7 @@ pub const ONE_EIGHTH_RIGHT_EIGHT: &str = "▕";
 /// ▏xxxxx▕
 /// ▔▔▔▔▔▔▔
 /// ```
-#[allow(clippy::doc_markdown)]
+#[expect(clippy::doc_markdown)]
 pub const ONE_EIGHTH_WIDE: Set = Set {
     top_right: ONE_EIGHTH_BOTTOM_EIGHT,
     top_left: ONE_EIGHTH_BOTTOM_EIGHT,
@@ -255,7 +255,7 @@ pub const ONE_EIGHTH_WIDE: Set = Set {
 /// ▕xx▏
 /// ▕▁▁▏
 /// ```
-#[allow(clippy::doc_markdown)]
+#[expect(clippy::doc_markdown)]
 pub const ONE_EIGHTH_TALL: Set = Set {
     top_right: ONE_EIGHTH_LEFT_EIGHT,
     top_left: ONE_EIGHTH_RIGHT_EIGHT,

--- a/ratatui-core/src/text/span.rs
+++ b/ratatui-core/src/text/span.rs
@@ -328,7 +328,7 @@ impl<'a> Span<'a> {
         Line::from(self).left_aligned()
     }
 
-    #[allow(clippy::wrong_self_convention)]
+    #[expect(clippy::wrong_self_convention)]
     #[deprecated = "use `into_left_aligned_line()` instead"]
     pub fn to_left_aligned_line(self) -> Line<'a> {
         self.into_left_aligned_line()
@@ -348,7 +348,7 @@ impl<'a> Span<'a> {
         Line::from(self).centered()
     }
 
-    #[allow(clippy::wrong_self_convention)]
+    #[expect(clippy::wrong_self_convention)]
     #[deprecated = "use `into_centered_line()` instead"]
     pub fn to_centered_line(self) -> Line<'a> {
         self.into_centered_line()
@@ -368,7 +368,7 @@ impl<'a> Span<'a> {
         Line::from(self).right_aligned()
     }
 
-    #[allow(clippy::wrong_self_convention)]
+    #[expect(clippy::wrong_self_convention)]
     #[deprecated = "use `into_right_aligned_line()` instead"]
     pub fn to_right_aligned_line(self) -> Line<'a> {
         self.into_right_aligned_line()

--- a/ratatui-widgets/src/block.rs
+++ b/ratatui-widgets/src/block.rs
@@ -715,7 +715,7 @@ impl Block<'_> {
     /// be cut off if the block is too small to fit all titles. This is not ideal and should be
     /// the left side of that leftmost that is cut off. This is due to the line being truncated
     /// incorrectly. See <https://github.com/ratatui/ratatui/issues/932>
-    #[allow(clippy::similar_names)]
+    #[expect(clippy::similar_names)]
     fn render_right_titles(&self, position: Position, area: Rect, buf: &mut Buffer) {
         let titles = self.filtered_titles(position, Alignment::Right);
         let mut titles_area = self.titles_area(area, position);
@@ -750,7 +750,7 @@ impl Block<'_> {
     /// Currently this method aligns the titles to the left inside a centered area. This is not
     /// ideal and should be fixed in the future to align the titles to the center of the block and
     /// truncate both sides of the titles if the block is too small to fit all titles.
-    #[allow(clippy::similar_names)]
+    #[expect(clippy::similar_names)]
     fn render_center_titles(&self, position: Position, area: Rect, buf: &mut Buffer) {
         let titles = self
             .filtered_titles(position, Alignment::Center)
@@ -785,7 +785,7 @@ impl Block<'_> {
     }
 
     /// Render titles aligned to the left of the block
-    #[allow(clippy::similar_names)]
+    #[expect(clippy::similar_names)]
     fn render_left_titles(&self, position: Position, area: Rect, buf: &mut Buffer) {
         let titles = self.filtered_titles(position, Alignment::Left);
         let mut titles_area = self.titles_area(area, position);
@@ -981,14 +981,14 @@ mod tests {
         assert!(!block.has_title_at_position(Position::Top));
         assert!(block.has_title_at_position(Position::Bottom));
 
-        #[allow(deprecated)] // until Title is removed
+        #[expect(deprecated)] // until Title is removed
         let block = Block::new()
             .title(Title::from("Test").position(Position::Top))
             .title_position(Position::Bottom);
         assert!(block.has_title_at_position(Position::Top));
         assert!(!block.has_title_at_position(Position::Bottom));
 
-        #[allow(deprecated)] // until Title is removed
+        #[expect(deprecated)] // until Title is removed
         let block = Block::new()
             .title(Title::from("Test").position(Position::Bottom))
             .title_position(Position::Top);
@@ -999,7 +999,7 @@ mod tests {
         assert!(block.has_title_at_position(Position::Top));
         assert!(block.has_title_at_position(Position::Bottom));
 
-        #[allow(deprecated)] // until Title is removed
+        #[expect(deprecated)] // until Title is removed
         let block = Block::new()
             .title(Title::from("Test").position(Position::Top))
             .title(Title::from("Test"))
@@ -1007,7 +1007,7 @@ mod tests {
         assert!(block.has_title_at_position(Position::Top));
         assert!(block.has_title_at_position(Position::Bottom));
 
-        #[allow(deprecated)] // until Title is removed
+        #[expect(deprecated)] // until Title is removed
         let block = Block::new()
             .title(Title::from("Test"))
             .title(Title::from("Test").position(Position::Bottom))
@@ -1226,7 +1226,7 @@ mod tests {
         use HorizontalAlignment::*;
         use Position::*;
         let mut buffer = Buffer::empty(Rect::new(0, 0, 11, 3));
-        #[allow(deprecated)] // until Title is removed
+        #[expect(deprecated)] // until Title is removed
         Block::bordered()
             .title(Title::from("A").position(Top).alignment(Left))
             .title(Title::from("B").position(Top).alignment(Center))

--- a/ratatui-widgets/src/canvas/line.rs
+++ b/ratatui-widgets/src/canvas/line.rs
@@ -32,7 +32,7 @@ impl Line {
 }
 
 impl Shape for Line {
-    #[allow(clippy::similar_names)]
+    #[expect(clippy::similar_names)]
     fn draw(&self, painter: &mut Painter) {
         let (x_bounds, y_bounds) = painter.bounds();
         let Some((world_x1, world_y1, world_x2, world_y2)) =

--- a/ratatui-widgets/src/canvas/world.rs
+++ b/ratatui-widgets/src/canvas/world.rs
@@ -6121,7 +6121,7 @@ pub static WORLD_LOW_RESOLUTION: [(f64, f64); 1166] = [
     (120.43, 16.43),
     (121.72, 18.40),
     (125.34, 9.79),
-    #[allow(clippy::approx_constant)]
+    #[expect(clippy::approx_constant)]
     (125.56, 6.28),
     (122.38, 7.00),
     (125.10, 9.38),

--- a/ratatui-widgets/src/chart.rs
+++ b/ratatui-widgets/src/chart.rs
@@ -973,7 +973,7 @@ impl Widget for Chart<'_> {
 }
 
 impl Widget for &Chart<'_> {
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn render(self, area: Rect, buf: &mut Buffer) {
         buf.set_style(area, self.style);
 

--- a/ratatui-widgets/src/gauge.rs
+++ b/ratatui-widgets/src/gauge.rs
@@ -36,7 +36,7 @@ use crate::block::{Block, BlockExt};
 /// # See also
 ///
 /// - [`LineGauge`] for a thin progress bar
-#[allow(clippy::struct_field_names)] // gauge_style needs to be differentiated to style
+#[expect(clippy::struct_field_names)] // gauge_style needs to be differentiated to style
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Gauge<'a> {
     block: Option<Block<'a>>,
@@ -528,7 +528,7 @@ mod tests {
         );
     }
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     #[test]
     fn line_gauge_can_be_stylized_with_deprecated_gauge_style() {
         let gauge =
@@ -558,7 +558,7 @@ mod tests {
         );
     }
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     #[test]
     fn line_gauge_deprecated_line_set() {
         let gauge = LineGauge::default().line_set(symbols::line::DOUBLE);

--- a/ratatui-widgets/src/list/rendering.rs
+++ b/ratatui-widgets/src/list/rendering.rs
@@ -369,7 +369,7 @@ mod tests {
         assert_eq!(buffer, expected,);
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     #[test]
     fn combinations() {
         #[track_caller]

--- a/ratatui-widgets/src/reflow.rs
+++ b/ratatui-widgets/src/reflow.rs
@@ -178,7 +178,7 @@ where
         }
         pending_line.append(&mut self.pending_word);
 
-        #[allow(clippy::else_if_without_else)]
+        #[expect(clippy::else_if_without_else)]
         if !pending_line.is_empty() {
             self.wrapped_lines.push_back(pending_line);
         } else if pending_line.capacity() > 0 {
@@ -202,7 +202,6 @@ where
     O: Iterator<Item = (I, Alignment)>,
     I: Iterator<Item = StyledGrapheme<'a>>,
 {
-    #[allow(clippy::too_many_lines)]
     fn next_line<'lend>(&'lend mut self) -> Option<WrappedLine<'lend, 'a>> {
         if self.max_line_width == 0 {
             return None;
@@ -345,7 +344,7 @@ fn trim_offset(src: &str, mut offset: usize) -> &str {
             break;
         }
     }
-    #[allow(clippy::string_slice)] // Is safe as it comes from UnicodeSegmentation
+    #[expect(clippy::string_slice)] // Is safe as it comes from UnicodeSegmentation
     &src[start..]
 }
 

--- a/ratatui-widgets/src/scrollbar.rs
+++ b/ratatui-widgets/src/scrollbar.rs
@@ -365,7 +365,7 @@ impl<'a> Scrollbar<'a> {
     /// respective setters to change their value.
     ///
     /// This is a fluent setter method which must be chained or used as it consumes self
-    #[allow(clippy::needless_pass_by_value)] // Breaking change
+    #[expect(clippy::needless_pass_by_value)] // Breaking change
     #[must_use = "method moves the value of self and returns the modified value"]
     pub const fn symbols(mut self, symbols: Set) -> Self {
         self.thumb_symbol = symbols.thumb;

--- a/ratatui-widgets/src/sparkline.rs
+++ b/ratatui-widgets/src/sparkline.rs
@@ -553,7 +553,6 @@ mod tests {
     #[test]
     fn it_does_not_panic_if_max_is_set_to_zero() {
         // see https://github.com/rust-lang/rust-clippy/issues/13191
-        #[allow(clippy::unnecessary_min_or_max)]
         let widget = Sparkline::default().data([0, 1, 2]).max(0);
         let buffer = render(widget, 6);
         assert_eq!(buffer, Buffer::with_lines(["   xxx"]));

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -1105,7 +1105,7 @@ mod tests {
 
         // ensure that code that uses &[] continues to work as there is a large amount of code that
         // uses this pattern
-        #[allow(clippy::needless_borrows_for_generic_args)]
+        #[expect(clippy::needless_borrows_for_generic_args)]
         let table = Table::default().widths(&[Constraint::Length(100)]);
         assert_eq!(table.widths, [Constraint::Length(100)]);
 
@@ -1114,7 +1114,7 @@ mod tests {
 
         // ensure that code that uses &some_vec continues to work as there is a large amount of code
         // that uses this pattern
-        #[allow(clippy::needless_borrows_for_generic_args)]
+        #[expect(clippy::needless_borrows_for_generic_args)]
         let table = Table::default().widths(&vec![Constraint::Length(100)]);
         assert_eq!(table.widths, [Constraint::Length(100)]);
 
@@ -1157,7 +1157,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     fn highlight_style() {
         let style = Style::default().red().italic();
         let table = Table::default().highlight_style(style);
@@ -1806,8 +1806,6 @@ mod tests {
             );
         }
 
-        /// NOTE: `segment_size` is deprecated use flex instead!
-        #[allow(deprecated)]
         #[test]
         fn underconstrained_segment_size() {
             let table = Table::default().widths([Min(10), Min(10), Min(1)]);
@@ -1980,7 +1978,7 @@ mod tests {
             );
         }
 
-        #[allow(clippy::too_many_lines)]
+        #[expect(clippy::too_many_lines)]
         #[test]
         fn insufficient_area_highlight_symbol_and_column_spacing_allocation() {
             // column spacing is prioritized over every other constraint

--- a/ratatui/src/widgets.rs
+++ b/ratatui/src/widgets.rs
@@ -87,7 +87,6 @@ pub trait FrameExt {
     /// ```
     ///
     /// [`Layout`]: crate::layout::Layout
-    #[allow(clippy::needless_pass_by_value)]
     fn render_widget_ref<W: WidgetRef>(&mut self, widget: W, area: Rect);
 
     /// Render a [`StatefulWidgetRef`] to the current buffer using
@@ -117,7 +116,6 @@ pub trait FrameExt {
     /// # }
     /// ```
     /// [`Layout`]: crate::layout::Layout
-    #[allow(clippy::needless_pass_by_value)]
     fn render_stateful_widget_ref<W>(&mut self, widget: W, area: Rect, state: &mut W::State)
     where
         W: StatefulWidgetRef;
@@ -125,12 +123,10 @@ pub trait FrameExt {
 
 #[cfg(feature = "unstable-widget-ref")]
 impl FrameExt for ratatui_core::terminal::Frame<'_> {
-    #[allow(clippy::needless_pass_by_value)]
     fn render_widget_ref<W: WidgetRef>(&mut self, widget: W, area: Rect) {
         widget.render_ref(area, self.buffer_mut());
     }
 
-    #[allow(clippy::needless_pass_by_value)]
     fn render_stateful_widget_ref<W>(&mut self, widget: W, area: Rect, state: &mut W::State)
     where
         W: StatefulWidgetRef,


### PR DESCRIPTION
Drop no longer needed overrides.

Supported since 1.81.0

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
