### PR TITLE
fix: Change order of operations for length calculation of pixel buffers fo…

### DIFF
--- a/ratatui-widgets/src/canvas.rs
+++ b/ratatui-widgets/src/canvas.rs
@@ -967,11 +967,11 @@ mod tests {
         let mut b_grid = BrailleGrid::new(u16::MAX, 3);
         let mut c_grid = CharGrid::new(u16::MAX, 3, 'd');
 
-        let max_u16 = u16::MAX as usize;
+        let max = u16::MAX as usize + 10;
 
         // see if we can paint outside bounds
-        b_grid.paint(max_u16 + 10, max_u16 + 10, Color::Red);
-        c_grid.paint(max_u16 + 10, max_u16 + 10, Color::Red);
+        b_grid.paint(max, max, Color::Red);
+        c_grid.paint(max, max, Color::Red);
         // see if we can paint usize max bounds
         b_grid.paint(usize::MAX, usize::MAX, Color::Red);
         c_grid.paint(usize::MAX, usize::MAX, Color::Red);


### PR DESCRIPTION
Fixes: https://github.com/ratatui/ratatui/issues/1449 

The issue 1449 was about trying to render ratatui canvas on a very small font size and terminal scaled `Ctrl+-` all the way down, because of the high value of integers, which caused some integer overflows.

NOTE: We have to double check if the current behavior by the canvas is valid under the scaled down circumstance currently of we want to change the way canvas grid works?