### PR TITLE
chore: remove clap-cargo from xtask

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,15 +295,6 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
@@ -329,26 +320,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
-dependencies = [
- "camino",
- "cargo-platform 0.1.9",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cfca2aaa699835ba88faf58a06342a314a950d2b9686165e038286c30316868"
 dependencies = [
  "camino",
- "cargo-platform 0.2.0",
+ "cargo-platform",
  "cargo-util-schemas",
  "semver",
  "serde",
@@ -451,19 +428,6 @@ checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
-]
-
-[[package]]
-name = "clap-cargo"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d546f0e84ff2bfa4da1ce9b54be42285767ba39c688572ca32412a09a73851e5"
-dependencies = [
- "anstyle",
- "cargo_metadata 0.19.2",
- "clap",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4470,9 +4434,8 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 name = "xtask"
 version = "0.0.0"
 dependencies = [
- "cargo_metadata 0.21.0",
+ "cargo_metadata",
  "clap",
- "clap-cargo",
  "clap-verbosity-flag",
  "color-eyre",
  "duct",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 [dependencies]
 cargo_metadata = "0.21"
 clap = { version = "4.5.41", features = ["derive"] }
-clap-cargo = { version = "0.15.1", features = ["cargo_metadata"] }
 clap-verbosity-flag = { version = "3.0.3", default-features = false, features = ["tracing"] }
 color-eyre = "0.6.5"
 duct = "1.0.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,6 +9,7 @@ use std::process::Output;
 
 use cargo_metadata::{MetadataCommand, TargetKind};
 use clap::Parser;
+use clap::builder::styling::{AnsiColor, Styles};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
 use color_eyre::Result;
 use color_eyre::eyre::Context;
@@ -39,8 +40,18 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+/// Matches the clap styling
+pub const HELP_STYLES: Styles = Styles::styled()
+    .header(AnsiColor::Green.on_default().bold())
+    .usage(AnsiColor::Green.on_default().bold())
+    .literal(AnsiColor::Cyan.on_default().bold())
+    .placeholder(AnsiColor::Cyan.on_default())
+    .error(AnsiColor::Red.on_default().bold())
+    .valid(AnsiColor::Cyan.on_default().bold())
+    .invalid(AnsiColor::Yellow.on_default().bold());
+
 #[derive(Debug, Parser)]
-#[command(bin_name = "cargo xtask", styles = clap_cargo::style::CLAP_STYLING)]
+#[command(bin_name = "cargo xtask", styles = HELP_STYLES)]
 struct Args {
     #[command(subcommand)]
     command: Command,


### PR DESCRIPTION
Removed to avoid needing to bump our msrv. See
https://github.com/rust-lang/cargo/issues/15746\#issuecomment-3071774343
for more details.

