### PR TITLE
fix(no_std): propagate `std` feature flag to dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,16 +925,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,14 +1670,11 @@ dependencies = [
 
 [[package]]
 name = "kasuari"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dc2e630352db5500d8bfd6827305ad904ebe165a5c046ce8057a00794312cbb"
+checksum = "def1b67294a9fdc95eeeeafd1209c7a1b8a82aa0bf80ac2ab2a7d0318e9c7622"
 dependencies = [
  "hashbrown",
- "quickcheck",
- "quickcheck_macros",
- "rstest",
  "thiserror 2.0.12",
 ]
 
@@ -2366,28 +2353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quickcheck"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
-dependencies = [
- "env_logger",
- "log",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "quickcheck_macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,9 +2468,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.15",
-]
 
 [[package]]
 name = "rand_core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ document-features = "0.2.11"
 hashbrown = "0.15.2"
 indoc = "2.0.6"
 instability = "0.3.7"
-itertools = "0.13.0"
+itertools = { version = "0.13.0", default-features = false, features = ["use_alloc"] }
 pretty_assertions = "1.4.1"
 ratatui = { path = "ratatui", version = "0.30.0-alpha.2" }
 ratatui-core = { path = "ratatui-core", version = "0.1.0-alpha.3" }
@@ -46,7 +46,7 @@ ratatui-widgets = { path = "ratatui-widgets", version = "0.3.0-alpha.2" }
 rstest = "0.25.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-strum = { version = "0.26.3", features = ["derive"] }
+strum = { version = "0.26.3", default-features = false, features = ["derive"] }
 termion = "4.0.5"
 termwiz = { version = "0.23.3" }
 unicode-segmentation = "1.12.0"

--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -25,7 +25,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = []
 
 ## enables std
-std = []
+std = [
+  "itertools/use_std",
+  "thiserror/std",
+  "kasuari/std",
+  "compact_str/std",
+  "unicode-truncate/std",
+  "strum/std",
+]
 
 ## enables layout cache
 layout-cache = ["std"]
@@ -51,19 +58,19 @@ serde = ["dep:serde", "bitflags/serde", "compact_str/serde"]
 [dependencies]
 anstyle = { version = "1", optional = true }
 bitflags = "2.3"
-compact_str = "0.9.0"
+compact_str = { version = "0.9.0", default-features = false }
 document-features = { workspace = true, optional = true }
 hashbrown = "0.15.2"
 indoc.workspace = true
 itertools.workspace = true
-kasuari = "0.4.0"
+kasuari = { version = "0.4.6", default-features = false }
 lru = "0.12.0"
 palette = { version = "0.7.6", optional = true }
 serde = { workspace = true, optional = true }
 strum.workspace = true
-thiserror = "2"
+thiserror = { version = "2", default-features = false }
 unicode-segmentation.workspace = true
-unicode-truncate = "2"
+unicode-truncate = { version = "2", default-features = false }
 unicode-width.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
Disables `std` feature flags in dependencies and only enables them with `ratatui` and `ratatui-core`'s `std` feature flag.
~~Additionally bumps version of `kasuari`~~ _(moved to #1844)_, to get upstream changes that allow disabling dependency on `std`.
This partially fixes the issue of still depending on `std`, when `std` feature flag is disabled.