### PR TITLE
feat: Enable serde propagation to backend crates (crossterm, termion)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix",
+ "serde",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -3340,6 +3341,7 @@ dependencies = [
  "libredox",
  "numtoa",
  "redox_termios",
+ "serde",
 ]
 
 [[package]]
@@ -3376,6 +3378,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
+ "serde",
  "sha2",
  "signal-hook",
  "siphasher",
@@ -3868,6 +3871,7 @@ checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "atomic",
  "getrandom 0.3.2",
+ "serde",
 ]
 
 [[package]]
@@ -4032,6 +4036,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.2",
  "mac_address",
+ "serde",
  "sha2",
  "thiserror 1.0.69",
  "uuid 1.16.0",
@@ -4046,6 +4051,7 @@ dependencies = [
  "csscolorparser",
  "deltae",
  "lazy_static",
+ "serde",
  "wezterm-dynamic",
 ]
 

--- a/ratatui-crossterm/Cargo.toml
+++ b/ratatui-crossterm/Cargo.toml
@@ -17,6 +17,9 @@ rust-version.workspace = true
 [features]
 default = ["underline-color"]
 
+## Enables serde for crossterm dependency
+serde = ["crossterm/serde"]
+
 ## enables the backend code that sets the underline color.
 ## Underline color is not supported on Windows 7.
 underline-color = ["ratatui-core/underline-color"]

--- a/ratatui-termion/Cargo.toml
+++ b/ratatui-termion/Cargo.toml
@@ -21,6 +21,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
+## Enables serde for termion dependency
+serde = ["termion/serde"]
 ## Use terminal scrolling regions to make Terminal::insert_before less prone to flickering.
 scrolling-regions = ["ratatui-core/scrolling-regions"]
 ## Enables all unstable features.

--- a/ratatui-termwiz/Cargo.toml
+++ b/ratatui-termwiz/Cargo.toml
@@ -22,6 +22,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = []
 
+## Enables serde for termwiz dependency
+serde = ["termwiz/use_serde"]
+
 ## Enables the backend code that sets the underline color.
 ## Underline color is not supported on Windows 7.
 underline-color = []

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -39,7 +39,14 @@ termwiz = ["dep:ratatui-termwiz"]
 #! The following optional features are available for all backends:
 ## enables serialization and deserialization of style and color types using the [`serde`] crate.
 ## This is useful if you want to save themes to a file.
-serde = ["dep:serde", "ratatui-core/serde", "ratatui-widgets/serde"]
+serde = [
+  "dep:serde",
+  "ratatui-core/serde",
+  "ratatui-widgets/serde",
+  "ratatui-crossterm?/serde",
+  "ratatui-termion?/serde",
+  "ratatui-termwiz?/serde",
+]
 
 ## enables conversions from colors in the [`palette`] crate to [`Color`](crate::style::Color).
 palette = ["ratatui-core/palette", "dep:palette"]


### PR DESCRIPTION
This PR propagates the serde feature from the main ratatui crate to the ratatui-crossterm and ratatui-termion backend crates. Solves #1805