### PR TITLE
chore: remove OpenSSL license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,7 +9,6 @@ allow = [
   "BSD-3-Clause",
   "ISC",
   "MIT",
-  "OpenSSL",
   "Unicode-3.0",
   "Unicode-DFS-2016",
   "WTFPL",


### PR DESCRIPTION
Only keep licenses in the allow list that are actually used
