### PR TITLE
fix(layout-cache): import `NonZeroUsize` only when `layout-cache` is enabled

### DIFF
--- a/ratatui-core/src/layout/layout.rs
+++ b/ratatui-core/src/layout/layout.rs
@@ -1,6 +1,7 @@
 use alloc::rc::Rc;
 use alloc::vec::Vec;
 use core::iter;
+#[cfg(feature = "layout-cache")]
 use core::num::NonZeroUsize;
 
 use hashbrown::HashMap;


### PR DESCRIPTION
This silences unused import warning, when `layout-cache` is disabled.
