### PR TITLE
chore: move time to dev-dependencies

### DIFF
--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -76,7 +76,7 @@ all-widgets = ["widget-calendar"]
 
 #! Widgets that add dependencies are gated behind feature flags to prevent unused transitive
 #! dependencies. The available features are:
-## enables the [`calendar`](widgets::calendar) widget module and adds a dependency on [`time`].
+## enables the [`calendar`](widgets::calendar) widget module.
 widget-calendar = ["ratatui-widgets/calendar"]
 
 #! The following optional features are only available for some backends:

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -77,7 +77,7 @@ all-widgets = ["widget-calendar"]
 #! Widgets that add dependencies are gated behind feature flags to prevent unused transitive
 #! dependencies. The available features are:
 ## enables the [`calendar`](widgets::calendar) widget module and adds a dependency on [`time`].
-widget-calendar = ["ratatui-widgets/calendar", "dep:time"]
+widget-calendar = ["ratatui-widgets/calendar"]
 
 #! The following optional features are only available for some backends:
 
@@ -124,7 +124,6 @@ ratatui-macros = { workspace = true, optional = true }
 ratatui-termwiz = { workspace = true, optional = true }
 ratatui-widgets = { workspace = true }
 serde = { workspace = true, optional = true }
-time = { version = "0.3.39", optional = true, features = ["local-offset"] }
 
 [target.'cfg(not(windows))'.dependencies]
 ratatui-termion = { workspace = true, optional = true }
@@ -142,6 +141,7 @@ rand = "0.9.1"
 rand_chacha = "0.9.0"
 rstest = "0.25.0"
 serde_json.workspace = true
+time = { version = "0.3.39", features = ["local-offset"] }
 tokio = { version = "1.44.2", features = ["rt", "macros", "time", "rt-multi-thread"] }
 tracing = "0.1.40"
 tracing-appender = "0.2.3"

--- a/ratatui/tests/widgets_calendar.rs
+++ b/ratatui/tests/widgets_calendar.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "widget-calendar")]
+#![cfg(test)]
 use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
 use ratatui::style::Style;

--- a/ratatui/tests/widgets_calendar.rs
+++ b/ratatui/tests/widgets_calendar.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+#![cfg(feature = "widget-calendar")]
 use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
 use ratatui::style::Style;


### PR DESCRIPTION
Since `time` is only used in `ratatui` in tests, I believe it should be moved to dev-dependencies. 