### PR TITLE
chore(ci): stop publish-alpha from running on forks

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -15,6 +15,7 @@ jobs:
   publish-alpha:
     name: Create an alpha release
     runs-on: ubuntu-latest
+    if: github.repository == 'ratatui/ratatui'
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
I can't sleep because every Saturday alpha release fails on my ratatui fork. This should fix my insomnia.