### PR TITLE
feat: support no-std for calendar widget

### DIFF
--- a/ratatui-widgets/Cargo.toml
+++ b/ratatui-widgets/Cargo.toml
@@ -25,7 +25,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["all-widgets"]
 
 ## enables std
-std = []
+std = ["time/local-offset"]
 
 ## enables serialization and deserialization of style and color types using the [`serde`] crate.
 ## This is useful if you want to save themes to a file.
@@ -60,7 +60,7 @@ line-clipping = "0.3.0"
 ratatui-core = { workspace = true }
 serde = { workspace = true, optional = true }
 strum.workspace = true
-time = { version = "0.3.11", optional = true, features = ["local-offset"] }
+time = { version = "0.3.11", optional = true, default-features = false }
 unicode-segmentation.workspace = true
 unicode-width.workspace = true
 

--- a/ratatui-widgets/src/calendar.rs
+++ b/ratatui-widgets/src/calendar.rs
@@ -17,7 +17,7 @@ use ratatui_core::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui_core::style::Style;
 use ratatui_core::text::{Line, Span};
 use ratatui_core::widgets::Widget;
-use time::{Date, Duration, OffsetDateTime};
+use time::{Date, Duration};
 
 use crate::block::{Block, BlockExt};
 
@@ -218,7 +218,9 @@ impl CalendarEventStore {
     /// your own type that implements [`Into<Style>`]).
     ///
     /// [`Color`]: ratatui_core::style::Color
+    #[cfg(feature = "std")]
     pub fn today<S: Into<Style>>(style: S) -> Self {
+        use time::OffsetDateTime;
         let mut res = Self::default();
         res.add(
             OffsetDateTime::now_local()


### PR DESCRIPTION
Removes the CalendarEventStore::today() function in no-std environments
