### PR TITLE
chore: change Borders::NONE to a proper const

### DIFF
--- a/ratatui-widgets/src/borders.rs
+++ b/ratatui-widgets/src/borders.rs
@@ -10,8 +10,6 @@ bitflags! {
     #[derive(Default, Clone, Copy, Eq, PartialEq, Hash)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct Borders: u8 {
-        /// Show no border (default)
-        const NONE   = 0b0000;
         /// Show the top border
         const TOP    = 0b0001;
         /// Show the right border
@@ -23,6 +21,11 @@ bitflags! {
         /// Show all borders
         const ALL = Self::TOP.bits() | Self::RIGHT.bits() | Self::BOTTOM.bits() | Self::LEFT.bits();
     }
+}
+
+impl Borders {
+    /// Show no border (default)
+    pub const NONE: Self = Self::empty();
 }
 
 /// The type of border of a [`Block`](crate::block::Block).
@@ -172,13 +175,11 @@ impl BorderType {
     }
 }
 
-/// Implement the `Debug` trait for the `Borders` bitflags. This is a manual implementation to
-/// display the flags in a more readable way. The default implementation would display the
-/// flags as 'Border(0x0)' for `Borders::NONE` for example.
 impl fmt::Debug for Borders {
-    /// Display the Borders bitflags as a list of names. For example, `Borders::NONE` will be
-    /// displayed as `NONE` and `Borders::ALL` will be displayed as `ALL`. If multiple flags are
-    /// set, they will be displayed separated by a pipe character.
+    /// Display the Borders bitflags as a list of names.
+    ///
+    /// `Borders::NONE` is displayed as `NONE` and `Borders::ALL` is displayed as `ALL`. If multiple
+    /// flags are set, they are otherwise displayed separated by a pipe character.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_empty() {
             return write!(f, "NONE");
@@ -186,17 +187,12 @@ impl fmt::Debug for Borders {
         if self.is_all() {
             return write!(f, "ALL");
         }
-        let mut first = true;
-        for (name, border) in self.iter_names() {
-            if border == Self::NONE {
-                continue;
-            }
-            if first {
-                write!(f, "{name}")?;
-                first = false;
-            } else {
-                write!(f, " | {name}")?;
-            }
+        let mut names = self.iter_names().map(|(name, _)| name);
+        if let Some(first) = names.next() {
+            write!(f, "{first}")?;
+        }
+        for name in names {
+            write!(f, " | {name}")?;
         }
         Ok(())
     }


### PR DESCRIPTION
https://docs.rs/bitflags/latest/bitflags/#zero-bit-flags

> Flags with no bits set should be avoided because they interact strangely with [Flags::contains](https://docs.rs/bitflags/latest/bitflags/trait.Flags.html#method.contains) and [Flags::intersects](https://docs.rs/bitflags/latest/bitflags/trait.Flags.html#method.intersects). A zero-bit flag is always contained, but is never intersected. The names of zero-bit flags can be parsed, but are never formatted.

Removing this simplifies the manual Debug impl that previously had to check for Borders::NONE and now does not.

---

This is technically breaking (for anyone using contains / intersects), but not in a way that should have been reasonable to ever been relied upon as defined behavior. I'm leaning towards not documenting this as a breaking change because it's such an unlikely edge case to hit.