### PR TITLE
chore: Use edition.workspace so that all crates are on the same edition

### DIFF
--- a/ratatui-macros/Cargo.toml
+++ b/ratatui-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ratatui-macros"
 version = "0.7.0-alpha.2"
-edition = "2021"
+edition.workspace = true
 authors = ["The Ratatui Developers"]
 description = "Macros for Ratatui"
 license = "MIT"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-edition = "2021"
+edition.workspace = true
 publish = false
 license.workspace = true
 


### PR DESCRIPTION
The workspace edition is currently 2021 so this doesn't actually change anything yet. It just means that when the workspace edition does change, it will change for all crates at once.

Part of #1727 