### PR TITLE
feat(error)!: introduce `ratatui_core::error::Error`

### DIFF
--- a/examples/apps/demo/src/crossterm.rs
+++ b/examples/apps/demo/src/crossterm.rs
@@ -43,14 +43,11 @@ pub fn run(tick_rate: Duration, enhanced_graphics: bool) -> Result<(), Box<dyn E
     Ok(())
 }
 
-fn run_app<B: Backend>(
-    terminal: &mut Terminal<B>,
+fn run_app<W: io::Write>(
+    terminal: &mut Terminal<CrosstermBackend<W>>,
     mut app: App,
     tick_rate: Duration,
-) -> Result<(), Box<dyn Error>>
-where
-    B::Error: 'static,
-{
+) -> Result<(), Box<dyn Error>> {
     let mut last_tick = Instant::now();
     loop {
         terminal.draw(|frame| ui::draw(frame, &mut app))?;

--- a/examples/apps/demo/src/termion.rs
+++ b/examples/apps/demo/src/termion.rs
@@ -32,14 +32,11 @@ pub fn run(tick_rate: Duration, enhanced_graphics: bool) -> Result<(), Box<dyn E
     Ok(())
 }
 
-fn run_app<B: Backend>(
-    terminal: &mut Terminal<B>,
+fn run_app<W: io::Write>(
+    terminal: &mut Terminal<TermionBackend<W>>,
     mut app: App,
     tick_rate: Duration,
-) -> Result<(), Box<dyn Error>>
-where
-    B::Error: 'static,
-{
+) -> Result<(), Box<dyn Error>> {
     let events = events(tick_rate);
     loop {
         terminal.draw(|frame| ui::draw(frame, &mut app))?;

--- a/ratatui-core/src/backend.rs
+++ b/ratatui-core/src/backend.rs
@@ -145,9 +145,13 @@ pub struct WindowSize {
 /// [`Terminal`] struct provides a higher level interface for interacting with the terminal.
 ///
 /// [`Terminal`]: https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html
-pub trait Backend {
+pub trait Backend
+where
+    Self::Error: core::error::Error,
+    crate::error::Error: From<Self::Error>,
+{
     /// Error type associated with this Backend.
-    type Error: core::error::Error;
+    type Error;
 
     /// Draw the given content to the terminal screen.
     ///

--- a/ratatui-core/src/backend/test.rs
+++ b/ratatui-core/src/backend/test.rs
@@ -5,7 +5,6 @@ use alloc::string::String;
 use alloc::vec;
 use core::fmt::{self, Write};
 use core::iter;
-use std::io;
 
 use unicode_width::UnicodeWidthStr;
 
@@ -28,7 +27,7 @@ use crate::layout::{Position, Rect, Size};
 /// let mut backend = TestBackend::new(10, 2);
 /// backend.clear()?;
 /// backend.assert_buffer_lines(["          "; 2]);
-/// # std::io::Result::Ok(())
+/// # core::result::Result::Ok(())
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -233,10 +232,12 @@ impl fmt::Display for TestBackend {
     }
 }
 
-impl Backend for TestBackend {
-    type Error = io::Error;
+type Result<T> = core::result::Result<T, core::convert::Infallible>;
 
-    fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
+impl Backend for TestBackend {
+    type Error = core::convert::Infallible;
+
+    fn draw<'a, I>(&mut self, content: I) -> Result<()>
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {
@@ -246,31 +247,31 @@ impl Backend for TestBackend {
         Ok(())
     }
 
-    fn hide_cursor(&mut self) -> io::Result<()> {
+    fn hide_cursor(&mut self) -> Result<()> {
         self.cursor = false;
         Ok(())
     }
 
-    fn show_cursor(&mut self) -> io::Result<()> {
+    fn show_cursor(&mut self) -> Result<()> {
         self.cursor = true;
         Ok(())
     }
 
-    fn get_cursor_position(&mut self) -> io::Result<Position> {
+    fn get_cursor_position(&mut self) -> Result<Position> {
         Ok(self.pos.into())
     }
 
-    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> Result<()> {
         self.pos = position.into().into();
         Ok(())
     }
 
-    fn clear(&mut self) -> io::Result<()> {
+    fn clear(&mut self) -> Result<()> {
         self.buffer.reset();
         Ok(())
     }
 
-    fn clear_region(&mut self, clear_type: ClearType) -> io::Result<()> {
+    fn clear_region(&mut self, clear_type: ClearType) -> Result<()> {
         let region = match clear_type {
             ClearType::All => return self.clear(),
             ClearType::AfterCursor => {
@@ -310,7 +311,7 @@ impl Backend for TestBackend {
     /// the cursor y position then that number of empty lines (at most the buffer's height in this
     /// case but this limit is instead replaced with scrolling in most backend implementations) will
     /// be added after the current position and the cursor will be moved to the last row.
-    fn append_lines(&mut self, line_count: u16) -> io::Result<()> {
+    fn append_lines(&mut self, line_count: u16) -> Result<()> {
         let Position { x: cur_x, y: cur_y } = self.get_cursor_position()?;
         let Rect { width, height, .. } = self.buffer.area;
 
@@ -347,11 +348,11 @@ impl Backend for TestBackend {
         Ok(())
     }
 
-    fn size(&self) -> io::Result<Size> {
+    fn size(&self) -> Result<Size> {
         Ok(self.buffer.area.as_size())
     }
 
-    fn window_size(&mut self) -> io::Result<WindowSize> {
+    fn window_size(&mut self) -> Result<WindowSize> {
         // Some arbitrary window pixel size, probably doesn't need much testing.
         const WINDOW_PIXEL_SIZE: Size = Size {
             width: 640,
@@ -363,16 +364,12 @@ impl Backend for TestBackend {
         })
     }
 
-    fn flush(&mut self) -> io::Result<()> {
+    fn flush(&mut self) -> Result<()> {
         Ok(())
     }
 
     #[cfg(feature = "scrolling-regions")]
-    fn scroll_region_up(
-        &mut self,
-        region: core::ops::Range<u16>,
-        scroll_by: u16,
-    ) -> io::Result<()> {
+    fn scroll_region_up(&mut self, region: core::ops::Range<u16>, scroll_by: u16) -> Result<()> {
         let width: usize = self.buffer.area.width.into();
         let cell_region_start = width * region.start.min(self.buffer.area.height) as usize;
         let cell_region_end = width * region.end.min(self.buffer.area.height) as usize;
@@ -418,11 +415,7 @@ impl Backend for TestBackend {
     }
 
     #[cfg(feature = "scrolling-regions")]
-    fn scroll_region_down(
-        &mut self,
-        region: core::ops::Range<u16>,
-        scroll_by: u16,
-    ) -> io::Result<()> {
+    fn scroll_region_down(&mut self, region: core::ops::Range<u16>, scroll_by: u16) -> Result<()> {
         let width: usize = self.buffer.area.width.into();
         let cell_region_start = width * region.start.min(self.buffer.area.height) as usize;
         let cell_region_end = width * region.end.min(self.buffer.area.height) as usize;
@@ -923,7 +916,7 @@ mod tests {
     }
 
     #[test]
-    fn append_lines_truncates_beyond_u16_max() -> io::Result<()> {
+    fn append_lines_truncates_beyond_u16_max() -> Result<()> {
         let mut backend = TestBackend::new(10, 5);
 
         // Fill the scrollback with 65535 + 10 lines.

--- a/ratatui-core/src/error.rs
+++ b/ratatui-core/src/error.rs
@@ -1,0 +1,17 @@
+use alloc::string::String;
+use core::convert::Infallible;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("other error: `{0}`")]
+    Other(String),
+}
+
+impl From<Infallible> for Error {
+    fn from(_: Infallible) -> Self {
+        unreachable!()
+    }
+}
+

--- a/ratatui-core/src/lib.rs
+++ b/ratatui-core/src/lib.rs
@@ -49,7 +49,9 @@ extern crate alloc;
 
 pub mod backend;
 pub mod buffer;
+pub mod error;
 pub mod layout;
+pub mod result;
 pub mod style;
 pub mod symbols;
 pub mod terminal;

--- a/ratatui-core/src/result.rs
+++ b/ratatui-core/src/result.rs
@@ -1,0 +1,1 @@
+pub type Result<T> = core::result::Result<T, crate::error::Error>;

--- a/ratatui/src/init.rs
+++ b/ratatui/src/init.rs
@@ -77,7 +77,7 @@ pub fn init() -> DefaultTerminal {
 /// let terminal = ratatui::try_init()?;
 /// # Ok::<(), std::io::Error>(())
 /// ```
-pub fn try_init() -> io::Result<DefaultTerminal> {
+pub fn try_init() -> crate::result::Result<DefaultTerminal> {
     set_panic_hook();
     enable_raw_mode()?;
     execute!(stdout(), EnterAlternateScreen)?;
@@ -166,7 +166,9 @@ pub fn init_with_options(options: TerminalOptions) -> DefaultTerminal {
 /// let terminal = ratatui::try_init_with_options(options)?;
 /// # Ok::<(), std::io::Error>(())
 /// ```
-pub fn try_init_with_options(options: TerminalOptions) -> io::Result<DefaultTerminal> {
+pub fn try_init_with_options(
+    options: TerminalOptions,
+) -> Result<DefaultTerminal, ratatui_core::error::Error> {
     set_panic_hook();
     enable_raw_mode()?;
     let backend = CrosstermBackend::new(stdout());

--- a/ratatui/src/lib.rs
+++ b/ratatui/src/lib.rs
@@ -357,7 +357,7 @@ pub mod backend {
 }
 
 pub mod prelude;
-pub use ratatui_core::{style, symbols, text};
+pub use ratatui_core::{error, result, style, symbols, text};
 pub mod widgets;
 pub use ratatui_widgets::border;
 #[cfg(feature = "crossterm")]

--- a/ratatui/tests/stylize.rs
+++ b/ratatui/tests/stylize.rs
@@ -1,5 +1,3 @@
-use std::io;
-
 use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -57,7 +55,7 @@ fn barchart_can_be_stylized() {
 }
 
 #[test]
-fn block_can_be_stylized() -> io::Result<()> {
+fn block_can_be_stylized() -> Result<(), ratatui::error::Error> {
     let block = Block::bordered()
         .title("Title".light_blue())
         .on_cyan()
@@ -89,7 +87,7 @@ fn block_can_be_stylized() -> io::Result<()> {
 }
 
 #[test]
-fn paragraph_can_be_stylized() -> io::Result<()> {
+fn paragraph_can_be_stylized() -> Result<(), ratatui::error::Error> {
     let paragraph = Paragraph::new("Text".cyan());
 
     let area = Rect::new(0, 0, 10, 1);


### PR DESCRIPTION
Follow up to #1778
Introduce `ratatui_core::error::Error` and require backends to implement `From<ratatui_core::error::Error>` for associated `Error` type.

WIP, the problem I'm facing:

```rust
pub trait Backend {
    type Error: core::error::Error + Into<crate::error::Error>;
}
```
This does _not_ make type parameters `B: Backend` 
satisfy `crate::error::Error: From<B as Backend>::Error` bound.

I also tried:
```rust
pub trait Backend 
where
    Self::Error: core::error::Error,
    crate::error::Error: From<Self::Error>,
{
    type Error;
}
```

But this still produces the same problem:
```rust
impl<B> Terminal<B>
where
    B: Backend,
{
...
```
> the trait bound `error::Error: From<<B as Backend>::Error>` is not satisfied [E0277]
> the trait `From<<B as Backend>::Error>` is not implemented for `error::Error`
> Note: required by a bound in `Backend`

Generally this can be fixed by adding another bound to where clause, everywhere where `B: Backend` type param is used, but this doesn't feel right. I don't know if this is a compiler limitation, but I can't find a way to make it work without it.

I'm open to suggestions.