### PR TITLE
perf(ratatui-core): add unified text to prevent unnecessary heap allocation in table and listitem

### DIFF
--- a/examples/apps/hyperlink/src/main.rs
+++ b/examples/apps/hyperlink/src/main.rs
@@ -13,7 +13,7 @@ use ratatui::DefaultTerminal;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Stylize;
-use ratatui::text::{Line, Text};
+use ratatui::text::{Line, UnifiedText};
 use ratatui::widgets::Widget;
 
 fn main() -> Result<()> {
@@ -53,12 +53,12 @@ impl App {
 ///
 /// [OSC 8]: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
 struct Hyperlink<'content> {
-    text: Text<'content>,
+    text: UnifiedText<'content>,
     url: String,
 }
 
 impl<'content> Hyperlink<'content> {
-    fn new(text: impl Into<Text<'content>>, url: impl Into<String>) -> Self {
+    fn new(text: impl Into<UnifiedText<'content>>, url: impl Into<String>) -> Self {
         Self {
             text: text.into(),
             url: url.into(),

--- a/ratatui-core/src/text.rs
+++ b/ratatui-core/src/text.rs
@@ -62,3 +62,6 @@ pub use span::{Span, ToSpan};
 
 mod text;
 pub use text::{Text, ToText};
+
+mod unified;
+pub use unified::{ToUnifiedLine, ToUnifiedSpan, ToUnifiedText, UnifiedText};

--- a/ratatui-core/src/text/unified.rs
+++ b/ratatui-core/src/text/unified.rs
@@ -1,0 +1,220 @@
+use alloc::borrow::Cow;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt::{Debug, Display, Formatter, Result};
+
+use super::{Line, Span, Text, ToLine, ToSpan, ToText};
+use crate::buffer::Buffer;
+use crate::layout::Rect;
+use crate::style::{Style, Styled};
+use crate::widgets::Widget;
+
+/// A wrapper arround three different ratatuis text types
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum UnifiedText<'a> {
+    Span(Span<'a>),
+    Line(Line<'a>),
+    Text(Text<'a>),
+}
+
+impl<'a> UnifiedText<'a> {
+    pub fn raw<T: Into<Cow<'a, str>>>(s: T) -> Self {
+        let s = s.into();
+        if s.contains('\n') {
+            Self::Text(s.into())
+        } else {
+            Self::Span(s.into())
+        }
+    }
+
+    pub fn height(&self) -> usize {
+        if let Self::Text(text) = self {
+            text.height()
+        } else {
+            1
+        }
+    }
+
+    pub fn width(&self) -> usize {
+        match self {
+            UnifiedText::Span(span) => span.width(),
+            UnifiedText::Line(line) => line.width(),
+            UnifiedText::Text(text) => text.width(),
+        }
+    }
+}
+
+pub trait ToUnifiedSpan {
+    fn to_unified_span(&self) -> UnifiedText<'_>;
+}
+
+impl<T: ToSpan> ToUnifiedSpan for T {
+    fn to_unified_span(&self) -> UnifiedText<'_> {
+        UnifiedText::Span(self.to_span())
+    }
+}
+
+pub trait ToUnifiedLine {
+    fn to_unified_line(&self) -> UnifiedText<'_>;
+}
+
+impl<T: ToLine> ToUnifiedLine for T {
+    fn to_unified_line(&self) -> UnifiedText<'_> {
+        UnifiedText::Line(self.to_line())
+    }
+}
+
+pub trait ToUnifiedText {
+    fn to_unified_text(&self) -> UnifiedText<'_>;
+}
+
+impl<T: ToText> ToUnifiedText for T {
+    fn to_unified_text(&self) -> UnifiedText<'_> {
+        UnifiedText::Text(self.to_text())
+    }
+}
+
+impl Default for UnifiedText<'_> {
+    fn default() -> Self {
+        Self::Span(Span::default())
+    }
+}
+
+impl<'a> From<Span<'a>> for UnifiedText<'a> {
+    fn from(value: Span<'a>) -> Self {
+        Self::Span(value)
+    }
+}
+
+impl<'a> From<Line<'a>> for UnifiedText<'a> {
+    fn from(value: Line<'a>) -> Self {
+        Self::Line(value)
+    }
+}
+
+impl<'a> From<Text<'a>> for UnifiedText<'a> {
+    fn from(value: Text<'a>) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl Styled for UnifiedText<'_> {
+    type Item = Self;
+
+    fn style(&self) -> Style {
+        match self {
+            UnifiedText::Span(span) => span.style(),
+            UnifiedText::Line(line) => line.style(),
+            UnifiedText::Text(text) => text.style(),
+        }
+    }
+
+    fn set_style<S: Into<Style>>(self, style: S) -> Self::Item {
+        match self {
+            UnifiedText::Span(span) => UnifiedText::Span(span.set_style(style)),
+            UnifiedText::Line(line) => UnifiedText::Line(line.set_style(style)),
+            UnifiedText::Text(text) => UnifiedText::Text(text.set_style(style)),
+        }
+    }
+}
+
+impl Widget for &UnifiedText<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        match self {
+            UnifiedText::Span(span) => span.render(area, buf),
+            UnifiedText::Line(line) => line.render(area, buf),
+            UnifiedText::Text(text) => text.render(area, buf),
+        }
+    }
+}
+
+impl Widget for UnifiedText<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        match self {
+            UnifiedText::Span(span) => span.render(area, buf),
+            UnifiedText::Line(line) => line.render(area, buf),
+            UnifiedText::Text(text) => text.render(area, buf),
+        }
+    }
+}
+
+impl From<String> for UnifiedText<'_> {
+    fn from(s: String) -> Self {
+        Self::raw(s)
+    }
+}
+
+impl<'a> From<&'a str> for UnifiedText<'a> {
+    fn from(s: &'a str) -> Self {
+        Self::raw(s)
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for UnifiedText<'a> {
+    fn from(s: Cow<'a, str>) -> Self {
+        Self::raw(s)
+    }
+}
+
+impl<'a> From<Vec<Line<'a>>> for UnifiedText<'a> {
+    fn from(lines: Vec<Line<'a>>) -> Self {
+        Self::Text(lines.into())
+    }
+}
+
+impl<'a> From<Vec<Span<'a>>> for UnifiedText<'a> {
+    fn from(spans: Vec<Span<'a>>) -> Self {
+        Self::Line(spans.into())
+    }
+}
+
+impl<'a, T> FromIterator<T> for UnifiedText<'a>
+where
+    T: Into<Line<'a>>,
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self::Text(Text::from_iter(iter))
+    }
+}
+
+impl Display for UnifiedText<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            UnifiedText::Span(span) => Display::fmt(span, f),
+            UnifiedText::Line(line) => Display::fmt(line, f),
+            UnifiedText::Text(text) => Display::fmt(text, f),
+        }
+    }
+}
+
+impl<'a> From<UnifiedText<'a>> for Text<'a> {
+    fn from(value: UnifiedText<'a>) -> Self {
+        match value {
+            UnifiedText::Span(span) => span.into(),
+            UnifiedText::Line(line) => line.into(),
+            UnifiedText::Text(text) => text,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::text::{ToUnifiedSpan, ToUnifiedText, UnifiedText};
+    #[test]
+    fn from_multiline_str() {
+        let str = "Hello\nWorld!";
+        assert_eq!(UnifiedText::raw(str), str.to_unified_text());
+    }
+
+    #[test]
+    fn from_str() {
+        let str = "Hello World!";
+        assert_eq!(UnifiedText::raw(str), str.to_unified_span());
+    }
+}

--- a/ratatui-widgets/src/list/item.rs
+++ b/ratatui-widgets/src/list/item.rs
@@ -1,5 +1,5 @@
 use ratatui_core::style::Style;
-use ratatui_core::text::Text;
+use ratatui_core::text::UnifiedText;
 
 /// A single item in a [`List`]
 ///
@@ -8,12 +8,12 @@ use ratatui_core::text::Text;
 /// lines.
 ///
 /// You can set the style of an item with [`ListItem::style`] or using the [`Stylize`] trait.
-/// This [`Style`] will be combined with the [`Style`] of the inner [`Text`]. The [`Style`]
+/// This [`Style`] will be combined with the [`Style`] of the inner [`UnifiedText`]. The [`Style`]
 /// of the [`Text`] will be added to the [`Style`] of the [`ListItem`].
 ///
-/// You can also align a `ListItem` by aligning its underlying [`Text`] and [`Line`]s. For that,
-/// see [`Text::alignment`] and [`Line::alignment`]. On a multiline `Text`, one `Line` can override
-/// the alignment by setting it explicitly.
+/// You can also align a `ListItem` by aligning its underlying [`UnifiedText`] and [`Line`]s. For
+/// that, see [`Text::alignment`] and [`Line::alignment`]. On a multiline `UnifiedText`, one `Line`
+/// can override the alignment by setting it explicitly.
 ///
 /// # Examples
 ///
@@ -24,7 +24,7 @@ use ratatui_core::text::Text;
 /// let item = ListItem::new("Item 1");
 /// ```
 ///
-/// Anything that can be converted to [`Text`] can be a [`ListItem`].
+/// Anything that can be converted to [`UnifiedText`] can be a [`ListItem`].
 ///
 /// ```rust
 /// use ratatui::text::Line;
@@ -71,14 +71,14 @@ use ratatui_core::text::Text;
 /// [`Line::alignment`]: ratatui_core::text::Line::alignment
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct ListItem<'a> {
-    pub(crate) content: Text<'a>,
+    pub(crate) content: UnifiedText<'a>,
     pub(crate) style: Style,
 }
 
 impl<'a> ListItem<'a> {
     /// Creates a new [`ListItem`]
     ///
-    /// The `content` parameter accepts any value that can be converted into [`Text`].
+    /// The `content` parameter accepts any value that can be converted into [`UnifiedText`].
     ///
     /// # Examples
     ///
@@ -90,7 +90,7 @@ impl<'a> ListItem<'a> {
     /// let item = ListItem::new("Item 1");
     /// ```
     ///
-    /// Anything that can be converted to [`Text`] can be a [`ListItem`].
+    /// Anything that can be converted to [`UnifiedText`] can be a [`ListItem`].
     ///
     /// ```rust
     /// use ratatui::text::Line;
@@ -114,7 +114,7 @@ impl<'a> ListItem<'a> {
     ///   [`ListItem`]
     pub fn new<T>(content: T) -> Self
     where
-        T: Into<Text<'a>>,
+        T: Into<UnifiedText<'a>>,
     {
         Self {
             content: content.into(),
@@ -209,7 +209,7 @@ impl<'a> ListItem<'a> {
 
 impl<'a, T> From<T> for ListItem<'a>
 where
-    T: Into<Text<'a>>,
+    T: Into<UnifiedText<'a>>,
 {
     fn from(value: T) -> Self {
         Self::new(value)
@@ -231,21 +231,21 @@ mod tests {
     #[test]
     fn new_from_str() {
         let item = ListItem::new("Test item");
-        assert_eq!(item.content, Text::from("Test item"));
+        assert_eq!(item.content, UnifiedText::from("Test item"));
         assert_eq!(item.style, Style::default());
     }
 
     #[test]
     fn new_from_string() {
         let item = ListItem::new("Test item".to_string());
-        assert_eq!(item.content, Text::from("Test item"));
+        assert_eq!(item.content, UnifiedText::from("Test item"));
         assert_eq!(item.style, Style::default());
     }
 
     #[test]
     fn new_from_cow_str() {
         let item = ListItem::new(Cow::Borrowed("Test item"));
-        assert_eq!(item.content, Text::from("Test item"));
+        assert_eq!(item.content, UnifiedText::from("Test item"));
         assert_eq!(item.style, Style::default());
     }
 
@@ -253,7 +253,7 @@ mod tests {
     fn new_from_span() {
         let span = Span::styled("Test item", Style::default().fg(Color::Blue));
         let item = ListItem::new(span.clone());
-        assert_eq!(item.content, Text::from(span));
+        assert_eq!(item.content, UnifiedText::from(span));
         assert_eq!(item.style, Style::default());
     }
 
@@ -264,7 +264,7 @@ mod tests {
             Span::styled("item", Style::default().fg(Color::Red)),
         ]);
         let item = ListItem::new(spans.clone());
-        assert_eq!(item.content, Text::from(spans));
+        assert_eq!(item.content, UnifiedText::from(spans));
         assert_eq!(item.style, Style::default());
     }
 
@@ -281,7 +281,7 @@ mod tests {
             ]),
         ];
         let item = ListItem::new(lines.clone());
-        assert_eq!(item.content, Text::from(lines));
+        assert_eq!(item.content, UnifiedText::from(lines));
         assert_eq!(item.style, Style::default());
     }
 
@@ -289,7 +289,7 @@ mod tests {
     fn str_into_list_item() {
         let s = "Test item";
         let item: ListItem = s.into();
-        assert_eq!(item.content, Text::from(s));
+        assert_eq!(item.content, UnifiedText::from(s));
         assert_eq!(item.style, Style::default());
     }
 
@@ -297,7 +297,7 @@ mod tests {
     fn string_into_list_item() {
         let s = String::from("Test item");
         let item: ListItem = s.clone().into();
-        assert_eq!(item.content, Text::from(s));
+        assert_eq!(item.content, UnifiedText::from(s));
         assert_eq!(item.style, Style::default());
     }
 
@@ -305,7 +305,7 @@ mod tests {
     fn span_into_list_item() {
         let s = Span::from("Test item");
         let item: ListItem = s.clone().into();
-        assert_eq!(item.content, Text::from(s));
+        assert_eq!(item.content, UnifiedText::from(s));
         assert_eq!(item.style, Style::default());
     }
 
@@ -313,14 +313,14 @@ mod tests {
     fn vec_lines_into_list_item() {
         let lines = vec![Line::raw("l1"), Line::raw("l2")];
         let item: ListItem = lines.clone().into();
-        assert_eq!(item.content, Text::from(lines));
+        assert_eq!(item.content, UnifiedText::from(lines));
         assert_eq!(item.style, Style::default());
     }
 
     #[test]
     fn style() {
         let item = ListItem::new("Test item").style(Style::default().bg(Color::Red));
-        assert_eq!(item.content, Text::from("Test item"));
+        assert_eq!(item.content, UnifiedText::from("Test item"));
         assert_eq!(item.style, Style::default().bg(Color::Red));
     }
 

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::{Constraint, Flex, Layout, Rect};
 use ratatui_core::style::{Style, Styled};
-use ratatui_core::text::Text;
+use ratatui_core::text::UnifiedText;
 use ratatui_core::widgets::{StatefulWidget, Widget};
 
 pub use self::cell::Cell;
@@ -262,7 +262,7 @@ pub struct Table<'a> {
     cell_highlight_style: Style,
 
     /// Symbol in front of the selected row
-    highlight_symbol: Text<'a>,
+    highlight_symbol: UnifiedText<'a>,
 
     /// Decides when to allocate spacing for the row selection
     highlight_spacing: HighlightSpacing,
@@ -284,7 +284,7 @@ impl Default for Table<'_> {
             row_highlight_style: Style::new(),
             column_highlight_style: Style::new(),
             cell_highlight_style: Style::new(),
-            highlight_symbol: Text::default(),
+            highlight_symbol: UnifiedText::default(),
             highlight_spacing: HighlightSpacing::default(),
             flex: Flex::Start,
         }
@@ -653,7 +653,7 @@ impl<'a> Table<'a> {
     /// let table = Table::new(rows, widths).highlight_symbol(">>");
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn highlight_symbol<T: Into<Text<'a>>>(mut self, highlight_symbol: T) -> Self {
+    pub fn highlight_symbol<T: Into<UnifiedText<'a>>>(mut self, highlight_symbol: T) -> Self {
         self.highlight_symbol = highlight_symbol.into();
         self
     }
@@ -1063,7 +1063,7 @@ mod tests {
         assert_eq!(table.block, None);
         assert_eq!(table.style, Style::default());
         assert_eq!(table.row_highlight_style, Style::default());
-        assert_eq!(table.highlight_symbol, Text::default());
+        assert_eq!(table.highlight_symbol, UnifiedText::default());
         assert_eq!(table.highlight_spacing, HighlightSpacing::WhenSelected);
         assert_eq!(table.flex, Flex::Start);
     }
@@ -1079,7 +1079,7 @@ mod tests {
         assert_eq!(table.block, None);
         assert_eq!(table.style, Style::default());
         assert_eq!(table.row_highlight_style, Style::default());
-        assert_eq!(table.highlight_symbol, Text::default());
+        assert_eq!(table.highlight_symbol, UnifiedText::default());
         assert_eq!(table.highlight_spacing, HighlightSpacing::WhenSelected);
         assert_eq!(table.flex, Flex::Start);
     }
@@ -1192,7 +1192,7 @@ mod tests {
     #[test]
     fn highlight_symbol() {
         let table = Table::default().highlight_symbol(">>");
-        assert_eq!(table.highlight_symbol, Text::from(">>"));
+        assert_eq!(table.highlight_symbol, UnifiedText::from(">>"));
     }
 
     #[test]
@@ -1468,8 +1468,8 @@ mod tests {
             let rows = vec![
                 Row::new(vec!["Cell1", "Cell2"]),
                 Row::new(vec![
-                    Text::raw("Cell3-Line1\nCell3-Line2\nCell3-Line3"),
-                    Text::raw("Cell4-Line1\nCell4-Line2\nCell4-Line3"),
+                    UnifiedText::raw("Cell3-Line1\nCell3-Line2\nCell3-Line3"),
+                    UnifiedText::raw("Cell4-Line1\nCell4-Line2\nCell4-Line3"),
                 ])
                 .height(3),
             ];


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
Resolves #1904
`Cell` and `ListItem` now use `UnifiedText` which is either a `Span` a `Line` or `Text`. This avoids unnecessary heap allocation. The enum is not yet documented properly, but it is 100% compatible as everything convertible to `Text` is also convertible to `UnifiedText`

