### PR TITLE
feat: use CoW for List and Table contents

### DIFF
--- a/examples/apps/demo2/src/tabs/recipe.rs
+++ b/examples/apps/demo2/src/tabs/recipe.rs
@@ -1,3 +1,5 @@
+use std::cell::OnceCell;
+
 use itertools::Itertools;
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Alignment, Constraint, Layout, Margin, Rect};
@@ -155,11 +157,14 @@ fn render_recipe(area: Rect, buf: &mut Buffer) {
 }
 
 fn render_ingredients(selected_row: usize, area: Rect, buf: &mut Buffer) {
+    let ingredient_rows: OnceCell<Vec<Row<'_>>> = OnceCell::new();
+    let rows = ingredient_rows.get_or_init(|| INGREDIENTS.iter().map(|i| (*i).into()).collect());
+
     let mut state = TableState::default().with_selected(Some(selected_row));
-    let rows = INGREDIENTS.iter().copied();
     let theme = THEME.recipe;
     StatefulWidget::render(
-        Table::new(rows, [Constraint::Length(7), Constraint::Length(30)])
+        Table::from(rows)
+            .widths([Constraint::Length(7), Constraint::Length(30)])
             .block(Block::new().style(theme.ingredients))
             .header(Row::new(vec!["Qty", "Ingredient"]).style(theme.ingredients_header))
             .row_highlight_style(Style::new().light_yellow()),

--- a/examples/apps/inline/src/main.rs
+++ b/examples/apps/inline/src/main.rs
@@ -262,7 +262,7 @@ fn render(frame: &mut Frame, downloads: &Downloads) {
             ]))
         })
         .collect();
-    let list = List::new(items);
+    let list = List::from(&items);
     frame.render_widget(list, list_area);
 
     #[expect(clippy::cast_possible_truncation)]

--- a/examples/apps/todo-list/src/main.rs
+++ b/examples/apps/todo-list/src/main.rs
@@ -231,7 +231,7 @@ impl App {
             .collect();
 
         // Create a List from all list items and highlight the currently selected one
-        let list = List::new(items)
+        let list = List::from(&items)
             .block(block)
             .highlight_style(SELECTED_STYLE)
             .highlight_symbol(">")

--- a/examples/apps/user-input/src/main.rs
+++ b/examples/apps/user-input/src/main.rs
@@ -220,7 +220,7 @@ impl App {
                 ListItem::new(content)
             })
             .collect();
-        let messages = List::new(messages).block(Block::bordered().title("Messages"));
+        let messages = List::from(&messages).block(Block::bordered().title("Messages"));
         frame.render_widget(messages, messages_area);
     }
 }

--- a/ratatui-macros/src/lib.rs
+++ b/ratatui-macros/src/lib.rs
@@ -173,6 +173,7 @@ mod layout;
 mod line;
 mod list_items;
 mod row;
+mod row_cells;
 mod span;
 mod text;
 

--- a/ratatui-macros/src/lib.rs
+++ b/ratatui-macros/src/lib.rs
@@ -171,6 +171,7 @@ pub use alloc::{format, vec};
 
 mod layout;
 mod line;
+mod list_items;
 mod row;
 mod span;
 mod text;

--- a/ratatui-macros/src/lib.rs
+++ b/ratatui-macros/src/lib.rs
@@ -175,6 +175,7 @@ mod list_items;
 mod row;
 mod row_cells;
 mod span;
+mod table_rows;
 mod text;
 
 // Re-export the core crate to use the types in macros

--- a/ratatui-macros/src/list_items.rs
+++ b/ratatui-macros/src/list_items.rs
@@ -1,0 +1,73 @@
+/// Creates a fixed sized array of [`ListItem`]s.
+///
+/// Can be used together with [`List::from`] to minimize memory allocations during rendering.
+///
+/// # Example
+///
+/// ```
+/// use ratatui_macros::list_items;
+/// use ratatui_widgets::list::List;
+///
+/// let items = list_items!["Item 1", "Item 2", "Item 3"];
+/// let list = List::from(&items);
+/// assert!(list.is_borrowed());
+/// ```
+///
+/// [`List::from`]: ratatui_widgets::list::List::from
+/// [`ListItem`]: ratatui_widgets::list::ListItem
+#[macro_export]
+macro_rules! list_items {
+    () => (
+        [] as [::ratatui_widgets::list::ListItem<'_>; 0]
+    );
+    ($($x:expr),+ $(,)?) => (
+        [$(Into::<::ratatui_widgets::list::ListItem<'_>>::into($x)),+]
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui_widgets::list::List;
+
+    #[test]
+    fn empty_borrowed() {
+        let items = list_items![];
+        let list = List::from(&items);
+        assert!(list.is_borrowed());
+    }
+
+    #[test]
+    fn empty_owned() {
+        let items = list_items!();
+        let list = List::new(items);
+        assert!(list.is_owned());
+    }
+
+    #[test]
+    fn single_borrowed() {
+        let items = list_items!["Item0"];
+        let list = List::from(&items);
+        assert!(list.is_borrowed());
+    }
+
+    #[test]
+    fn single_owned() {
+        let items = list_items!["Item0"];
+        let list = List::new(items);
+        assert!(list.is_owned());
+    }
+
+    #[test]
+    fn double_borrowed() {
+        let items = list_items!["Item0", "Item1"];
+        let list = List::from(&items);
+        assert!(list.is_borrowed());
+    }
+
+    #[test]
+    fn double_owned() {
+        let items = list_items!["Item0", "Item1"];
+        let list = List::new(items);
+        assert!(list.is_owned());
+    }
+}

--- a/ratatui-macros/src/row_cells.rs
+++ b/ratatui-macros/src/row_cells.rs
@@ -1,0 +1,72 @@
+/// Creates a fixed sized array of [`Cell`]s.
+///
+/// Can be used together with [`Row::from`] to minimize memory allocations during rendering.
+///
+/// # Example
+///
+/// ```
+/// use ratatui_macros::row_cells;
+/// use ratatui_widgets::table::Row;
+///
+/// let cells = row_cells!["Cell1", "Cell2", "Cell3"];
+/// Row::from(&cells);
+/// ```
+///
+/// [`Cell`]: ratatui_widgets::table::Cell
+/// [`Row::from`]: ratatui_widgets::table::Row::from
+#[macro_export]
+macro_rules! row_cells {
+    () => (
+        ([] as [::ratatui_widgets::table::Cell<'_>; 0])
+    );
+    ($($x:expr),+ $(,)?) => (
+        [$(Into::<::ratatui_widgets::table::Cell<'_>>::into($x)),+]
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui_widgets::table::Row;
+
+    #[test]
+    fn empty_borrowed() {
+        let cells = row_cells![];
+        let row = Row::from(&cells);
+        assert!(row.is_borrowed());
+    }
+
+    #[test]
+    fn empty_owned() {
+        let cells = row_cells!();
+        let row = Row::new(cells);
+        assert!(row.is_owned());
+    }
+
+    #[test]
+    fn single_borrowed() {
+        let cells = row_cells!["Item0"];
+        let row = Row::from(&cells);
+        assert!(row.is_borrowed());
+    }
+
+    #[test]
+    fn single_owned() {
+        let cells = row_cells!["Item0"];
+        let row = Row::new(cells);
+        assert!(row.is_owned());
+    }
+
+    #[test]
+    fn double_borrowed() {
+        let cells = row_cells!["Item0", "Item1"];
+        let row = Row::from(&cells);
+        assert!(row.is_borrowed());
+    }
+
+    #[test]
+    fn double_owned() {
+        let cells = row_cells!["Item0", "Item1"];
+        let row = Row::new(cells);
+        assert!(row.is_owned());
+    }
+}

--- a/ratatui-macros/src/table_rows.rs
+++ b/ratatui-macros/src/table_rows.rs
@@ -1,0 +1,90 @@
+/// Creates a fixed sized array of [`Row`]s.
+///
+/// Can be used together with [`Table::from`] to minimize memory allocations during rendering.
+///
+/// # Example
+///
+/// ```
+/// use ratatui_core::layout::Constraint;
+/// use ratatui_macros::table_rows;
+/// use ratatui_widgets::table::Table;
+///
+/// let rows = table_rows![
+///     ["Cell1", "Value1"],
+///     ["Cell2", "Value2"],
+///     ["Cell3", "Value3"]
+/// ];
+/// let widths = [
+///     Constraint::Length(5),
+///     Constraint::Length(5),
+///     Constraint::Length(10),
+/// ];
+/// let table = Table::from(&rows).widths(widths);
+/// ```
+///
+/// [`Row`]: ratatui_widgets::table::Row
+/// [`Table::from`]: ratatui_widgets::table::Table::from
+#[macro_export]
+macro_rules! table_rows {
+    () => (
+        ([] as [::ratatui_widgets::table::Row<'_>; 0])
+    );
+    ($([$($x:expr),+ $(,)?]),+ $(,)?) => (
+        // TODO: avoid to_vec() to minimize memory allocations
+        [$(Into::<::ratatui_widgets::table::Row<'_>>::into(vec![$(Into::<::ratatui_widgets::table::Cell<'_>>::into($x)),+])),+]
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use ratatui_core::layout::Constraint;
+    use ratatui_widgets::table::Table;
+
+    #[test]
+    fn empty_borrowed() {
+        let rows = table_rows![];
+        let table = Table::from(&rows).widths([] as [Constraint; 0]);
+        assert!(table.is_borrowed());
+    }
+
+    #[test]
+    fn empty_owned() {
+        let rows = table_rows!();
+        let table = Table::new(rows, [] as [Constraint; 0]);
+        assert!(table.is_owned());
+    }
+
+    #[test]
+    fn single_borrowed() {
+        let rows = table_rows![["Item0"]];
+        let array = [Constraint::Percentage(100)];
+        let table = Table::from(&rows).widths(array);
+        assert!(table.is_borrowed());
+    }
+
+    #[test]
+    fn single_owned() {
+        let rows = table_rows![["Item0"]];
+        let array = [Constraint::Percentage(100)];
+        let table = Table::new(rows, array);
+        assert!(table.is_owned());
+    }
+
+    #[test]
+    fn double_borrowed() {
+        let rows = table_rows![["Item0", "Value0"], ["Item1", "Value1"]];
+        let array = [Constraint::Percentage(100)];
+        let table = Table::from(&rows).widths(array);
+        assert!(table.is_borrowed());
+    }
+
+    #[test]
+    fn double_owned() {
+        let rows = table_rows![["Item0", "Value0"], ["Item1", "Value1"]];
+        let array = [Constraint::Percentage(100)];
+        let table = Table::new(rows, array);
+        assert!(table.is_owned());
+    }
+}

--- a/ratatui-widgets/examples/list.rs
+++ b/ratatui-widgets/examples/list.rs
@@ -20,15 +20,22 @@ use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::macros::list_items;
 use ratatui::style::{Color, Modifier, Style, Stylize};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{List, ListDirection, ListState};
+use ratatui::widgets::{List, ListDirection, ListItem, ListState};
 
 fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
     let mut list_state = ListState::default().with_selected(Some(0));
     ratatui::run(|terminal| {
+        let bottom_items = list_items![
+            "[Remy]: I'm building one now.\nIt even supports multiline text!",
+            "[Gusteau]: With enough passion, yes.",
+            "[Remy]: But can anyone build a TUI in Rust?",
+            "[Gusteau]: Anyone can cook!",
+        ];
+
         loop {
-            terminal.draw(|frame| render(frame, &mut list_state))?;
+            terminal.draw(|frame| render(frame, &mut list_state, &bottom_items))?;
             if let Some(key) = event::read()?.as_key_press_event() {
                 match key.code {
                     KeyCode::Char('j') | KeyCode::Down => list_state.select_next(),
@@ -42,7 +49,7 @@ fn main() -> color_eyre::Result<()> {
 }
 
 /// Render the UI with various lists.
-fn render(frame: &mut Frame, list_state: &mut ListState) {
+fn render(frame: &mut Frame, list_state: &mut ListState, bottom_items: &[ListItem]) {
     let constraints = [
         Constraint::Length(1),
         Constraint::Fill(1),
@@ -58,10 +65,11 @@ fn render(frame: &mut Frame, list_state: &mut ListState) {
     frame.render_widget(title.centered(), top);
 
     render_list(frame, first, list_state);
-    render_bottom_list(frame, second);
+    render_bottom_list(frame, second, bottom_items);
 }
 
 /// Render a list.
+/// Construct the items on each render iteration.
 pub fn render_list(frame: &mut Frame, area: Rect, list_state: &mut ListState) {
     let items = list_items!["Item 1", "Item 2", "Item 3", "Item 4"];
     let list = List::from(&items)
@@ -73,14 +81,9 @@ pub fn render_list(frame: &mut Frame, area: Rect, list_state: &mut ListState) {
 }
 
 /// Render a bottom-to-top list.
-pub fn render_bottom_list(frame: &mut Frame, area: Rect) {
-    let items = list_items![
-        "[Remy]: I'm building one now.\nIt even supports multiline text!",
-        "[Gusteau]: With enough passion, yes.",
-        "[Remy]: But can anyone build a TUI in Rust?",
-        "[Gusteau]: Anyone can cook!",
-    ];
-    let list = List::from(&items)
+/// Use the pre-created list of items.
+pub fn render_bottom_list(frame: &mut Frame, area: Rect, bottom_items: &[ListItem]) {
+    let list = List::from(bottom_items)
         .style(Color::White)
         .highlight_style(Style::new().yellow().italic())
         .highlight_symbol("> ".red())

--- a/ratatui-widgets/examples/list.rs
+++ b/ratatui-widgets/examples/list.rs
@@ -17,6 +17,7 @@
 use crossterm::event::{self, KeyCode};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::macros::list_items;
 use ratatui::style::{Color, Modifier, Style, Stylize};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{List, ListDirection, ListState};
@@ -62,8 +63,8 @@ fn render(frame: &mut Frame, list_state: &mut ListState) {
 
 /// Render a list.
 pub fn render_list(frame: &mut Frame, area: Rect, list_state: &mut ListState) {
-    let items = ["Item 1", "Item 2", "Item 3", "Item 4"];
-    let list = List::new(items)
+    let items = list_items!["Item 1", "Item 2", "Item 3", "Item 4"];
+    let list = List::from(&items)
         .style(Color::White)
         .highlight_style(Modifier::REVERSED)
         .highlight_symbol("> ");
@@ -73,13 +74,13 @@ pub fn render_list(frame: &mut Frame, area: Rect, list_state: &mut ListState) {
 
 /// Render a bottom-to-top list.
 pub fn render_bottom_list(frame: &mut Frame, area: Rect) {
-    let items = [
+    let items = list_items![
         "[Remy]: I'm building one now.\nIt even supports multiline text!",
         "[Gusteau]: With enough passion, yes.",
         "[Remy]: But can anyone build a TUI in Rust?",
         "[Gusteau]: Anyone can cook!",
     ];
-    let list = List::new(items)
+    let list = List::from(&items)
         .style(Color::White)
         .highlight_style(Style::new().yellow().italic())
         .highlight_symbol("> ".red())

--- a/ratatui-widgets/examples/table.rs
+++ b/ratatui-widgets/examples/table.rs
@@ -84,7 +84,8 @@ pub fn render_table(frame: &mut Frame, area: Rect, table_state: &mut TableState)
         Constraint::Percentage(20),
         Constraint::Percentage(50),
     ];
-    let table = Table::new(rows, widths)
+    let table = Table::from(&rows)
+        .widths(widths)
         .header(header)
         .footer(footer.italic())
         .column_spacing(1)

--- a/ratatui-widgets/examples/table.rs
+++ b/ratatui-widgets/examples/table.rs
@@ -29,8 +29,26 @@ fn main() -> Result<()> {
     table_state.select_first();
     table_state.select_first_column();
     ratatui::run(|terminal| {
+        let header = Row::new(["Ingredient", "Quantity", "Macros"])
+            .style(Style::new().bold())
+            .bottom_margin(1);
+
+        let rows = [
+            Row::new(["Eggplant", "1 medium", "25 kcal, 6g carbs, 1g protein"]),
+            Row::new(["Tomato", "2 large", "44 kcal, 10g carbs, 2g protein"]),
+            Row::new(["Zucchini", "1 medium", "33 kcal, 7g carbs, 2g protein"]),
+            Row::new(["Bell Pepper", "1 medium", "24 kcal, 6g carbs, 1g protein"]),
+            Row::new(["Garlic", "2 cloves", "9 kcal, 2g carbs, 0.4g protein"]),
+        ];
+        let footer = Row::new([
+            "Ratatouille Recipe",
+            "",
+            "135 kcal, 31g carbs, 6.4g protein",
+        ])
+        .italic();
+
         loop {
-            terminal.draw(|frame| render(frame, &mut table_state))?;
+            terminal.draw(|frame| render(frame, &mut table_state, &header, &rows, &footer))?;
             if let Some(key) = event::read()?.as_key_press_event() {
                 match key.code {
                     KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
@@ -48,7 +66,13 @@ fn main() -> Result<()> {
 }
 
 /// Render the UI with a table.
-fn render(frame: &mut Frame, table_state: &mut TableState) {
+fn render<'a>(
+    frame: &mut Frame,
+    table_state: &mut TableState,
+    header: &'a Row<'a>,
+    rows: &'a [Row<'a>],
+    footer: &'a Row<'a>,
+) {
     let layout = Layout::vertical([Constraint::Length(1), Constraint::Fill(1)]).spacing(1);
     let [top, main] = frame.area().layout(&layout);
 
@@ -58,36 +82,27 @@ fn render(frame: &mut Frame, table_state: &mut TableState) {
     ]);
     frame.render_widget(title.centered(), top);
 
-    render_table(frame, main, table_state);
+    render_table(frame, main, table_state, header, rows, footer);
 }
 
 /// Render a table with some rows and columns.
-pub fn render_table(frame: &mut Frame, area: Rect, table_state: &mut TableState) {
-    let header = Row::new(["Ingredient", "Quantity", "Macros"])
-        .style(Style::new().bold())
-        .bottom_margin(1);
-
-    let rows = [
-        Row::new(["Eggplant", "1 medium", "25 kcal, 6g carbs, 1g protein"]),
-        Row::new(["Tomato", "2 large", "44 kcal, 10g carbs, 2g protein"]),
-        Row::new(["Zucchini", "1 medium", "33 kcal, 7g carbs, 2g protein"]),
-        Row::new(["Bell Pepper", "1 medium", "24 kcal, 6g carbs, 1g protein"]),
-        Row::new(["Garlic", "2 cloves", "9 kcal, 2g carbs, 0.4g protein"]),
-    ];
-    let footer = Row::new([
-        "Ratatouille Recipe",
-        "",
-        "135 kcal, 31g carbs, 6.4g protein",
-    ]);
+pub fn render_table<'a>(
+    frame: &mut Frame,
+    area: Rect,
+    table_state: &mut TableState,
+    header: &'a Row<'a>,
+    rows: &'a [Row<'a>],
+    footer: &'a Row<'a>,
+) {
     let widths = [
         Constraint::Percentage(30),
         Constraint::Percentage(20),
         Constraint::Percentage(50),
     ];
-    let table = Table::from(&rows)
+    let table = Table::from(rows)
         .widths(widths)
         .header(header)
-        .footer(footer.italic())
+        .footer(footer)
         .column_spacing(1)
         .style(Color::White)
         .row_highlight_style(Style::new().on_black().bold())

--- a/ratatui-widgets/src/list.rs
+++ b/ratatui-widgets/src/list.rs
@@ -27,6 +27,9 @@ mod state;
 ///
 /// [`Table`]: crate::table::Table
 ///
+/// List items can be created on the stack with the macro `list_items!` and used via
+/// [`List::from`] to avoid dynamic allocations.
+///
 /// List items can be aligned using [`Text::alignment`], for more details see [`ListItem`].
 ///
 /// [`List`] is also a [`StatefulWidget`], which means you can use it with [`ListState`] to allow
@@ -73,15 +76,18 @@ mod state;
 /// ```rust
 /// use ratatui::Frame;
 /// use ratatui::layout::Rect;
+/// use ratatui::macros::list_items;
 /// use ratatui::style::{Style, Stylize};
 /// use ratatui::widgets::{Block, List, ListState};
 ///
 /// # fn ui(frame: &mut Frame) {
 /// # let area = Rect::default();
+///
 /// // This should be stored outside of the function in your application state.
 /// let mut state = ListState::default();
-/// let items = ["Item 1", "Item 2", "Item 3"];
-/// let list = List::new(items)
+/// let items = list_items!["Item 1", "Item 2", "Item 3"];
+///
+/// let list = List::from(&items)
 ///     .block(Block::bordered().title("List"))
 ///     .highlight_style(Style::new().reversed())
 ///     .highlight_symbol(">>")
@@ -154,19 +160,21 @@ impl<'a> List<'a> {
     /// From a slice of [`&str`]
     ///
     /// ```
+    /// use ratatui::macros::list_items;
     /// use ratatui::widgets::List;
     ///
-    /// let list = List::new(["Item 1", "Item 2"]);
+    /// let list = List::new(list_items!["Item 1", "Item 2"]);
     /// ```
     ///
     /// From [`Text`]
     ///
     /// ```
+    /// use ratatui::macros::list_items;
     /// use ratatui::style::{Style, Stylize};
     /// use ratatui::text::Text;
     /// use ratatui::widgets::List;
     ///
-    /// let list = List::new([
+    /// let list = List::new(list_items![
     ///     Text::styled("Item 1", Style::new().red()),
     ///     Text::styled("Item 2", Style::new().red()),
     /// ]);
@@ -434,11 +442,10 @@ impl<'a> List<'a> {
     /// # Example
     ///
     /// ```
-    /// use ratatui::widgets::{List, ListItem};
+    /// use ratatui::widgets::List;
     ///
-    /// let items = [ListItem::new("Item 1"), ListItem::new("Item 2"), ListItem::new("Item 3")];
-    /// let list = List::from(&items);
-    /// assert!(list.is_borrowed());
+    /// let list = List::new(["Item 1", "Item 2", "Item 3"]);
+    /// assert!(list.is_owned());
     /// ```
     pub const fn is_owned(&self) -> bool {
         match self.items {
@@ -449,13 +456,27 @@ impl<'a> List<'a> {
 
     /// Returns whether the list borrows its items.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
+    /// use ratatui::widgets::{List, ListItem};
+    ///
+    /// let items = [
+    ///     ListItem::new("Item 1"),
+    ///     ListItem::new("Item 2"),
+    ///     ListItem::new("Item 3"),
+    /// ];
+    /// let list = List::from(&items);
+    /// assert!(list.is_borrowed());
+    /// ```
+    ///
+    /// ```
+    /// use ratatui::macros::list_items;
     /// use ratatui::widgets::List;
     ///
-    /// let list = List::new(["Item 1", "Item 2", "Item 3"]);
-    /// assert!(list.is_owned());
+    /// let items = list_items!["Item 1", "Item 2", "Item 3"];
+    /// let list = List::from(&items);
+    /// assert!(list.is_borrowed());
     /// ```
     pub const fn is_borrowed(&self) -> bool {
         !self.is_owned()

--- a/ratatui-widgets/src/list.rs
+++ b/ratatui-widgets/src/list.rs
@@ -1,6 +1,7 @@
 //! The [`List`] widget is used to display a list of items and allows selecting one or multiple
 //! items.
 
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 
 use ratatui_core::style::{Style, Styled};
@@ -105,12 +106,12 @@ mod state;
 /// [`Text::alignment`]: ratatui_core::text::Text::alignment
 /// [`StatefulWidget`]: ratatui_core::widgets::StatefulWidget
 /// [`Widget`]: ratatui_core::widgets::Widget
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
+#[derive(Debug, Clone, Default, Eq, Hash, PartialEq)]
 pub struct List<'a> {
     /// An optional block to wrap the widget in
     pub(crate) block: Option<Block<'a>>,
     /// The items in the list
-    pub(crate) items: Vec<ListItem<'a>>,
+    pub(crate) items: Cow<'a, [ListItem<'a>]>,
     /// Style used as a base style for the widget
     pub(crate) style: Style,
     /// List display direction
@@ -182,6 +183,7 @@ impl<'a> List<'a> {
     /// ```
     ///
     /// [`Text`]: ratatui_core::text::Text
+    #[must_use = "constructor"]
     pub fn new<T>(items: T) -> Self
     where
         T: IntoIterator,
@@ -426,6 +428,38 @@ impl<'a> List<'a> {
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
+
+    /// Returns whether the list owns its items.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ratatui::widgets::{List, ListItem};
+    ///
+    /// let items = [ListItem::new("Item 1"), ListItem::new("Item 2"), ListItem::new("Item 3")];
+    /// let list = List::from(&items);
+    /// assert!(list.is_borrowed());
+    /// ```
+    pub const fn is_owned(&self) -> bool {
+        match self.items {
+            Cow::Owned(_) => true,
+            Cow::Borrowed(_) => false,
+        }
+    }
+
+    /// Returns whether the list borrows its items.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ratatui::widgets::List;
+    ///
+    /// let list = List::new(["Item 1", "Item 2", "Item 3"]);
+    /// assert!(list.is_owned());
+    /// ```
+    pub const fn is_borrowed(&self) -> bool {
+        !self.is_owned()
+    }
 }
 
 impl Styled for List<'_> {
@@ -457,7 +491,53 @@ where
     Item: Into<ListItem<'a>>,
 {
     fn from_iter<Iter: IntoIterator<Item = Item>>(iter: Iter) -> Self {
-        Self::new(iter)
+        let items = iter.into_iter().map(Into::into).collect();
+        Self::from(Cow::Owned(items))
+    }
+}
+
+impl<'a> From<Cow<'a, [ListItem<'a>]>> for List<'a> {
+    fn from(value: Cow<'a, [ListItem<'a>]>) -> Self {
+        Self {
+            items: value,
+            ..Self::default()
+        }
+    }
+}
+
+impl<'a> From<Vec<ListItem<'a>>> for List<'a> {
+    fn from(value: Vec<ListItem<'a>>) -> Self {
+        Self {
+            items: Cow::Owned(value),
+            ..Self::default()
+        }
+    }
+}
+
+impl<'a> From<&'a Vec<ListItem<'a>>> for List<'a> {
+    fn from(value: &'a Vec<ListItem<'a>>) -> Self {
+        Self {
+            items: Cow::Borrowed(value),
+            ..Self::default()
+        }
+    }
+}
+
+impl<'a, const N: usize> From<&'a [ListItem<'a>; N]> for List<'a> {
+    fn from(value: &'a [ListItem<'a>; N]) -> Self {
+        Self {
+            items: Cow::Borrowed(value),
+            ..Self::default()
+        }
+    }
+}
+
+impl<'a> From<&'a [ListItem<'a>]> for List<'a> {
+    fn from(value: &'a [ListItem<'a>]) -> Self {
+        Self {
+            items: Cow::Borrowed(value),
+            ..Self::default()
+        }
     }
 }
 
@@ -479,6 +559,19 @@ mod tests {
         let collected: List = (0..3).map(|i| format!("Item{i}")).collect();
         let expected = List::new(["Item0", "Item1", "Item2"]);
         assert_eq!(collected, expected);
+    }
+
+    #[test]
+    fn fluent_items() {
+        let collected: List = (0..3).map(|i| format!("Item{i}")).collect();
+        assert_eq!(
+            collected.items,
+            Cow::<[ListItem]>::Owned(vec![
+                ListItem::from("Item0"),
+                "Item1".into(),
+                "Item2".into(),
+            ])
+        );
     }
 
     #[test]
@@ -653,5 +746,85 @@ mod tests {
         let list = List::new(items);
         // This should not panic, even if the buffer has zero size.
         list.render(buffer.area, &mut buffer, &mut state);
+    }
+
+    #[test]
+    fn from_cow_borrowed() {
+        let items = [ListItem::from("Item0")];
+        let cow: Cow<[ListItem<'_>]> = Cow::Borrowed(&items);
+        let list = List::from(cow);
+        assert_eq!(
+            list.items,
+            Cow::Borrowed(&[ListItem {
+                content: Text::from(Line::from("Item0")),
+                style: Style::new(),
+            }])
+        );
+    }
+
+    #[test]
+    fn from_cow_owned() {
+        let items: Vec<_> = [ListItem::from("Item0")].to_vec();
+        let cow: Cow<[ListItem<'_>]> = Cow::Owned(items);
+        let list = List::from(cow);
+        assert_eq!(
+            list.items,
+            Cow::<[ListItem]>::Owned(vec![ListItem {
+                content: Text::from(Line::from("Item0")),
+                style: Style::new(),
+            }])
+        );
+    }
+
+    #[test]
+    fn from_slice_borrowed() {
+        let items = [ListItem::from("Item0")];
+        let list = List::from(&items);
+        assert_eq!(
+            list.items,
+            Cow::Borrowed(&[ListItem {
+                content: Text::from(Line::from("Item0")),
+                style: Style::new(),
+            }])
+        );
+    }
+
+    #[test]
+    fn from_slice_owned() {
+        let items: Vec<_> = [ListItem::from("Item0")].to_vec();
+        let list = List::from(items.as_slice());
+        assert_eq!(
+            list.items,
+            Cow::<[ListItem]>::Owned(vec![ListItem {
+                content: Text::from(Line::from("Item0")),
+                style: Style::new(),
+            }])
+        );
+    }
+
+    #[test]
+    fn from_vec_borrowed() {
+        let items: Vec<_> = [ListItem::from("Item0")].to_vec();
+        let list = List::from(&items);
+        assert_eq!(
+            list.items,
+            Cow::Borrowed(&[ListItem {
+                content: Text::from(Line::from("Item0")),
+                style: Style::new(),
+            }])
+        );
+    }
+
+    #[test]
+    fn from_vec_owned() {
+        let items: Vec<_> = [ListItem::from("Item0")].to_vec();
+        let list = List::from(items);
+        assert_eq!(
+            list.items,
+            Cow::<[ListItem]>::Owned(vec![ListItem {
+                content: Text::from(Line::from("Item0")),
+                style: Style::new(),
+            }])
+        );
     }
 }

--- a/ratatui-widgets/src/list/item.rs
+++ b/ratatui-widgets/src/list/item.rs
@@ -112,6 +112,7 @@ impl<'a> ListItem<'a> {
     ///
     /// - [`List::new`](super::List::new) to create a list of items that can be converted to
     ///   [`ListItem`]
+    #[must_use = "constructor"]
     pub fn new<T>(content: T) -> Self
     where
         T: Into<Text<'a>>,

--- a/ratatui-widgets/src/table/cell.rs
+++ b/ratatui-widgets/src/table/cell.rs
@@ -75,6 +75,7 @@ impl<'a> Cell<'a> {
     /// ]));
     /// Cell::new(Text::from("a text"));
     /// ```
+    #[must_use = "constructor"]
     pub fn new<T>(content: T) -> Self
     where
         T: Into<Text<'a>>,

--- a/ratatui-widgets/src/table/row.rs
+++ b/ratatui-widgets/src/table/row.rs
@@ -1,5 +1,6 @@
 use alloc::borrow::Cow;
 use alloc::vec::Vec;
+use core::ops::Deref;
 
 use ratatui_core::style::{Style, Styled};
 
@@ -353,6 +354,38 @@ impl<'a> From<Cow<'a, [Cell<'a>]>> for Row<'a> {
             cells: value,
             ..Self::default()
         }
+    }
+}
+
+/// A copy-on-write container for a row of cells.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum RowCow<'a> {
+    /// A borrowed row of cells.
+    Borrowed(&'a Row<'a>),
+    /// An owned row of cells.
+    Owned(Row<'a>),
+}
+
+impl<'a> Deref for RowCow<'a> {
+    type Target = Row<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            RowCow::Borrowed(row) => row,
+            RowCow::Owned(row) => row,
+        }
+    }
+}
+
+impl<'a> From<&'a Row<'a>> for RowCow<'a> {
+    fn from(value: &'a Row<'a>) -> Self {
+        RowCow::Borrowed(value)
+    }
+}
+
+impl<'a> From<Row<'a>> for RowCow<'a> {
+    fn from(value: Row<'a>) -> Self {
+        RowCow::Owned(value)
     }
 }
 

--- a/ratatui-widgets/src/table/row.rs
+++ b/ratatui-widgets/src/table/row.rs
@@ -1,3 +1,4 @@
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 
 use ratatui_core::style::{Style, Styled};
@@ -73,7 +74,7 @@ use super::Cell;
 /// [`Stylize`]: ratatui_core::style::Stylize
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct Row<'a> {
-    pub(crate) cells: Vec<Cell<'a>>,
+    pub(crate) cells: Cow<'a, [Cell<'a>]>,
     pub(crate) height: u16,
     pub(crate) top_margin: u16,
     pub(crate) bottom_margin: u16,
@@ -98,6 +99,7 @@ impl<'a> Row<'a> {
     ///     Cell::new("Cell 3"),
     /// ]);
     /// ```
+    #[must_use = "constructor"]
     pub fn new<T>(cells: T) -> Self
     where
         T: IntoIterator,
@@ -239,6 +241,43 @@ impl<'a> Row<'a> {
         self.style = style.into();
         self
     }
+
+    /// Return whether the row owns its cells.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ratatui::widgets::{Cell, Row};
+    ///
+    /// let cells = vec!["Cell 1", "Cell 2", "Cell 3"];
+    /// let row = Row::new(cells);
+    /// assert!(row.is_owned());
+    /// ```
+    pub const fn is_owned(&self) -> bool {
+        match self.cells {
+            Cow::Borrowed(_) => false,
+            Cow::Owned(_) => true,
+        }
+    }
+
+    /// Return whether the row borrows its cells.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ratatui::widgets::{Cell, Row};
+    ///
+    /// let cells = [
+    ///     Cell::from("Cell 1"),
+    ///     Cell::from("Cell 2"),
+    ///     Cell::from("Cell 3"),
+    /// ];
+    /// let row = Row::from(&cells);
+    /// assert!(row.is_borrowed());
+    /// ```
+    pub const fn is_borrowed(&self) -> bool {
+        !self.is_owned()
+    }
 }
 
 // private methods for rendering
@@ -263,12 +302,57 @@ impl Styled for Row<'_> {
     }
 }
 
+impl<'a> From<Vec<Cell<'a>>> for Row<'a> {
+    fn from(value: Vec<Cell<'a>>) -> Self {
+        Self {
+            cells: Cow::Owned(value),
+            ..Self::default()
+        }
+    }
+}
+
+impl<'a> From<&'a Vec<Cell<'a>>> for Row<'a> {
+    fn from(value: &'a Vec<Cell<'a>>) -> Self {
+        Self {
+            cells: Cow::Borrowed(value),
+            ..Self::default()
+        }
+    }
+}
+
+impl<'a> From<&'a [Cell<'a>]> for Row<'a> {
+    fn from(value: &'a [Cell<'a>]) -> Self {
+        Self {
+            cells: Cow::Borrowed(value),
+            ..Self::default()
+        }
+    }
+}
+
+impl<'a, const N: usize> From<&'a [Cell<'a>; N]> for Row<'a> {
+    fn from(value: &'a [Cell<'a>; N]) -> Self {
+        Self {
+            cells: Cow::Borrowed(value),
+            ..Self::default()
+        }
+    }
+}
+
 impl<'a, Item> FromIterator<Item> for Row<'a>
 where
     Item: Into<Cell<'a>>,
 {
     fn from_iter<IterCells: IntoIterator<Item = Item>>(cells: IterCells) -> Self {
         Self::new(cells)
+    }
+}
+
+impl<'a> From<Cow<'a, [Cell<'a>]>> for Row<'a> {
+    fn from(value: Cow<'a, [Cell<'a>]>) -> Self {
+        Self {
+            cells: value,
+            ..Self::default()
+        }
     }
 }
 
@@ -299,6 +383,34 @@ mod tests {
         let cells = vec![Cell::from("")];
         let row = Row::default().cells(cells.clone());
         assert_eq!(row.cells, cells);
+    }
+
+    #[test]
+    fn from_vec() {
+        let cells = vec![Cell::from("")];
+        let row = Row::from(cells);
+        assert_eq!(row.cells, Cow::<[Cell]>::Owned(vec![Cell::new("")]));
+    }
+
+    #[test]
+    fn from_vec_ref() {
+        let cells = vec![Cell::from("")];
+        let row = Row::from(&cells);
+        assert_eq!(row.cells, Cow::Borrowed(&[Cell::new("")]));
+    }
+
+    #[test]
+    fn from_slice() {
+        let cells = vec![Cell::from("")];
+        let row = Row::from(cells.as_slice());
+        assert_eq!(row.cells, Cow::Borrowed(&[Cell::new("")]));
+    }
+
+    #[test]
+    fn from_array() {
+        let cells = [Cell::from("")];
+        let row = Row::from(&cells);
+        assert_eq!(row.cells, Cow::Borrowed(&[Cell::new("")]));
     }
 
     #[test]
@@ -341,5 +453,21 @@ mod tests {
                 .add_modifier(Modifier::BOLD)
                 .remove_modifier(Modifier::ITALIC)
         );
+    }
+
+    #[test]
+    fn from_cow_borrowed() {
+        let cells: [_; 1] = [Cell::from("Item0")];
+        let cow: Cow<[Cell<'_>]> = Cow::Borrowed(&cells);
+        let row = Row::from(cow);
+        assert_eq!(row.cells, Cow::Borrowed(&[Cell::from("Item0")]));
+    }
+
+    #[test]
+    fn from_cow_owned() {
+        let cells: Vec<_> = [Cell::from("Item0")].to_vec();
+        let cow: Cow<[Cell<'_>]> = Cow::Owned(cells);
+        let row = Row::from(cow);
+        assert_eq!(row.cells, Cow::<[Cell]>::Owned(vec![Cell::from("Item0")]));
     }
 }

--- a/ratatui/benches/main/list.rs
+++ b/ratatui/benches/main/list.rs
@@ -16,14 +16,14 @@ fn list(c: &mut Criterion) {
         // Render default list
         group.bench_with_input(
             BenchmarkId::new("render", line_count),
-            &List::new(lines.clone()),
+            &List::from(&lines),
             render,
         );
 
         // Render with an offset to the middle of the list and a selected item
         group.bench_with_input(
             BenchmarkId::new("render_scroll_half", line_count),
-            &List::new(lines.clone()).highlight_symbol(">>"),
+            &List::from(&lines).highlight_symbol(">>"),
             |b, list| {
                 render_stateful(
                     b,

--- a/ratatui/benches/main/table.rs
+++ b/ratatui/benches/main/table.rs
@@ -18,14 +18,16 @@ fn table(c: &mut Criterion) {
             // Render default table
             group.bench_with_input(
                 BenchmarkId::new("render", &bench_sizes),
-                &Table::new(rows.clone(), [] as [Constraint; 0]),
+                &Table::from(&rows).widths([] as [Constraint; 0]),
                 render,
             );
 
             // Render with an offset to the middle of the table and a selected row
             group.bench_with_input(
                 BenchmarkId::new("render_scroll_half", &bench_sizes),
-                &Table::new(rows, [] as [Constraint; 0]).highlight_symbol(">>"),
+                &Table::from(&rows)
+                    .widths([] as [Constraint; 0])
+                    .highlight_symbol(">>"),
                 |b, table| {
                     render_stateful(
                         b,


### PR DESCRIPTION
Use a Copy-on-Write type for the contents of tables and lists so their content can be cached and only recomputed on actual changes.  This avoids unnecessary computations for the rendering in case of unchanged data.

Related to ratatui/ratatui-table#5.

Contains first commit of ratatui/ratatui#1791, with `'lend` and `'data` lifetimes combined into `'a`.
