### PR TITLE
refactor: Swap const and non-const arms in color! and modifier! macros

### DIFF
--- a/ratatui-core/src/style/stylize.rs
+++ b/ratatui-core/src/style/stylize.rs
@@ -112,20 +112,6 @@ impl fmt::Debug for ColorDebug {
 /// }
 /// ```
 macro_rules! color {
-    ( $variant:expr, $color:ident(), $on_color:ident() -> $ty:ty ) => {
-        #[doc = concat!("Sets the foreground color to [`", stringify!($color), "`](", stringify!($variant), ").")]
-        #[must_use = concat!("`", stringify!($color), "` returns the modified style without modifying the original")]
-        fn $color(self) -> $ty {
-            self.fg($variant)
-        }
-
-        #[doc = concat!("Sets the background color to [`", stringify!($color), "`](", stringify!($variant), ").")]
-        #[must_use = concat!("`", stringify!($on_color), "` returns the modified style without modifying the original")]
-        fn $on_color(self) -> $ty {
-            self.bg($variant)
-        }
-    };
-
     (pub const $variant:expr, $color:ident(), $on_color:ident() -> $ty:ty ) => {
         #[doc = concat!("Sets the foreground color to [`", stringify!($color), "`](", stringify!($variant), ").")]
         #[must_use = concat!("`", stringify!($color), "` returns the modified style without modifying the original")]
@@ -136,6 +122,20 @@ macro_rules! color {
         #[doc = concat!("Sets the background color to [`", stringify!($color), "`](", stringify!($variant), ").")]
         #[must_use = concat!("`", stringify!($on_color), "` returns the modified style without modifying the original")]
         pub const fn $on_color(self) -> $ty {
+            self.bg($variant)
+        }
+    };
+
+    ( $variant:expr, $color:ident(), $on_color:ident() -> $ty:ty ) => {
+        #[doc = concat!("Sets the foreground color to [`", stringify!($color), "`](", stringify!($variant), ").")]
+        #[must_use = concat!("`", stringify!($color), "` returns the modified style without modifying the original")]
+        fn $color(self) -> $ty {
+            self.fg($variant)
+        }
+
+        #[doc = concat!("Sets the background color to [`", stringify!($color), "`](", stringify!($variant), ").")]
+        #[must_use = concat!("`", stringify!($on_color), "` returns the modified style without modifying the original")]
+        fn $on_color(self) -> $ty {
             self.bg($variant)
         }
     };
@@ -162,20 +162,6 @@ macro_rules! color {
 /// }
 /// ```
 macro_rules! modifier {
-    ( $variant:expr, $modifier:ident(), $not_modifier:ident() -> $ty:ty ) => {
-        #[doc = concat!("Adds the [`", stringify!($modifier), "`](", stringify!($variant), ") modifier.")]
-        #[must_use = concat!("`", stringify!($modifier), "` returns the modified style without modifying the original")]
-        fn $modifier(self) -> $ty {
-            self.add_modifier($variant)
-        }
-
-        #[doc = concat!("Removes the [`", stringify!($modifier), "`](", stringify!($variant), ") modifier.")]
-        #[must_use = concat!("`", stringify!($not_modifier), "` returns the modified style without modifying the original")]
-        fn $not_modifier(self) -> $ty {
-            self.remove_modifier($variant)
-        }
-    };
-
     (pub const $variant:expr, $modifier:ident(), $not_modifier:ident() -> $ty:ty ) => {
         #[doc = concat!("Adds the [`", stringify!($modifier), "`](", stringify!($variant), ") modifier.")]
         #[must_use = concat!("`", stringify!($modifier), "` returns the modified style without modifying the original")]
@@ -186,6 +172,20 @@ macro_rules! modifier {
         #[doc = concat!("Removes the [`", stringify!($modifier), "`](", stringify!($variant), ") modifier.")]
         #[must_use = concat!("`", stringify!($not_modifier), "` returns the modified style without modifying the original")]
         pub const fn $not_modifier(self) -> $ty {
+            self.remove_modifier($variant)
+        }
+    };
+
+    ( $variant:expr, $modifier:ident(), $not_modifier:ident() -> $ty:ty ) => {
+        #[doc = concat!("Adds the [`", stringify!($modifier), "`](", stringify!($variant), ") modifier.")]
+        #[must_use = concat!("`", stringify!($modifier), "` returns the modified style without modifying the original")]
+        fn $modifier(self) -> $ty {
+            self.add_modifier($variant)
+        }
+
+        #[doc = concat!("Removes the [`", stringify!($modifier), "`](", stringify!($variant), ") modifier.")]
+        #[must_use = concat!("`", stringify!($not_modifier), "` returns the modified style without modifying the original")]
+        fn $not_modifier(self) -> $ty {
             self.remove_modifier($variant)
         }
     };


### PR DESCRIPTION
This gets us a little bit closer to Edition 2024 support (#1727)

I am still learning but I think I'm understanding [this part of the edition 2024 guide](https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html) correctly: If we leave these macro definitions unchanged and upgrade to Edition 2024, the first arm will always match, because `expr` will start matching `const` expressions that it didn't match in Edition 2021. And then the second arm will never match.

So, we simply switch the order to explicitly match const expressions first. This is a no-op for Edition 2021 but will make these work as expected under Edition 2024.