### PR TITLE
fix: avoid unnecessary imports in minimal build

### DIFF
--- a/ratatui-core/src/backend.rs
+++ b/ratatui-core/src/backend.rs
@@ -100,7 +100,6 @@
 //! [Examples]: https://github.com/ratatui/ratatui/tree/main/ratatui/examples/README.md
 //! [Backend Comparison]: https://ratatui.rs/concepts/backends/comparison/
 //! [Ratatui Website]: https://ratatui.rs
-use core::ops;
 use std::io;
 
 use strum::{Display, EnumString};
@@ -342,7 +341,11 @@ pub trait Backend {
     /// For examples of how this function is expected to work, refer to the tests for
     /// [`TestBackend::scroll_region_up`].
     #[cfg(feature = "scrolling-regions")]
-    fn scroll_region_up(&mut self, region: ops::Range<u16>, line_count: u16) -> io::Result<()>;
+    fn scroll_region_up(
+        &mut self,
+        region: core::ops::Range<u16>,
+        line_count: u16,
+    ) -> io::Result<()>;
 
     /// Scroll a region of the screen downwards, where a region is specified by a (half-open) range
     /// of rows.
@@ -363,7 +366,11 @@ pub trait Backend {
     /// For examples of how this function is expected to work, refer to the tests for
     /// [`TestBackend::scroll_region_down`].
     #[cfg(feature = "scrolling-regions")]
-    fn scroll_region_down(&mut self, region: ops::Range<u16>, line_count: u16) -> io::Result<()>;
+    fn scroll_region_down(
+        &mut self,
+        region: core::ops::Range<u16>,
+        line_count: u16,
+    ) -> io::Result<()>;
 }
 
 #[cfg(test)]

--- a/ratatui-core/src/backend/test.rs
+++ b/ratatui-core/src/backend/test.rs
@@ -2,7 +2,7 @@
 //! It is used in the integration tests to verify the correctness of the library.
 
 use core::fmt::{self, Write};
-use core::{iter, ops};
+use core::iter;
 use std::io;
 
 use unicode_width::UnicodeWidthStr;
@@ -364,7 +364,11 @@ impl Backend for TestBackend {
     }
 
     #[cfg(feature = "scrolling-regions")]
-    fn scroll_region_up(&mut self, region: ops::Range<u16>, scroll_by: u16) -> io::Result<()> {
+    fn scroll_region_up(
+        &mut self,
+        region: core::ops::Range<u16>,
+        scroll_by: u16,
+    ) -> io::Result<()> {
         let width: usize = self.buffer.area.width.into();
         let cell_region_start = width * region.start.min(self.buffer.area.height) as usize;
         let cell_region_end = width * region.end.min(self.buffer.area.height) as usize;
@@ -410,7 +414,11 @@ impl Backend for TestBackend {
     }
 
     #[cfg(feature = "scrolling-regions")]
-    fn scroll_region_down(&mut self, region: ops::Range<u16>, scroll_by: u16) -> io::Result<()> {
+    fn scroll_region_down(
+        &mut self,
+        region: core::ops::Range<u16>,
+        scroll_by: u16,
+    ) -> io::Result<()> {
         let width: usize = self.buffer.area.width.into();
         let cell_region_start = width * region.start.min(self.buffer.area.height) as usize;
         let cell_region_end = width * region.end.min(self.buffer.area.height) as usize;
@@ -1023,7 +1031,7 @@ mod tests {
         #[case([A, B, C, D, E], 2..2, 2, [],                    [A, B, C, D, E])]
         fn scroll_region_up<const L: usize, const M: usize, const N: usize>(
             #[case] initial_screen: [&'static str; L],
-            #[case] range: ops::Range<u16>,
+            #[case] range: core::ops::Range<u16>,
             #[case] scroll_by: u16,
             #[case] expected_scrollback: [&'static str; M],
             #[case] expected_buffer: [&'static str; N],
@@ -1057,7 +1065,7 @@ mod tests {
         #[case([A, B, C, D, E], 2..2, 2, [A, B, C, D, E])]
         fn scroll_region_down<const M: usize, const N: usize>(
             #[case] initial_screen: [&'static str; M],
-            #[case] range: ops::Range<u16>,
+            #[case] range: core::ops::Range<u16>,
             #[case] scroll_by: u16,
             #[case] expected_buffer: [&'static str; N],
         ) {


### PR DESCRIPTION
core::ops::Range is only used with the feature `scrolling-regions`. Ensure a minimal `cargo check` reports no warnings.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
