### PR TITLE
fix: panic when rendering widgets on too small buffer

### DIFF
--- a/ratatui-widgets/src/barchart.rs
+++ b/ratatui-widgets/src/barchart.rs
@@ -1473,6 +1473,7 @@ mod tests {
         ]);
         assert_eq!(buffer, expected);
     }
+
     #[rstest]
     #[case::horizontal(Direction::Horizontal)]
     #[case::vertical(Direction::Vertical)]

--- a/ratatui-widgets/src/barchart.rs
+++ b/ratatui-widgets/src/barchart.rs
@@ -1477,7 +1477,7 @@ mod tests {
     #[rstest]
     #[case::horizontal(Direction::Horizontal)]
     #[case::vertical(Direction::Vertical)]
-    fn buffer_overflow(#[case] direction: Direction) {
+    fn render_in_minimal_buffer(#[case] direction: Direction) {
         let chart = BarChart::default()
             .data(&[("A", 1), ("B", 2)])
             .bar_width(3)

--- a/ratatui-widgets/src/barchart.rs
+++ b/ratatui-widgets/src/barchart.rs
@@ -1487,5 +1487,21 @@ mod tests {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         // This should not panic, even if the buffer is too small to render the chart.
         chart.render(buffer.area, &mut buffer);
+        assert_eq!(buffer, Buffer::with_lines([" "]));
+    }
+
+    #[rstest]
+    #[case::horizontal(Direction::Horizontal)]
+    #[case::vertical(Direction::Vertical)]
+    fn render_in_empty_buffer(#[case] direction: Direction) {
+        let chart = BarChart::default()
+            .data(&[("A", 1), ("B", 2)])
+            .bar_width(3)
+            .bar_gap(1)
+            .direction(direction);
+
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        // This should not panic, even if the buffer is empty.
+        chart.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/barchart.rs
+++ b/ratatui-widgets/src/barchart.rs
@@ -515,7 +515,7 @@ impl BarChart<'_> {
             let margin = u16::from(label_size != 0);
             Rect {
                 x: area.x + label_size + margin,
-                width: area.width.saturating_sub(label_size + margin),
+                width: area.width.saturating_sub(label_size).saturating_sub(margin),
                 ..area
             }
         };

--- a/ratatui-widgets/src/barchart.rs
+++ b/ratatui-widgets/src/barchart.rs
@@ -1493,15 +1493,15 @@ mod tests {
     #[rstest]
     #[case::horizontal(Direction::Horizontal)]
     #[case::vertical(Direction::Vertical)]
-    fn render_in_empty_buffer(#[case] direction: Direction) {
+    fn render_in_zero_size_buffer(#[case] direction: Direction) {
         let chart = BarChart::default()
             .data(&[("A", 1), ("B", 2)])
             .bar_width(3)
             .bar_gap(1)
             .direction(direction);
 
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
-        // This should not panic, even if the buffer is empty.
+        let mut buffer = Buffer::empty(Rect::ZERO);
+        // This should not panic, even if the buffer has zero size.
         chart.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/block.rs
+++ b/ratatui-widgets/src/block.rs
@@ -2147,9 +2147,9 @@ mod tests {
     }
 
     #[test]
-    fn render_in_empty_buffer() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
-        // This should not panic, even if the buffer is empty.
+    fn render_in_zero_size_buffer() {
+        let mut buffer = Buffer::empty(Rect::ZERO);
+        // This should not panic, even if the buffer has zero size.
         Block::bordered()
             .title("I'm too big for this buffer")
             .padding(Padding::uniform(10))

--- a/ratatui-widgets/src/block.rs
+++ b/ratatui-widgets/src/block.rs
@@ -2136,7 +2136,7 @@ mod tests {
     }
 
     #[test]
-    fn buffer_overflow() {
+    fn render_in_minimal_buffer() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         // This should not panic, even if the buffer is too small to render the block.
         Block::bordered()

--- a/ratatui-widgets/src/block.rs
+++ b/ratatui-widgets/src/block.rs
@@ -2143,5 +2143,16 @@ mod tests {
             .title("I'm too big for this buffer")
             .padding(Padding::uniform(10))
             .render(buffer.area, &mut buffer);
+        assert_eq!(buffer, Buffer::with_lines(["┌"]));
+    }
+
+    #[test]
+    fn render_in_empty_buffer() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        // This should not panic, even if the buffer is empty.
+        Block::bordered()
+            .title("I'm too big for this buffer")
+            .padding(Padding::uniform(10))
+            .render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/block.rs
+++ b/ratatui-widgets/src/block.rs
@@ -2134,4 +2134,14 @@ mod tests {
             .render(buffer.area, &mut buffer);
         assert_eq!(buffer, Buffer::with_lines(["  C1R67890"]));
     }
+
+    #[test]
+    fn buffer_overflow() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+        // This should not panic, even if the buffer is too small to render the block.
+        Block::bordered()
+            .title("I'm too big for this buffer")
+            .padding(Padding::uniform(10))
+            .render(buffer.area, &mut buffer);
+    }
 }

--- a/ratatui-widgets/src/calendar.rs
+++ b/ratatui-widgets/src/calendar.rs
@@ -316,13 +316,13 @@ mod tests {
     }
 
     #[test]
-    fn render_in_empty_buffer() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+    fn render_in_zero_size_buffer() {
+        let mut buffer = Buffer::empty(Rect::ZERO);
         let calendar = Monthly::new(
             Date::from_calendar_date(1984, Month::January, 1).unwrap(),
             CalendarEventStore::default(),
         );
-        // This should not panic, even if the buffer is empty.
+        // This should not panic, even if the buffer has zero size.
         calendar.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/calendar.rs
+++ b/ratatui-widgets/src/calendar.rs
@@ -307,7 +307,7 @@ mod tests {
     fn buffer_overflow() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let calendar = Monthly::new(
-            Date::from_calendar_date(2023, Month::January, 1).unwrap(),
+            Date::from_calendar_date(1984, Month::January, 1).unwrap(),
             CalendarEventStore::default(),
         );
         // This should not panic, even if the buffer is too small to render the calendar.

--- a/ratatui-widgets/src/calendar.rs
+++ b/ratatui-widgets/src/calendar.rs
@@ -304,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    fn buffer_overflow() {
+    fn render_in_minimal_buffer() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let calendar = Monthly::new(
             Date::from_calendar_date(1984, Month::January, 1).unwrap(),

--- a/ratatui-widgets/src/calendar.rs
+++ b/ratatui-widgets/src/calendar.rs
@@ -302,4 +302,15 @@ mod tests {
     fn test_today() {
         CalendarEventStore::today(Style::default());
     }
+
+    #[test]
+    fn buffer_overflow() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+        let calendar = Monthly::new(
+            Date::from_calendar_date(2023, Month::January, 1).unwrap(),
+            CalendarEventStore::default(),
+        );
+        // This should not panic, even if the buffer is too small to render the calendar.
+        calendar.render(buffer.area, &mut buffer);
+    }
 }

--- a/ratatui-widgets/src/calendar.rs
+++ b/ratatui-widgets/src/calendar.rs
@@ -312,5 +312,17 @@ mod tests {
         );
         // This should not panic, even if the buffer is too small to render the calendar.
         calendar.render(buffer.area, &mut buffer);
+        assert_eq!(buffer, Buffer::with_lines([" "]));
+    }
+
+    #[test]
+    fn render_in_empty_buffer() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        let calendar = Monthly::new(
+            Date::from_calendar_date(1984, Month::January, 1).unwrap(),
+            CalendarEventStore::default(),
+        );
+        // This should not panic, even if the buffer is empty.
+        calendar.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/canvas.rs
+++ b/ratatui-widgets/src/canvas.rs
@@ -978,7 +978,7 @@ mod tests {
     }
 
     #[test]
-    fn buffer_overflow() {
+    fn render_in_minimal_buffer() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let canvas = Canvas::default()
             .x_bounds([0.0, 10.0])

--- a/ratatui-widgets/src/canvas.rs
+++ b/ratatui-widgets/src/canvas.rs
@@ -976,4 +976,15 @@ mod tests {
         b_grid.paint(usize::MAX, usize::MAX, Color::Red);
         c_grid.paint(usize::MAX, usize::MAX, Color::Red);
     }
+
+    #[test]
+    fn buffer_overflow() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+        let canvas = Canvas::default()
+            .x_bounds([0.0, 10.0])
+            .y_bounds([0.0, 10.0])
+            .paint(|_ctx| {});
+        // This should not panic, even if the buffer is too small to render the canvas.
+        canvas.render(buffer.area, &mut buffer);
+    }
 }

--- a/ratatui-widgets/src/canvas.rs
+++ b/ratatui-widgets/src/canvas.rs
@@ -990,13 +990,13 @@ mod tests {
     }
 
     #[test]
-    fn render_in_empty_buffer() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+    fn render_in_zero_size_buffer() {
+        let mut buffer = Buffer::empty(Rect::ZERO);
         let canvas = Canvas::default()
             .x_bounds([0.0, 10.0])
             .y_bounds([0.0, 10.0])
             .paint(|_ctx| {});
-        // This should not panic, even if the buffer is empty.
+        // This should not panic, even if the buffer has zero size.
         canvas.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/canvas.rs
+++ b/ratatui-widgets/src/canvas.rs
@@ -986,5 +986,17 @@ mod tests {
             .paint(|_ctx| {});
         // This should not panic, even if the buffer is too small to render the canvas.
         canvas.render(buffer.area, &mut buffer);
+        assert_eq!(buffer, Buffer::with_lines([" "]));
+    }
+
+    #[test]
+    fn render_in_empty_buffer() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        let canvas = Canvas::default()
+            .x_bounds([0.0, 10.0])
+            .y_bounds([0.0, 10.0])
+            .paint(|_ctx| {});
+        // This should not panic, even if the buffer is empty.
+        canvas.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/chart.rs
+++ b/ratatui-widgets/src/chart.rs
@@ -1547,4 +1547,14 @@ mod tests {
         ]);
         assert_eq!(buffer, expected);
     }
+
+    #[test]
+    fn buffer_overflow() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+        let chart = Chart::new(vec![Dataset::default().data(&[(0.0, 0.0), (1.0, 1.0)])])
+            .x_axis(Axis::default().bounds([0.0, 1.0]))
+            .y_axis(Axis::default().bounds([0.0, 1.0]));
+        // This should not panic, even if the buffer is too small to render the chart.
+        chart.render(buffer.area, &mut buffer);
+    }
 }

--- a/ratatui-widgets/src/chart.rs
+++ b/ratatui-widgets/src/chart.rs
@@ -1560,12 +1560,12 @@ mod tests {
     }
 
     #[test]
-    fn render_in_empty_buffer() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+    fn render_in_zero_size_buffer() {
+        let mut buffer = Buffer::empty(Rect::ZERO);
         let chart = Chart::new(vec![Dataset::default().data(&[(0.0, 0.0), (1.0, 1.0)])])
             .x_axis(Axis::default().bounds([0.0, 1.0]))
             .y_axis(Axis::default().bounds([0.0, 1.0]));
-        // This should not panic, even if the buffer is empty.
+        // This should not panic, even if the buffer has zero size.
         chart.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/chart.rs
+++ b/ratatui-widgets/src/chart.rs
@@ -1549,7 +1549,7 @@ mod tests {
     }
 
     #[test]
-    fn buffer_overflow() {
+    fn render_in_minimal_buffer() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let chart = Chart::new(vec![Dataset::default().data(&[(0.0, 0.0), (1.0, 1.0)])])
             .x_axis(Axis::default().bounds([0.0, 1.0]))

--- a/ratatui-widgets/src/chart.rs
+++ b/ratatui-widgets/src/chart.rs
@@ -1556,5 +1556,16 @@ mod tests {
             .y_axis(Axis::default().bounds([0.0, 1.0]));
         // This should not panic, even if the buffer is too small to render the chart.
         chart.render(buffer.area, &mut buffer);
+        assert_eq!(buffer, Buffer::with_lines(["•"]));
+    }
+
+    #[test]
+    fn render_in_empty_buffer() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        let chart = Chart::new(vec![Dataset::default().data(&[(0.0, 0.0), (1.0, 1.0)])])
+            .x_axis(Axis::default().bounds([0.0, 1.0]))
+            .y_axis(Axis::default().bounds([0.0, 1.0]));
+        // This should not panic, even if the buffer is empty.
+        chart.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/gauge.rs
+++ b/ratatui-widgets/src/gauge.rs
@@ -606,18 +606,18 @@ mod tests {
     }
 
     #[test]
-    fn render_in_empty_buffer_gauge() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+    fn render_in_zero_size_buffer_gauge() {
+        let mut buffer = Buffer::empty(Rect::ZERO);
         let gauge = Gauge::default().percent(50);
-        // This should not panic, even if the buffer is empty.
+        // This should not panic, even if the buffer has zero size.
         gauge.render(buffer.area, &mut buffer);
     }
 
     #[test]
-    fn render_in_empty_buffer_line_gauge() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+    fn render_in_zero_size_buffer_line_gauge() {
+        let mut buffer = Buffer::empty(Rect::ZERO);
         let line_gauge = LineGauge::default().ratio(0.5);
-        // This should not panic, even if the buffer is empty.
+        // This should not panic, even if the buffer has zero size.
         line_gauge.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/gauge.rs
+++ b/ratatui-widgets/src/gauge.rs
@@ -586,4 +586,20 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn buffer_overflow_gauge() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+        let gauge = Gauge::default().percent(50);
+        // This should not panic, even if the buffer is too small to render the gauge.
+        gauge.render(buffer.area, &mut buffer);
+    }
+
+    #[test]
+    fn buffer_overflow_line_gauge() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+        let line_gauge = LineGauge::default().ratio(0.5);
+        // This should not panic, even if the buffer is too small to render the line gauge.
+        line_gauge.render(buffer.area, &mut buffer);
+    }
 }

--- a/ratatui-widgets/src/gauge.rs
+++ b/ratatui-widgets/src/gauge.rs
@@ -593,6 +593,7 @@ mod tests {
         let gauge = Gauge::default().percent(50);
         // This should not panic, even if the buffer is too small to render the gauge.
         gauge.render(buffer.area, &mut buffer);
+        assert_eq!(buffer, Buffer::with_lines(["5"]));
     }
 
     #[test]
@@ -600,6 +601,23 @@ mod tests {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let line_gauge = LineGauge::default().ratio(0.5);
         // This should not panic, even if the buffer is too small to render the line gauge.
+        line_gauge.render(buffer.area, &mut buffer);
+        assert_eq!(buffer, Buffer::with_lines(["5"]));
+    }
+
+    #[test]
+    fn render_in_empty_buffer_gauge() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        let gauge = Gauge::default().percent(50);
+        // This should not panic, even if the buffer is empty.
+        gauge.render(buffer.area, &mut buffer);
+    }
+
+    #[test]
+    fn render_in_empty_buffer_line_gauge() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        let line_gauge = LineGauge::default().ratio(0.5);
+        // This should not panic, even if the buffer is empty.
         line_gauge.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/gauge.rs
+++ b/ratatui-widgets/src/gauge.rs
@@ -588,7 +588,7 @@ mod tests {
     }
 
     #[test]
-    fn buffer_overflow_gauge() {
+    fn render_in_minimal_buffer_gauge() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let gauge = Gauge::default().percent(50);
         // This should not panic, even if the buffer is too small to render the gauge.
@@ -596,7 +596,7 @@ mod tests {
     }
 
     #[test]
-    fn buffer_overflow_line_gauge() {
+    fn render_in_minimal_buffer_line_gauge() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let line_gauge = LineGauge::default().ratio(0.5);
         // This should not panic, even if the buffer is too small to render the line gauge.

--- a/ratatui-widgets/src/list.rs
+++ b/ratatui-widgets/src/list.rs
@@ -627,7 +627,7 @@ mod tests {
     }
 
     #[test]
-    fn buffer_overflow() {
+    fn render_in_minimal_buffer() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let mut state = ListState::default().with_selected(None);
         let items = vec![

--- a/ratatui-widgets/src/list.rs
+++ b/ratatui-widgets/src/list.rs
@@ -625,4 +625,18 @@ mod tests {
             ])
         );
     }
+
+    #[test]
+    fn buffer_overflow() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+        let mut state = ListState::default().with_selected(None);
+        let items = vec![
+            ListItem::new("Item 1"),
+            ListItem::new("Item 2"),
+            ListItem::new("Item 3"),
+        ];
+        let list = List::new(items);
+        // This should not panic, even if the buffer is too small to render the list.
+        list.render(buffer.area, &mut buffer, &mut state);
+    }
 }

--- a/ratatui-widgets/src/list.rs
+++ b/ratatui-widgets/src/list.rs
@@ -642,8 +642,8 @@ mod tests {
     }
 
     #[test]
-    fn render_in_empty_buffer() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+    fn render_in_zero_size_buffer() {
+        let mut buffer = Buffer::empty(Rect::ZERO);
         let mut state = ListState::default().with_selected(None);
         let items = vec![
             ListItem::new("Item 1"),
@@ -651,7 +651,7 @@ mod tests {
             ListItem::new("Item 3"),
         ];
         let list = List::new(items);
-        // This should not panic, even if the buffer is empty.
+        // This should not panic, even if the buffer has zero size.
         list.render(buffer.area, &mut buffer, &mut state);
     }
 }

--- a/ratatui-widgets/src/list.rs
+++ b/ratatui-widgets/src/list.rs
@@ -638,5 +638,20 @@ mod tests {
         let list = List::new(items);
         // This should not panic, even if the buffer is too small to render the list.
         list.render(buffer.area, &mut buffer, &mut state);
+        std::assert_eq!(buffer, Buffer::with_lines(["I"]));
+    }
+
+    #[test]
+    fn render_in_empty_buffer() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        let mut state = ListState::default().with_selected(None);
+        let items = vec![
+            ListItem::new("Item 1"),
+            ListItem::new("Item 2"),
+            ListItem::new("Item 3"),
+        ];
+        let list = List::new(items);
+        // This should not panic, even if the buffer is empty.
+        list.render(buffer.area, &mut buffer, &mut state);
     }
 }

--- a/ratatui-widgets/src/list.rs
+++ b/ratatui-widgets/src/list.rs
@@ -638,7 +638,7 @@ mod tests {
         let list = List::new(items);
         // This should not panic, even if the buffer is too small to render the list.
         list.render(buffer.area, &mut buffer, &mut state);
-        std::assert_eq!(buffer, Buffer::with_lines(["I"]));
+        assert_eq!(buffer, Buffer::with_lines(["I"]));
     }
 
     #[test]

--- a/ratatui-widgets/src/logo.rs
+++ b/ratatui-widgets/src/logo.rs
@@ -237,10 +237,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn buffer_overflow() {
+    #[rstest]
+    #[case::tiny(Size::Tiny)]
+    #[case::small(Size::Small)]
+    fn buffer_overflow(#[case] size: Size) {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
-        let logo = RatatuiLogo::new(Size::Tiny);
+        let logo = RatatuiLogo::new(size);
         // This should not panic, even if the buffer is too small to render the logo.
         logo.render(buffer.area, &mut buffer);
     }

--- a/ratatui-widgets/src/logo.rs
+++ b/ratatui-widgets/src/logo.rs
@@ -240,7 +240,7 @@ mod tests {
     #[rstest]
     #[case::tiny(Size::Tiny)]
     #[case::small(Size::Small)]
-    fn buffer_overflow(#[case] size: Size) {
+    fn render_in_minimal_buffer(#[case] size: Size) {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let logo = RatatuiLogo::new(size);
         // This should not panic, even if the buffer is too small to render the logo.

--- a/ratatui-widgets/src/logo.rs
+++ b/ratatui-widgets/src/logo.rs
@@ -236,4 +236,12 @@ mod tests {
             ])
         );
     }
+
+    #[test]
+    fn buffer_overflow() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+        let logo = RatatuiLogo::new(Size::Tiny);
+        // This should not panic, even if the buffer is too small to render the logo.
+        logo.render(buffer.area, &mut buffer);
+    }
 }

--- a/ratatui-widgets/src/logo.rs
+++ b/ratatui-widgets/src/logo.rs
@@ -251,10 +251,10 @@ mod tests {
     #[rstest]
     #[case::tiny(Size::Tiny)]
     #[case::small(Size::Small)]
-    fn render_in_empty_buffer(#[case] size: Size) {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+    fn render_in_zero_size_buffer(#[case] size: Size) {
+        let mut buffer = Buffer::empty(Rect::ZERO);
         let logo = RatatuiLogo::new(size);
-        // This should not panic, even if the buffer is empty.
+        // This should not panic, even if the buffer has zero size.
         logo.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/logo.rs
+++ b/ratatui-widgets/src/logo.rs
@@ -238,12 +238,23 @@ mod tests {
     }
 
     #[rstest]
-    #[case::tiny(Size::Tiny)]
-    #[case::small(Size::Small)]
-    fn render_in_minimal_buffer(#[case] size: Size) {
+    #[case::tiny(Size::Tiny, Buffer::with_lines(["▛"]))]
+    #[case::small(Size::Small, Buffer::with_lines(["█"]))]
+    fn render_in_minimal_buffer(#[case] size: Size, #[case] expected: Buffer) {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let logo = RatatuiLogo::new(size);
         // This should not panic, even if the buffer is too small to render the logo.
+        logo.render(buffer.area, &mut buffer);
+        assert_eq!(buffer, expected);
+    }
+
+    #[rstest]
+    #[case::tiny(Size::Tiny)]
+    #[case::small(Size::Small)]
+    fn render_in_empty_buffer(#[case] size: Size) {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        let logo = RatatuiLogo::new(size);
+        // This should not panic, even if the buffer is empty.
         logo.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/mascot.rs
+++ b/ratatui-widgets/src/mascot.rs
@@ -135,10 +135,21 @@ impl Widget for RatatuiMascot {
     /// The logo colors are hardcorded in the widget.
     /// The eye color depends on whether it's open / blinking
     fn render(self, area: Rect, buf: &mut Buffer) {
+        let area = area.intersection(buf.area);
+        if area.is_empty() {
+            return;
+        }
+
         for (y, (line1, line2)) in RATATUI_MASCOT.lines().tuples().enumerate() {
             for (x, (ch1, ch2)) in line1.chars().zip(line2.chars()).enumerate() {
                 let x = area.left() + x as u16;
                 let y = area.top() + y as u16;
+
+                // Check if coordinates are within the buffer area
+                if x >= area.right() || y >= area.bottom() {
+                    continue;
+                }
+
                 let cell = &mut buf[(x, y)];
                 // given two cells which make up the top and bottom of the character,
                 // Foreground color should be the non-space, non-terminal
@@ -228,5 +239,13 @@ mod tests {
             .map(ratatui_core::buffer::Cell::symbol)
             .collect::<String>()
         );
+    }
+
+    #[test]
+    fn buffer_overflow() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+        let mascot = RatatuiMascot::new();
+        // This should not panic, even if the buffer is too small to render the mascot.
+        mascot.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/mascot.rs
+++ b/ratatui-widgets/src/mascot.rs
@@ -242,7 +242,7 @@ mod tests {
     }
 
     #[test]
-    fn buffer_overflow() {
+    fn render_in_minimal_buffer() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let mascot = RatatuiMascot::new();
         // This should not panic, even if the buffer is too small to render the mascot.

--- a/ratatui-widgets/src/mascot.rs
+++ b/ratatui-widgets/src/mascot.rs
@@ -251,10 +251,10 @@ mod tests {
     }
 
     #[test]
-    fn render_in_empty_buffer() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+    fn render_in_zero_size_buffer() {
+        let mut buffer = Buffer::empty(Rect::ZERO);
         let mascot = RatatuiMascot::new();
-        // This should not panic, even if the buffer is empty.
+        // This should not panic, even if the buffer has zero size.
         mascot.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/mascot.rs
+++ b/ratatui-widgets/src/mascot.rs
@@ -247,5 +247,14 @@ mod tests {
         let mascot = RatatuiMascot::new();
         // This should not panic, even if the buffer is too small to render the mascot.
         mascot.render(buffer.area, &mut buffer);
+        assert_eq!(buffer, Buffer::with_lines([" "]));
+    }
+
+    #[test]
+    fn render_in_empty_buffer() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        let mascot = RatatuiMascot::new();
+        // This should not panic, even if the buffer is empty.
+        mascot.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/paragraph.rs
+++ b/ratatui-widgets/src/paragraph.rs
@@ -1219,4 +1219,14 @@ mod tests {
             ])
         );
     }
+
+    #[test]
+    fn buffer_overflow() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+        let paragraph = Paragraph::new(
+            "This is a long paragraph that should not panic when rendered in a very small buffer area.",
+        );
+        // This should not panic, even if the buffer is too small to render the paragraph.
+        paragraph.render(buffer.area, &mut buffer);
+    }
 }

--- a/ratatui-widgets/src/paragraph.rs
+++ b/ratatui-widgets/src/paragraph.rs
@@ -1232,12 +1232,12 @@ mod tests {
     }
 
     #[test]
-    fn render_in_empty_buffer() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+    fn render_in_zero_size_buffer() {
+        let mut buffer = Buffer::empty(Rect::ZERO);
         let paragraph = Paragraph::new(
             "This is a long paragraph that should not panic when rendered in a very small buffer area.",
         );
-        // This should not panic, even if the buffer is empty.
+        // This should not panic, even if the buffer has zero size.
         paragraph.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/paragraph.rs
+++ b/ratatui-widgets/src/paragraph.rs
@@ -1228,5 +1228,16 @@ mod tests {
         );
         // This should not panic, even if the buffer is too small to render the paragraph.
         paragraph.render(buffer.area, &mut buffer);
+        assert_eq!(buffer, Buffer::with_lines(["T"]));
+    }
+
+    #[test]
+    fn render_in_empty_buffer() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        let paragraph = Paragraph::new(
+            "This is a long paragraph that should not panic when rendered in a very small buffer area.",
+        );
+        // This should not panic, even if the buffer is empty.
+        paragraph.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/paragraph.rs
+++ b/ratatui-widgets/src/paragraph.rs
@@ -1221,7 +1221,7 @@ mod tests {
     }
 
     #[test]
-    fn buffer_overflow() {
+    fn render_in_minimal_buffer() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let paragraph = Paragraph::new(
             "This is a long paragraph that should not panic when rendered in a very small buffer area.",

--- a/ratatui-widgets/src/paragraph.rs
+++ b/ratatui-widgets/src/paragraph.rs
@@ -1223,20 +1223,16 @@ mod tests {
     #[test]
     fn render_in_minimal_buffer() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
-        let paragraph = Paragraph::new(
-            "This is a long paragraph that should not panic when rendered in a very small buffer area.",
-        );
+        let paragraph = Paragraph::new("Lorem ipsum");
         // This should not panic, even if the buffer is too small to render the paragraph.
         paragraph.render(buffer.area, &mut buffer);
-        assert_eq!(buffer, Buffer::with_lines(["T"]));
+        assert_eq!(buffer, Buffer::with_lines(["L"]));
     }
 
     #[test]
     fn render_in_zero_size_buffer() {
         let mut buffer = Buffer::empty(Rect::ZERO);
-        let paragraph = Paragraph::new(
-            "This is a long paragraph that should not panic when rendered in a very small buffer area.",
-        );
+        let paragraph = Paragraph::new("Lorem ipsum");
         // This should not panic, even if the buffer has zero size.
         paragraph.render(buffer.area, &mut buffer);
     }

--- a/ratatui-widgets/src/scrollbar.rs
+++ b/ratatui-widgets/src/scrollbar.rs
@@ -1099,7 +1099,7 @@ mod tests {
     #[case::vertical_right(ScrollbarOrientation::VerticalRight)]
     #[case::horizontal_top(ScrollbarOrientation::HorizontalTop)]
     #[case::horizontal_bottom(ScrollbarOrientation::HorizontalBottom)]
-    fn buffer_overflow(#[case] orientation: ScrollbarOrientation) {
+    fn render_in_minimal_buffer(#[case] orientation: ScrollbarOrientation) {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let scrollbar = Scrollbar::new(orientation);
         let mut state = ScrollbarState::new(10).position(5);

--- a/ratatui-widgets/src/scrollbar.rs
+++ b/ratatui-widgets/src/scrollbar.rs
@@ -970,6 +970,8 @@ mod tests {
     #[case::position_8("<---#####>", 8, 10)]
     #[case::position_9("<----####>", 9, 10)]
     #[case::position_one_out_of_bounds("<----####>", 10, 10)]
+    #[case::position_few_out_of_bounds("<----####>", 15, 10)]
+    #[case::position_very_many_out_of_bounds("<----####>", 500, 10)]
     fn render_scrollbar_vertical_left(
         #[case] expected: &str,
         #[case] position: usize,
@@ -1000,7 +1002,9 @@ mod tests {
     #[case::position_8("<---#####>", 8, 10)]
     #[case::position_9("<----####>", 9, 10)]
     #[case::position_one_out_of_bounds("<----####>", 10, 10)]
-    fn render_scrollbar_vertical_rightl(
+    #[case::position_few_out_of_bounds("<----####>", 15, 10)]
+    #[case::position_very_many_out_of_bounds("<----####>", 500, 10)]
+    fn render_scrollbar_vertical_right(
         #[case] expected: &str,
         #[case] position: usize,
         #[case] content_length: usize,
@@ -1088,5 +1092,18 @@ mod tests {
 
         let mut state = ScrollbarState::new(10);
         scrollbar.render(zero_width_area, &mut buffer, &mut state);
+    }
+
+    #[rstest]
+    #[case::vertical_left(ScrollbarOrientation::VerticalLeft)]
+    #[case::vertical_right(ScrollbarOrientation::VerticalRight)]
+    #[case::horizontal_top(ScrollbarOrientation::HorizontalTop)]
+    #[case::horizontal_bottom(ScrollbarOrientation::HorizontalBottom)]
+    fn buffer_overflow(#[case] orientation: ScrollbarOrientation) {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+        let scrollbar = Scrollbar::new(orientation);
+        let mut state = ScrollbarState::new(10).position(5);
+        // This should not panic, even if the buffer is too small to render the scrollbar.
+        scrollbar.render(buffer.area, &mut buffer, &mut state);
     }
 }

--- a/ratatui-widgets/src/scrollbar.rs
+++ b/ratatui-widgets/src/scrollbar.rs
@@ -1105,5 +1105,19 @@ mod tests {
         let mut state = ScrollbarState::new(10).position(5);
         // This should not panic, even if the buffer is too small to render the scrollbar.
         scrollbar.render(buffer.area, &mut buffer, &mut state);
+        assert_eq!(buffer, Buffer::with_lines([" "]));
+    }
+
+    #[rstest]
+    #[case::vertical_left(ScrollbarOrientation::VerticalLeft)]
+    #[case::vertical_right(ScrollbarOrientation::VerticalRight)]
+    #[case::horizontal_top(ScrollbarOrientation::HorizontalTop)]
+    #[case::horizontal_bottom(ScrollbarOrientation::HorizontalBottom)]
+    fn render_in_empty_buffer(#[case] orientation: ScrollbarOrientation) {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        let scrollbar = Scrollbar::new(orientation);
+        let mut state = ScrollbarState::new(10).position(5);
+        // This should not panic, even if the buffer is empty.
+        scrollbar.render(buffer.area, &mut buffer, &mut state);
     }
 }

--- a/ratatui-widgets/src/scrollbar.rs
+++ b/ratatui-widgets/src/scrollbar.rs
@@ -1113,11 +1113,11 @@ mod tests {
     #[case::vertical_right(ScrollbarOrientation::VerticalRight)]
     #[case::horizontal_top(ScrollbarOrientation::HorizontalTop)]
     #[case::horizontal_bottom(ScrollbarOrientation::HorizontalBottom)]
-    fn render_in_empty_buffer(#[case] orientation: ScrollbarOrientation) {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+    fn render_in_zero_size_buffer(#[case] orientation: ScrollbarOrientation) {
+        let mut buffer = Buffer::empty(Rect::ZERO);
         let scrollbar = Scrollbar::new(orientation);
         let mut state = ScrollbarState::new(10).position(5);
-        // This should not panic, even if the buffer is empty.
+        // This should not panic, even if the buffer has zero size.
         scrollbar.render(buffer.area, &mut buffer, &mut state);
     }
 }

--- a/ratatui-widgets/src/sparkline.rs
+++ b/ratatui-widgets/src/sparkline.rs
@@ -708,5 +708,16 @@ mod tests {
             .max(10);
         // This should not panic, even if the buffer is too small to render the sparkline.
         sparkline.render(buffer.area, &mut buffer);
+        assert_eq!(buffer, Buffer::with_lines([" "]));
+    }
+
+    #[test]
+    fn render_in_empty_buffer() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        let sparkline = Sparkline::default()
+            .data([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+            .max(10);
+        // This should not panic, even if the buffer is empty.
+        sparkline.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/sparkline.rs
+++ b/ratatui-widgets/src/sparkline.rs
@@ -712,12 +712,12 @@ mod tests {
     }
 
     #[test]
-    fn render_in_empty_buffer() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+    fn render_in_zero_size_buffer() {
+        let mut buffer = Buffer::empty(Rect::ZERO);
         let sparkline = Sparkline::default()
             .data([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
             .max(10);
-        // This should not panic, even if the buffer is empty.
+        // This should not panic, even if the buffer has zero size.
         sparkline.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/sparkline.rs
+++ b/ratatui-widgets/src/sparkline.rs
@@ -699,4 +699,14 @@ mod tests {
                 .remove_modifier(Modifier::DIM)
         );
     }
+
+    #[test]
+    fn buffer_overflow() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+        let sparkline = Sparkline::default()
+            .data([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+            .max(10);
+        // This should not panic, even if the buffer is too small to render the sparkline.
+        sparkline.render(buffer.area, &mut buffer);
+    }
 }

--- a/ratatui-widgets/src/sparkline.rs
+++ b/ratatui-widgets/src/sparkline.rs
@@ -701,7 +701,7 @@ mod tests {
     }
 
     #[test]
-    fn buffer_overflow() {
+    fn render_in_minimal_buffer() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let sparkline = Sparkline::default()
             .data([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -2290,8 +2290,8 @@ mod tests {
     }
 
     #[test]
-    fn render_in_empty_buffer() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+    fn render_in_zero_size_buffer() {
+        let mut buffer = Buffer::empty(Rect::ZERO);
         let rows = vec![
             Row::new(vec!["Cell1", "Cell2", "Cell3"]),
             Row::new(vec!["Cell4", "Cell5", "Cell6"]),
@@ -2299,7 +2299,7 @@ mod tests {
         let table = Table::new(rows, [Constraint::Length(10); 3])
             .header(Row::new(vec!["Header1", "Header2", "Header3"]))
             .footer(Row::new(vec!["Footer1", "Footer2", "Footer3"]));
-        // This should not panic, even if the buffer is empty.
+        // This should not panic, even if the buffer has zero size.
         Widget::render(table, buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -2275,7 +2275,7 @@ mod tests {
     }
 
     #[test]
-    fn buffer_overflow() {
+    fn render_in_minimal_buffer() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let rows = vec![
             Row::new(vec!["Cell1", "Cell2", "Cell3"]),

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -2273,4 +2273,18 @@ mod tests {
         let column_count = table.column_count();
         assert_eq!(column_count, expected);
     }
+
+    #[test]
+    fn buffer_overflow() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+        let rows = vec![
+            Row::new(vec!["Cell1", "Cell2", "Cell3"]),
+            Row::new(vec!["Cell4", "Cell5", "Cell6"]),
+        ];
+        let table = Table::new(rows, [Constraint::Length(10); 3])
+            .header(Row::new(vec!["Header1", "Header2", "Header3"]))
+            .footer(Row::new(vec!["Footer1", "Footer2", "Footer3"]));
+        // This should not panic, even if the buffer is too small to render the table.
+        Widget::render(table, buffer.area, &mut buffer);
+    }
 }

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -2286,5 +2286,20 @@ mod tests {
             .footer(Row::new(vec!["Footer1", "Footer2", "Footer3"]));
         // This should not panic, even if the buffer is too small to render the table.
         Widget::render(table, buffer.area, &mut buffer);
+        assert_eq!(buffer, Buffer::with_lines([" "]));
+    }
+
+    #[test]
+    fn render_in_empty_buffer() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        let rows = vec![
+            Row::new(vec!["Cell1", "Cell2", "Cell3"]),
+            Row::new(vec!["Cell4", "Cell5", "Cell6"]),
+        ];
+        let table = Table::new(rows, [Constraint::Length(10); 3])
+            .header(Row::new(vec!["Header1", "Header2", "Header3"]))
+            .footer(Row::new(vec!["Footer1", "Footer2", "Footer3"]));
+        // This should not panic, even if the buffer is empty.
+        Widget::render(table, buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/tabs.rs
+++ b/ratatui-widgets/src/tabs.rs
@@ -678,7 +678,7 @@ mod tests {
     }
 
     #[test]
-    fn buffer_overflow() {
+    fn render_in_minimal_buffer() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
         let tabs = Tabs::new(vec!["Tab1", "Tab2", "Tab3", "Tab4"])
             .select(1)

--- a/ratatui-widgets/src/tabs.rs
+++ b/ratatui-widgets/src/tabs.rs
@@ -689,12 +689,12 @@ mod tests {
     }
 
     #[test]
-    fn render_in_empty_buffer() {
-        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+    fn render_in_zero_size_buffer() {
+        let mut buffer = Buffer::empty(Rect::ZERO);
         let tabs = Tabs::new(vec!["Tab1", "Tab2", "Tab3", "Tab4"])
             .select(1)
             .divider("|");
-        // This should not panic, even if the buffer is empty.
+        // This should not panic, even if the buffer has zero size.
         tabs.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/tabs.rs
+++ b/ratatui-widgets/src/tabs.rs
@@ -685,5 +685,16 @@ mod tests {
             .divider("|");
         // This should not panic, even if the buffer is too small to render the tabs.
         tabs.render(buffer.area, &mut buffer);
+        assert_eq!(buffer, Buffer::with_lines([" "]));
+    }
+
+    #[test]
+    fn render_in_empty_buffer() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+        let tabs = Tabs::new(vec!["Tab1", "Tab2", "Tab3", "Tab4"])
+            .select(1)
+            .divider("|");
+        // This should not panic, even if the buffer is empty.
+        tabs.render(buffer.area, &mut buffer);
     }
 }

--- a/ratatui-widgets/src/tabs.rs
+++ b/ratatui-widgets/src/tabs.rs
@@ -676,4 +676,14 @@ mod tests {
             Style::default().black().on_white().bold().not_italic()
         );
     }
+
+    #[test]
+    fn buffer_overflow() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+        let tabs = Tabs::new(vec!["Tab1", "Tab2", "Tab3", "Tab4"])
+            .select(1)
+            .divider("|");
+        // This should not panic, even if the buffer is too small to render the tabs.
+        tabs.render(buffer.area, &mut buffer);
+    }
 }


### PR DESCRIPTION
Fixes panic on overflow on horizontal `Barchart` and `RatatuiMascot`, adds proper tests to all widgets.