### PR TITLE
feat(no_std)!: option to disable layout cache for `no_std` compatibility

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -84,6 +84,20 @@ This is a quick summary of the sections below:
 
 ## Unreleased (0.30.0)
 
+## Disabling `default-features` will now disable layout cache, which can have a negative impact on performance ([#1795])
+
+[#1795]: https://github.com/ratatui/ratatui/pull/1795
+
+Layout cache is now opt-in in `ratatui-core` and enabled by default in `ratatui`.
+If app doesn't make use of `no_std`-compatibility, and disables `default-feature`,
+it is recommended to explicitly re-enable layout cache.
+Not doing so may impact performance.
+
+```diff
+- ratatui = { version = "0.29.0", default-features = false }
++ ratatui = { version = "0.30.0", default-features = false, features = ["ratatui-core/thread-local-cache"] }
+```
+
 ## The MSRV is now 1.81.0 ([#1786])
 
 [#1786]: https://github.com/ratatui/ratatui/pull/1786

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -84,7 +84,7 @@ This is a quick summary of the sections below:
 
 ## Unreleased (0.30.0)
 
-## Disabling `default-features` will now disable layout cache, which can have a negative impact on performance ([#1795])
+### Disabling `default-features` will now disable layout cache, which can have a negative impact on performance ([#1795])
 
 [#1795]: https://github.com/ratatui/ratatui/pull/1795
 

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -19,6 +19,7 @@ This is a quick summary of the sections below:
   - `Backend` now requires an associated `Error` type and `clear_region` method
   - `Backend` now uses `Self::Error` for error handling instead of `std::io::Error`
   - `Terminal<B>` now uses `B::Error` for error handling instead of `std::io::Error`
+  - Disabling `default-features` will now disable layout cache, which can have a negative impact on performance
 - [v0.29.0](#v0290)
   - `Sparkline::data` takes `IntoIterator<Item = SparklineBar>` instead of `&[u64]` and is no longer const
   - Removed public fields from `Rect` iterators

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -88,10 +88,9 @@ This is a quick summary of the sections below:
 
 [#1795]: https://github.com/ratatui/ratatui/pull/1795
 
-Layout cache is now opt-in in `ratatui-core` and enabled by default in `ratatui`.
-If app doesn't make use of `no_std`-compatibility, and disables `default-feature`,
-it is recommended to explicitly re-enable layout cache.
-Not doing so may impact performance.
+Layout cache is now opt-in in `ratatui-core` and enabled by default in `ratatui`. If app doesn't
+make use of `no_std`-compatibility, and disables `default-feature`, it is recommended to explicitly
+re-enable layout cache. Not doing so may impact performance.
 
 ```diff
 - ratatui = { version = "0.29.0", default-features = false }

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -21,6 +21,7 @@ This is a quick summary of the sections below:
   - `Terminal<B>` now uses `B::Error` for error handling instead of `std::io::Error`
   - `TestBackend` now uses `core::convert::Infallible` for error handling instead of `std::io::Error`
   - Disabling `default-features` will now disable layout cache, which can have a negative impact on performance
+  - `Layout::init_cache` and `Layout::DEFAULT_CACHE_SIZE` are now only available if `layout-cache` feature is enabled
 - [v0.29.0](#v0290)
   - `Sparkline::data` takes `IntoIterator<Item = SparklineBar>` instead of `&[u64]` and is no longer const
   - Removed public fields from `Rect` iterators
@@ -85,6 +86,13 @@ This is a quick summary of the sections below:
 
 ## Unreleased (0.30.0)
 
+### `Layout::init_cache` and `Layout::DEFAULT_CACHE_SIZE` are now only available if `layout-cache` feature is enabled ([#1795])
+
+[#1795]: https://github.com/ratatui/ratatui/pull/1795
+
+Previously, `Layout::init_cache` and `Layout::DEFAULT_CACHE_SIZE` were available independently of
+enabled feature flags.
+
 ### Disabling `default-features` will now disable layout cache, which can have a negative impact on performance ([#1795])
 
 [#1795]: https://github.com/ratatui/ratatui/pull/1795
@@ -95,7 +103,7 @@ re-enable layout cache. Not doing so may impact performance.
 
 ```diff
 - ratatui = { version = "0.29.0", default-features = false }
-+ ratatui = { version = "0.30.0", default-features = false, features = ["ratatui-core/layout-cache"] }
++ ratatui = { version = "0.30.0", default-features = false, features = ["layout-cache"] }
 ```
 
 ### `TestBackend` now uses `core::convert::Infallible` for error handling instead of `std::io::Error` ([#1823])

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -95,7 +95,7 @@ Not doing so may impact performance.
 
 ```diff
 - ratatui = { version = "0.29.0", default-features = false }
-+ ratatui = { version = "0.30.0", default-features = false, features = ["ratatui-core/thread-local-cache"] }
++ ratatui = { version = "0.30.0", default-features = false, features = ["ratatui-core/layout-cache"] }
 ```
 
 ## The MSRV is now 1.81.0 ([#1786])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,12 +667,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,14 +2618,12 @@ dependencies = [
  "anstyle",
  "bitflags 2.9.0",
  "compact_str",
- "critical-section",
  "document-features",
  "hashbrown",
  "indoc",
  "itertools 0.13.0",
  "kasuari",
  "lru",
- "once_cell",
  "palette",
  "pretty_assertions",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2618,12 +2624,14 @@ dependencies = [
  "anstyle",
  "bitflags 2.9.0",
  "compact_str",
+ "critical-section",
  "document-features",
  "hashbrown",
  "indoc",
  "itertools 0.13.0",
  "kasuari",
  "lru",
+ "once_cell",
  "palette",
  "pretty_assertions",
  "rstest",

--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -59,6 +59,8 @@ thiserror = "2"
 unicode-segmentation.workspace = true
 unicode-truncate = "2"
 unicode-width.workspace = true
+once_cell = "1.21.3"
+critical-section = "1.2.0"
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -27,8 +27,8 @@ default = []
 ## enables std
 std = []
 
-## enables layout cache based on thread-local LRU
-thread-local-cache = ["std"]
+## enables layout cache
+layout-cache = ["std"]
 
 ## enables conversions to / from colors, modifiers, and styles in the ['anstyle'] crate
 anstyle = ["dep:anstyle"]

--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -22,7 +22,13 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
+default = ["tls-layout-cache"]
+
+## enables std support
+std = []
+
+## enables layout cache based on thread-local storage
+tls-layout-cache = ["std"]
 
 ## enables conversions to / from colors, modifiers, and styles in the ['anstyle'] crate
 anstyle = ["dep:anstyle"]
@@ -46,12 +52,14 @@ serde = ["dep:serde", "bitflags/serde", "compact_str/serde"]
 anstyle = { version = "1", optional = true }
 bitflags = "2.3"
 compact_str = "0.9.0"
+critical-section = "1.2.0"
 document-features = { workspace = true, optional = true }
 hashbrown = "0.15.2"
 indoc.workspace = true
 itertools.workspace = true
 kasuari = "0.4.0"
 lru = "0.12.0"
+once_cell = "1.21.3"
 palette = { version = "0.7.6", optional = true }
 serde = { workspace = true, optional = true }
 strum.workspace = true
@@ -59,13 +67,12 @@ thiserror = "2"
 unicode-segmentation.workspace = true
 unicode-truncate = "2"
 unicode-width.workspace = true
-once_cell = "1.21.3"
-critical-section = "1.2.0"
 
 [dev-dependencies]
 pretty_assertions.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
+critical-section = {version = "1.2.0", features = ["std"]}
 
 [lints]
 workspace = true

--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -69,10 +69,10 @@ unicode-truncate = "2"
 unicode-width.workspace = true
 
 [dev-dependencies]
+critical-section = { version = "1.2.0", features = ["std"] }
 pretty_assertions.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
-critical-section = {version = "1.2.0", features = ["std"]}
 
 [lints]
 workspace = true

--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -22,13 +22,13 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["tls-layout-cache"]
+default = []
 
-## enables std support
+## enables std
 std = []
 
-## enables layout cache based on thread-local storage
-tls-layout-cache = ["std"]
+## enables layout cache based on thread-local LRU
+thread-local-cache = ["std"]
 
 ## enables conversions to / from colors, modifiers, and styles in the ['anstyle'] crate
 anstyle = ["dep:anstyle"]
@@ -52,14 +52,12 @@ serde = ["dep:serde", "bitflags/serde", "compact_str/serde"]
 anstyle = { version = "1", optional = true }
 bitflags = "2.3"
 compact_str = "0.9.0"
-critical-section = "1.2.0"
 document-features = { workspace = true, optional = true }
 hashbrown = "0.15.2"
 indoc.workspace = true
 itertools.workspace = true
 kasuari = "0.4.0"
 lru = "0.12.0"
-once_cell = "1.21.3"
 palette = { version = "0.7.6", optional = true }
 serde = { workspace = true, optional = true }
 strum.workspace = true
@@ -69,7 +67,6 @@ unicode-truncate = "2"
 unicode-width.workspace = true
 
 [dev-dependencies]
-critical-section = { version = "1.2.0", features = ["std"] }
 pretty_assertions.workspace = true
 rstest.workspace = true
 serde_json.workspace = true

--- a/ratatui-core/src/layout/layout.rs
+++ b/ratatui-core/src/layout/layout.rs
@@ -296,7 +296,7 @@ impl Layout {
     /// By default, the cache size is [`Self::DEFAULT_CACHE_SIZE`].
     pub fn init_cache(#[allow(unused_variables)] cache_size: NonZeroUsize) {
         #[cfg(feature = "thread-local-cache")]
-        with_layout_cache(|c| c.resize(cache_size));
+        with_layout_cache(|cache| cache.resize(cache_size));
     }
 
     /// Set the direction of the layout.
@@ -672,9 +672,9 @@ impl Layout {
 
         #[cfg(feature = "thread-local-cache")]
         {
-            with_layout_cache(|c| {
+            with_layout_cache(|cache| {
                 let key = (area, self.clone());
-                c.get_or_insert(key, split).clone()
+                cache.get_or_insert(key, split).clone()
             })
         }
 
@@ -1224,14 +1224,14 @@ mod tests {
     #[test]
     #[cfg(feature = "thread-local-cache")]
     fn cache_size() {
-        with_layout_cache(|c| {
-            assert_eq!(c.cap().get(), Layout::DEFAULT_CACHE_SIZE);
+        with_layout_cache(|cache| {
+            assert_eq!(cache.cap().get(), Layout::DEFAULT_CACHE_SIZE);
         });
 
         Layout::init_cache(NonZeroUsize::new(10).unwrap());
 
-        with_layout_cache(|c| {
-            assert_eq!(c.cap().get(), 10);
+        with_layout_cache(|cache| {
+            assert_eq!(cache.cap().get(), 10);
         });
     }
 

--- a/ratatui-core/src/layout/layout.rs
+++ b/ratatui-core/src/layout/layout.rs
@@ -283,7 +283,7 @@ impl Layout {
     ///
     /// By default, the cache size is [`Self::DEFAULT_CACHE_SIZE`].
     #[cfg(feature = "layout-cache")]
-    pub fn init_cache(#[allow(unused_variables)] cache_size: NonZeroUsize) {
+    pub fn init_cache(cache_size: NonZeroUsize) {
         LAYOUT_CACHE.with_borrow_mut(|cache| cache.resize(cache_size));
     }
 

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -26,15 +26,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 ## By default, we enable the crossterm backend as this is a reasonable choice for most applications
 ## as it is supported on Linux/Mac/Windows systems. We also enable the `underline-color` feature
 ## which allows you to set the underline color of text, the `macros` feature which provides
-## some useful macros and `ratatui-core/thread-local-cache` which speeds up layout cache calculations
+## some useful macros and `ratatui-core/layout-cache` which speeds up layout cache calculations
 ## in `std`-enabled environments.
-default = [
-  "crossterm",
-  "underline-color",
-  "all-widgets",
-  "macros",
-  "ratatui-core/thread-local-cache",
-]
+default = ["crossterm", "underline-color", "all-widgets", "macros", "ratatui-core/layout-cache"]
 #! Generally an application will only use one backend, so you should only enable one of the following features:
 ## enables the [`CrosstermBackend`](backend::CrosstermBackend) backend and adds a dependency on [`crossterm`].
 crossterm = ["dep:ratatui-crossterm"]

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -25,9 +25,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 #!
 ## By default, we enable the crossterm backend as this is a reasonable choice for most applications
 ## as it is supported on Linux/Mac/Windows systems. We also enable the `underline-color` feature
-## which allows you to set the underline color of text and the `macros` feature which provides
-## some useful macros.
-default = ["crossterm", "underline-color", "all-widgets", "macros"]
+## which allows you to set the underline color of text, the `macros` feature which provides
+## some useful macros and `ratatui-core/thread-local-cache` which speeds up layout cache calculations
+## in `std`-enabled environments.
+default = [
+  "crossterm",
+  "underline-color",
+  "all-widgets",
+  "macros",
+  "ratatui-core/thread-local-cache",
+]
 #! Generally an application will only use one backend, so you should only enable one of the following features:
 ## enables the [`CrosstermBackend`](backend::CrosstermBackend) backend and adds a dependency on [`crossterm`].
 crossterm = ["dep:ratatui-crossterm"]

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -26,9 +26,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 ## By default, we enable the crossterm backend as this is a reasonable choice for most applications
 ## as it is supported on Linux/Mac/Windows systems. We also enable the `underline-color` feature
 ## which allows you to set the underline color of text, the `macros` feature which provides
-## some useful macros and `ratatui-core/layout-cache` which speeds up layout cache calculations
+## some useful macros and `layout-cache` which speeds up layout cache calculations
 ## in `std`-enabled environments.
-default = ["crossterm", "underline-color", "all-widgets", "macros", "ratatui-core/layout-cache"]
+default = ["crossterm", "underline-color", "all-widgets", "macros", "layout-cache"]
 #! Generally an application will only use one backend, so you should only enable one of the following features:
 ## enables the [`CrosstermBackend`](backend::CrosstermBackend) backend and adds a dependency on [`crossterm`].
 crossterm = ["dep:ratatui-crossterm"]
@@ -48,6 +48,9 @@ serde = [
   "ratatui-termion?/serde",
   "ratatui-termwiz?/serde",
 ]
+
+## enables layout cache
+layout-cache = ["ratatui-core/layout-cache"]
 
 ## enables conversions from colors in the [`palette`] crate to [`Color`](crate::style::Color).
 palette = ["ratatui-core/palette", "dep:palette"]

--- a/xtask/src/commands/backend.rs
+++ b/xtask/src/commands/backend.rs
@@ -61,7 +61,7 @@ impl Run for TestBackend {
             "--all-targets",
             "--no-default-features",
             "--features",
-            format!("{backend},ratatui-core/thread-local-cache"),
+            format!("{backend},ratatui-core/thread-local-cache").as_str(),
         ])?;
         run_cargo(vec![
             "test",

--- a/xtask/src/commands/backend.rs
+++ b/xtask/src/commands/backend.rs
@@ -61,7 +61,7 @@ impl Run for TestBackend {
             "--all-targets",
             "--no-default-features",
             "--features",
-            format!("{backend},ratatui-core/layout-cache").as_str(),
+            format!("{backend},layout-cache").as_str(),
         ])?;
         run_cargo(vec![
             "test",

--- a/xtask/src/commands/backend.rs
+++ b/xtask/src/commands/backend.rs
@@ -54,6 +54,15 @@ impl Run for TestBackend {
             Backend::Termion => "termion",
             Backend::Termwiz => "termwiz",
         };
+        // This is a temporary hack to run tests both with and without layout cache.
+        // https://github.com/ratatui/ratatui/issues/1820
+        run_cargo(vec![
+            "test",
+            "--all-targets",
+            "--no-default-features",
+            "--features",
+            [backend, "ratatui-core/thread-local-cache"].join(",").as_str(),
+        ])?;
         run_cargo(vec![
             "test",
             "--all-targets",

--- a/xtask/src/commands/backend.rs
+++ b/xtask/src/commands/backend.rs
@@ -61,7 +61,9 @@ impl Run for TestBackend {
             "--all-targets",
             "--no-default-features",
             "--features",
-            [backend, "ratatui-core/thread-local-cache"].join(",").as_str(),
+            [backend, "ratatui-core/thread-local-cache"]
+                .join(",")
+                .as_str(),
         ])?;
         run_cargo(vec![
             "test",

--- a/xtask/src/commands/backend.rs
+++ b/xtask/src/commands/backend.rs
@@ -61,7 +61,7 @@ impl Run for TestBackend {
             "--all-targets",
             "--no-default-features",
             "--features",
-            format!("{backend},ratatui-core/thread-local-cache").as_str(),
+            format!("{backend},ratatui-core/layout-cache").as_str(),
         ])?;
         run_cargo(vec![
             "test",

--- a/xtask/src/commands/backend.rs
+++ b/xtask/src/commands/backend.rs
@@ -61,9 +61,7 @@ impl Run for TestBackend {
             "--all-targets",
             "--no-default-features",
             "--features",
-            [backend, "ratatui-core/thread-local-cache"]
-                .join(",")
-                .as_str(),
+            format!("{backend},ratatui-core/thread-local-cache"),
         ])?;
         run_cargo(vec![
             "test",


### PR DESCRIPTION
Resolves #1780 

BREAKING CHANGE: Disabling `default-features` will now disable layout cache, which can have a negative impact on performance. `Layout::init_cache` and `Layout::DEFAULT_CACHE_SIZE` are now only available if `layout-cache` feature is enabled.
