### PR TITLE
chore: Add 'const' to functions where possible.

### DIFF
--- a/examples/apps/constraint-explorer/src/main.rs
+++ b/examples/apps/constraint-explorer/src/main.rs
@@ -197,15 +197,15 @@ impl App {
         self.selected_index = index;
     }
 
-    fn increment_spacing(&mut self) {
+    const fn increment_spacing(&mut self) {
         self.spacing = self.spacing.saturating_add(1);
     }
 
-    fn decrement_spacing(&mut self) {
+    const fn decrement_spacing(&mut self) {
         self.spacing = self.spacing.saturating_sub(1);
     }
 
-    fn exit(&mut self) {
+    const fn exit(&mut self) {
         self.mode = AppMode::Quit;
     }
 

--- a/examples/apps/constraints/src/main.rs
+++ b/examples/apps/constraints/src/main.rs
@@ -81,7 +81,7 @@ impl App {
         Ok(())
     }
 
-    fn update_max_scroll_offset(&mut self) {
+    const fn update_max_scroll_offset(&mut self) {
         self.max_scroll_offset = (self.selected_tab.get_example_count() - 1) * EXAMPLE_HEIGHT;
     }
 
@@ -108,7 +108,7 @@ impl App {
         Ok(())
     }
 
-    fn quit(&mut self) {
+    const fn quit(&mut self) {
         self.state = AppState::Quit;
     }
 
@@ -124,7 +124,7 @@ impl App {
         self.scroll_offset = 0;
     }
 
-    fn up(&mut self) {
+    const fn up(&mut self) {
         self.scroll_offset = self.scroll_offset.saturating_sub(1);
     }
 
@@ -135,11 +135,11 @@ impl App {
             .min(self.max_scroll_offset);
     }
 
-    fn top(&mut self) {
+    const fn top(&mut self) {
         self.scroll_offset = 0;
     }
 
-    fn bottom(&mut self) {
+    const fn bottom(&mut self) {
         self.scroll_offset = self.max_scroll_offset;
     }
 }

--- a/examples/apps/flex/src/main.rs
+++ b/examples/apps/flex/src/main.rs
@@ -194,7 +194,7 @@ impl App {
         self.selected_tab = self.selected_tab.previous();
     }
 
-    fn up(&mut self) {
+    const fn up(&mut self) {
         self.scroll_offset = self.scroll_offset.saturating_sub(1);
     }
 
@@ -205,7 +205,7 @@ impl App {
             .min(max_scroll_offset());
     }
 
-    fn top(&mut self) {
+    const fn top(&mut self) {
         self.scroll_offset = 0;
     }
 
@@ -213,15 +213,15 @@ impl App {
         self.scroll_offset = max_scroll_offset();
     }
 
-    fn increment_spacing(&mut self) {
+    const fn increment_spacing(&mut self) {
         self.spacing = self.spacing.saturating_add(1);
     }
 
-    fn decrement_spacing(&mut self) {
+    const fn decrement_spacing(&mut self) {
         self.spacing = self.spacing.saturating_sub(1);
     }
 
-    fn quit(&mut self) {
+    const fn quit(&mut self) {
         self.state = AppState::Quit;
     }
 }

--- a/examples/apps/gauge/src/main.rs
+++ b/examples/apps/gauge/src/main.rs
@@ -93,11 +93,11 @@ impl App {
         Ok(())
     }
 
-    fn start(&mut self) {
+    const fn start(&mut self) {
         self.state = AppState::Started;
     }
 
-    fn quit(&mut self) {
+    const fn quit(&mut self) {
         self.state = AppState::Quitting;
     }
 }

--- a/examples/apps/input-form/src/main.rs
+++ b/examples/apps/input-form/src/main.rs
@@ -243,7 +243,7 @@ impl AgeField {
         self.value = self.value.saturating_add(1).min(Self::MAX);
     }
 
-    fn decrement(&mut self) {
+    const fn decrement(&mut self) {
         self.value = self.value.saturating_sub(1);
     }
 

--- a/examples/apps/table/src/main.rs
+++ b/examples/apps/table/src/main.rs
@@ -158,16 +158,16 @@ impl App {
         self.state.select_previous_column();
     }
 
-    pub fn next_color(&mut self) {
+    pub const fn next_color(&mut self) {
         self.color_index = (self.color_index + 1) % PALETTES.len();
     }
 
-    pub fn previous_color(&mut self) {
+    pub const fn previous_color(&mut self) {
         let count = PALETTES.len();
         self.color_index = (self.color_index + count - 1) % count;
     }
 
-    pub fn set_colors(&mut self) {
+    pub const fn set_colors(&mut self) {
         self.colors = TableColors::new(&PALETTES[self.color_index]);
     }
 

--- a/examples/apps/todo-list/src/main.rs
+++ b/examples/apps/todo-list/src/main.rs
@@ -128,7 +128,7 @@ impl App {
         }
     }
 
-    fn select_none(&mut self) {
+    const fn select_none(&mut self) {
         self.todo_list.state.select(None);
     }
 
@@ -139,11 +139,11 @@ impl App {
         self.todo_list.state.select_previous();
     }
 
-    fn select_first(&mut self) {
+    const fn select_first(&mut self) {
         self.todo_list.state.select_first();
     }
 
-    fn select_last(&mut self) {
+    const fn select_last(&mut self) {
         self.todo_list.state.select_last();
     }
 

--- a/examples/apps/user-input/src/main.rs
+++ b/examples/apps/user-input/src/main.rs
@@ -117,7 +117,7 @@ impl App {
         new_cursor_pos.clamp(0, self.input.chars().count())
     }
 
-    fn reset_cursor(&mut self) {
+    const fn reset_cursor(&mut self) {
         self.character_index = 0;
     }
 

--- a/ratatui-core/src/buffer/cell.rs
+++ b/ratatui-core/src/buffer/cell.rs
@@ -83,13 +83,13 @@ impl Cell {
     }
 
     /// Sets the foreground color of the cell.
-    pub fn set_fg(&mut self, color: Color) -> &mut Self {
+    pub const fn set_fg(&mut self, color: Color) -> &mut Self {
         self.fg = color;
         self
     }
 
     /// Sets the background color of the cell.
-    pub fn set_bg(&mut self, color: Color) -> &mut Self {
+    pub const fn set_bg(&mut self, color: Color) -> &mut Self {
         self.bg = color;
         self
     }
@@ -132,7 +132,7 @@ impl Cell {
     ///
     /// This is helpful when it is necessary to prevent the buffer from overwriting a cell that is
     /// covered by an image from some terminal graphics protocol (Sixel / iTerm / Kitty ...).
-    pub fn set_skip(&mut self, skip: bool) -> &mut Self {
+    pub const fn set_skip(&mut self, skip: bool) -> &mut Self {
         self.skip = skip;
         self
     }

--- a/ratatui-core/src/terminal/frame.rs
+++ b/ratatui-core/src/terminal/frame.rs
@@ -158,7 +158,7 @@ impl Frame<'_> {
     }
 
     /// Gets the buffer that this `Frame` draws into as a mutable reference.
-    pub fn buffer_mut(&mut self) -> &mut Buffer {
+    pub const fn buffer_mut(&mut self) -> &mut Buffer {
         self.buffer
     }
 

--- a/ratatui-core/src/terminal/terminal.rs
+++ b/ratatui-core/src/terminal/terminal.rs
@@ -166,7 +166,7 @@ where
     }
 
     /// Get a Frame object which provides a consistent view into the terminal state for rendering.
-    pub fn get_frame(&mut self) -> Frame {
+    pub const fn get_frame(&mut self) -> Frame {
         let count = self.frame_count;
         Frame {
             cursor_position: None,
@@ -177,7 +177,7 @@ where
     }
 
     /// Gets the current buffer as a mutable reference.
-    pub fn current_buffer_mut(&mut self) -> &mut Buffer {
+    pub const fn current_buffer_mut(&mut self) -> &mut Buffer {
         &mut self.buffers[self.current]
     }
 
@@ -187,7 +187,7 @@ where
     }
 
     /// Gets the backend as a mutable reference
-    pub fn backend_mut(&mut self) -> &mut B {
+    pub const fn backend_mut(&mut self) -> &mut B {
         &mut self.backend
     }
 

--- a/ratatui-crossterm/src/lib.rs
+++ b/ratatui-crossterm/src/lib.rs
@@ -133,7 +133,7 @@ where
         feature = "backend-writer",
         issue = "https://github.com/ratatui/ratatui/pull/991"
     )]
-    pub fn writer_mut(&mut self) -> &mut W {
+    pub const fn writer_mut(&mut self) -> &mut W {
         &mut self.writer
     }
 }

--- a/ratatui-termion/src/lib.rs
+++ b/ratatui-termion/src/lib.rs
@@ -118,7 +118,7 @@ where
         feature = "backend-writer",
         issue = "https://github.com/ratatui/ratatui/pull/991"
     )]
-    pub fn writer_mut(&mut self) -> &mut W {
+    pub const fn writer_mut(&mut self) -> &mut W {
         &mut self.writer
     }
 }

--- a/ratatui-termwiz/src/lib.rs
+++ b/ratatui-termwiz/src/lib.rs
@@ -113,7 +113,7 @@ impl TermwizBackend {
     }
 
     /// Returns a mutable reference to the buffered terminal used by the backend.
-    pub fn buffered_terminal_mut(&mut self) -> &mut BufferedTerminal<SystemTerminal> {
+    pub const fn buffered_terminal_mut(&mut self) -> &mut BufferedTerminal<SystemTerminal> {
         &mut self.buffered_terminal
     }
 }

--- a/ratatui-widgets/examples/line_gauge.rs
+++ b/ratatui-widgets/examples/line_gauge.rs
@@ -92,7 +92,7 @@ impl App {
         Ok(())
     }
 
-    fn reset(&mut self) {
+    const fn reset(&mut self) {
         self.progress = 0.0;
         self.progress_columns = 0;
         self.state = AppState::Stop;

--- a/ratatui-widgets/src/canvas.rs
+++ b/ratatui-widgets/src/canvas.rs
@@ -436,7 +436,7 @@ impl Painter<'_, '_> {
     /// let mut painter = Painter::from(&mut ctx);
     /// assert_eq!(painter.bounds(), (&[0.0, 2.0], &[0.0, 2.0]));
     /// ```
-    pub fn bounds(&self) -> (&[f64; 2], &[f64; 2]) {
+    pub const fn bounds(&self) -> (&[f64; 2], &[f64; 2]) {
         (&self.context.x_bounds, &self.context.y_bounds)
     }
 }

--- a/ratatui-widgets/src/list/state.rs
+++ b/ratatui-widgets/src/list/state.rs
@@ -106,7 +106,7 @@ impl ListState {
     /// let mut state = ListState::default();
     /// *state.offset_mut() = 1;
     /// ```
-    pub fn offset_mut(&mut self) -> &mut usize {
+    pub const fn offset_mut(&mut self) -> &mut usize {
         &mut self.offset
     }
 
@@ -138,7 +138,7 @@ impl ListState {
     /// let mut state = ListState::default();
     /// *state.selected_mut() = Some(1);
     /// ```
-    pub fn selected_mut(&mut self) -> &mut Option<usize> {
+    pub const fn selected_mut(&mut self) -> &mut Option<usize> {
         &mut self.selected
     }
 
@@ -154,7 +154,7 @@ impl ListState {
     /// let mut state = ListState::default();
     /// state.select(Some(1));
     /// ```
-    pub fn select(&mut self, index: Option<usize>) {
+    pub const fn select(&mut self, index: Option<usize>) {
         self.selected = index;
         if index.is_none() {
             self.offset = 0;
@@ -210,7 +210,7 @@ impl ListState {
     /// let mut state = ListState::default();
     /// state.select_first();
     /// ```
-    pub fn select_first(&mut self) {
+    pub const fn select_first(&mut self) {
         self.select(Some(0));
     }
 
@@ -227,7 +227,7 @@ impl ListState {
     /// let mut state = ListState::default();
     /// state.select_last();
     /// ```
-    pub fn select_last(&mut self) {
+    pub const fn select_last(&mut self) {
         self.select(Some(usize::MAX));
     }
 

--- a/ratatui-widgets/src/reflow.rs
+++ b/ratatui-widgets/src/reflow.rs
@@ -267,7 +267,7 @@ where
     }
 
     /// Set the horizontal offset to skip render.
-    pub fn set_horizontal_offset(&mut self, horizontal_offset: u16) {
+    pub const fn set_horizontal_offset(&mut self, horizontal_offset: u16) {
         self.horizontal_offset = horizontal_offset;
     }
 }

--- a/ratatui-widgets/src/scrollbar.rs
+++ b/ratatui-widgets/src/scrollbar.rs
@@ -456,7 +456,7 @@ impl ScrollbarState {
     }
 
     /// Decrements the scroll position by one, ensuring it doesn't go below zero.
-    pub fn prev(&mut self) {
+    pub const fn prev(&mut self) {
         self.position = self.position.saturating_sub(1);
     }
 
@@ -469,12 +469,12 @@ impl ScrollbarState {
     }
 
     /// Sets the scroll position to the start of the scrollable content.
-    pub fn first(&mut self) {
+    pub const fn first(&mut self) {
         self.position = 0;
     }
 
     /// Sets the scroll position to the end of the scrollable content.
-    pub fn last(&mut self) {
+    pub const fn last(&mut self) {
         self.position = self.content_length.saturating_sub(1);
     }
 

--- a/ratatui-widgets/src/table/state.rs
+++ b/ratatui-widgets/src/table/state.rs
@@ -182,7 +182,7 @@ impl TableState {
     /// let mut state = TableState::default();
     /// *state.offset_mut() = 1;
     /// ```
-    pub fn offset_mut(&mut self) -> &mut usize {
+    pub const fn offset_mut(&mut self) -> &mut usize {
         &mut self.offset
     }
 
@@ -247,7 +247,7 @@ impl TableState {
     /// let mut state = TableState::default();
     /// *state.selected_mut() = Some(1);
     /// ```
-    pub fn selected_mut(&mut self) -> &mut Option<usize> {
+    pub const fn selected_mut(&mut self) -> &mut Option<usize> {
         &mut self.selected
     }
 
@@ -262,7 +262,7 @@ impl TableState {
     /// let mut state = TableState::default();
     /// *state.selected_column_mut() = Some(1);
     /// ```
-    pub fn selected_column_mut(&mut self) -> &mut Option<usize> {
+    pub const fn selected_column_mut(&mut self) -> &mut Option<usize> {
         &mut self.selected_column
     }
 
@@ -278,7 +278,7 @@ impl TableState {
     /// let mut state = TableState::default();
     /// state.select(Some(1));
     /// ```
-    pub fn select(&mut self, index: Option<usize>) {
+    pub const fn select(&mut self, index: Option<usize>) {
         self.selected = index;
         if index.is_none() {
             self.offset = 0;
@@ -294,7 +294,7 @@ impl TableState {
     /// let mut state = TableState::default();
     /// state.select_column(Some(1));
     /// ```
-    pub fn select_column(&mut self, index: Option<usize>) {
+    pub const fn select_column(&mut self, index: Option<usize>) {
         self.selected_column = index;
     }
 
@@ -309,7 +309,7 @@ impl TableState {
     /// let mut state = TableState::default();
     /// state.select_cell(Some((1, 5)));
     /// ```
-    pub fn select_cell(&mut self, indexes: Option<(usize, usize)>) {
+    pub const fn select_cell(&mut self, indexes: Option<(usize, usize)>) {
         if let Some((r, c)) = indexes {
             self.selected = Some(r);
             self.selected_column = Some(c);
@@ -405,7 +405,7 @@ impl TableState {
     /// let mut state = TableState::default();
     /// state.select_first();
     /// ```
-    pub fn select_first(&mut self) {
+    pub const fn select_first(&mut self) {
         self.select(Some(0));
     }
 
@@ -421,7 +421,7 @@ impl TableState {
     /// let mut state = TableState::default();
     /// state.select_first_column();
     /// ```
-    pub fn select_first_column(&mut self) {
+    pub const fn select_first_column(&mut self) {
         self.select_column(Some(0));
     }
 
@@ -438,7 +438,7 @@ impl TableState {
     /// let mut state = TableState::default();
     /// state.select_last();
     /// ```
-    pub fn select_last(&mut self) {
+    pub const fn select_last(&mut self) {
         self.select(Some(usize::MAX));
     }
 
@@ -454,7 +454,7 @@ impl TableState {
     /// let mut state = TableState::default();
     /// state.select_last();
     /// ```
-    pub fn select_last_column(&mut self) {
+    pub const fn select_last_column(&mut self) {
         self.select_column(Some(usize::MAX));
     }
 

--- a/ratatui/tests/state_serde.rs
+++ b/ratatui/tests/state_serde.rs
@@ -40,7 +40,7 @@ impl Default for AppState {
     }
 }
 impl AppState {
-    fn select(&mut self, index: usize) {
+    const fn select(&mut self, index: usize) {
         self.list.select(Some(index));
         self.table.select_cell(Some((index, index)));
         self.scrollbar = self.scrollbar.position(index);


### PR DESCRIPTION
The Clippy check for this (missing_const_for_fn) is already enabled, but catches more cases in upcoming toolchain versions.

This is part of the work to unblock #1727