### PR TITLE
fix(macros): use crate re-export instead of module in user code

### DIFF
--- a/ratatui-macros/src/text.rs
+++ b/ratatui-macros/src/text.rs
@@ -38,13 +38,13 @@
 #[macro_export]
 macro_rules! text {
     () => {
-        ratatui_core::text::Text::default()
+        $crate::ratatui_core::text::Text::default()
     };
     ($line:expr; $n:expr) => {
-        ratatui_core::text::Text::from(vec![$line.into(); $n])
+        $crate::ratatui_core::text::Text::from(vec![$line.into(); $n])
     };
     ($($line:expr),+ $(,)?) => {{
-        ratatui_core::text::Text::from(vec![
+        $crate::ratatui_core::text::Text::from(vec![
         $(
             $line.into(),
         )+


### PR DESCRIPTION
Seems like the `text` macro uses the `ratatui-core` module from user code instead of the version that is re-exported.
Other macros already use the `$crate` prefix when using `ratatui-core` but I guess this was missed.

Since 0.30.0 stable hasn't been released yet existing I don't think this is a breaking change.