### PR TITLE
ci: use trusted publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
+      id-token: write
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'ratatui' }}
     steps:
@@ -29,13 +30,15 @@ jobs:
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # master
         with:
           toolchain: stable
+      - uses: rust-lang/crates-io-auth-action@63a7064947ceca9989005e118db3a5fecdc9259f # v1
+        id: auth
       - name: Run release-plz
         uses: release-plz/action@8724d33cd97b8295051102e2e19ca592962238f5 # v0.5
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:


### PR DESCRIPTION
https://blog.rust-lang.org/2025/07/11/crates-io-development-update-2025-07/
https://crates.io/docs/trusted-publishing

I've setup the crate settings so that they will correctly issue OIDC tokens for this.