### PR TITLE
perf: use cow in paragraph

### DIFF
--- a/examples/apps/scrollbar/src/main.rs
+++ b/examples/apps/scrollbar/src/main.rs
@@ -133,7 +133,7 @@ impl App {
             .title("Use h j k l or ◄ ▲ ▼ ► to scroll ".bold());
         frame.render_widget(title, chunks[0]);
 
-        let paragraph = Paragraph::from_borrowed_text(&text)
+        let paragraph = Paragraph::from(&text)
             .gray()
             .block(create_block("Vertical scrollbar with arrows"))
             .scroll((self.vertical_scroll as u16, 0));
@@ -146,7 +146,7 @@ impl App {
             &mut self.vertical_scroll_state,
         );
 
-        let paragraph = Paragraph::from_borrowed_text(&text)
+        let paragraph = Paragraph::from(&text)
             .gray()
             .block(create_block(
                 "Vertical scrollbar without arrows, without track symbol and mirrored",
@@ -166,7 +166,7 @@ impl App {
             &mut self.vertical_scroll_state,
         );
 
-        let paragraph = Paragraph::from_borrowed_text(&text)
+        let paragraph = Paragraph::from(&text)
             .gray()
             .block(create_block(
                 "Horizontal scrollbar with only begin arrow & custom thumb symbol",
@@ -184,7 +184,7 @@ impl App {
             &mut self.horizontal_scroll_state,
         );
 
-        let paragraph = Paragraph::from_borrowed_text(&text)
+        let paragraph = Paragraph::from(&text)
             .gray()
             .block(create_block(
                 "Horizontal scrollbar without arrows & custom thumb and track symbol",

--- a/examples/apps/scrollbar/src/main.rs
+++ b/examples/apps/scrollbar/src/main.rs
@@ -15,7 +15,7 @@ use crossterm::event::{self, KeyCode};
 use ratatui::layout::{Alignment, Constraint, Layout, Margin};
 use ratatui::style::{Color, Style, Stylize};
 use ratatui::symbols::scrollbar;
-use ratatui::text::{Line, Masked, Span};
+use ratatui::text::{Line, Masked, Span, Text};
 use ratatui::widgets::{Block, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState};
 use ratatui::{DefaultTerminal, Frame};
 
@@ -100,7 +100,7 @@ impl App {
         ])
         .split(area);
 
-        let text = vec![
+        let text = Text::from_iter([
             Line::from("This is a line "),
             Line::from("This is a line   ".red()),
             Line::from("This is a line".on_dark_gray()),
@@ -121,8 +121,9 @@ impl App {
                 Span::raw("Masked text: "),
                 Span::styled(Masked::new("password", '*'), Style::new().fg(Color::Red)),
             ]),
-        ];
-        self.vertical_scroll_state = self.vertical_scroll_state.content_length(text.len());
+        ]);
+
+        self.vertical_scroll_state = self.vertical_scroll_state.content_length(text.lines.len());
         self.horizontal_scroll_state = self.horizontal_scroll_state.content_length(long_line.len());
 
         let create_block = |title: &'static str| Block::bordered().gray().title(title.bold());
@@ -132,7 +133,7 @@ impl App {
             .title("Use h j k l or ◄ ▲ ▼ ► to scroll ".bold());
         frame.render_widget(title, chunks[0]);
 
-        let paragraph = Paragraph::new(text.clone())
+        let paragraph = Paragraph::from_borrowed_text(&text)
             .gray()
             .block(create_block("Vertical scrollbar with arrows"))
             .scroll((self.vertical_scroll as u16, 0));
@@ -145,7 +146,7 @@ impl App {
             &mut self.vertical_scroll_state,
         );
 
-        let paragraph = Paragraph::new(text.clone())
+        let paragraph = Paragraph::from_borrowed_text(&text)
             .gray()
             .block(create_block(
                 "Vertical scrollbar without arrows, without track symbol and mirrored",
@@ -165,7 +166,7 @@ impl App {
             &mut self.vertical_scroll_state,
         );
 
-        let paragraph = Paragraph::new(text.clone())
+        let paragraph = Paragraph::from_borrowed_text(&text)
             .gray()
             .block(create_block(
                 "Horizontal scrollbar with only begin arrow & custom thumb symbol",
@@ -183,7 +184,7 @@ impl App {
             &mut self.horizontal_scroll_state,
         );
 
-        let paragraph = Paragraph::new(text.clone())
+        let paragraph = Paragraph::from_borrowed_text(&text)
             .gray()
             .block(create_block(
                 "Horizontal scrollbar without arrows & custom thumb and track symbol",

--- a/ratatui-widgets/src/paragraph.rs
+++ b/ratatui-widgets/src/paragraph.rs
@@ -136,7 +136,7 @@ impl<'a> Paragraph<'a> {
     /// The `text` parameter can be a [`Text`] or any type that can be converted into a [`Text`]. By
     /// default, the text is styled with [`Style::default()`], not wrapped, and aligned to the left.
     ///
-    /// If you have a reference to [`Text`] use [`Paragraph::from_borrowed_text`]
+    /// If you have [`&Text`] or [`Cow<Text>`] use [`Paragraph::from`]
     /// # Examples
     ///
     /// ```rust
@@ -154,50 +154,7 @@ impl<'a> Paragraph<'a> {
     where
         T: Into<Text<'a>>,
     {
-        Self::from_cow_text(Cow::Owned(text.into()))
-    }
-
-    /// Creates a new [`Paragraph`] widget with the given text.
-    ///
-    /// By default, the text is styled with [`Style::default()`], not wrapped, and aligned to the
-    /// left.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use ratatui::style::{Style, Stylize};
-    /// use ratatui::text::{Line, Text};
-    /// use ratatui::widgets::Paragraph;
-    /// let text = Text::raw("Hello, world!");
-    /// let paragraph = Paragraph::from_cow_text(Cow::Borrowed(&text));
-    /// ```
-    pub const fn from_borrowed_text(text: &'a Text<'a>) -> Self {
-        Self::from_cow_text(Cow::Borrowed(text))
-    }
-
-    /// Creates a new [`Paragraph`] widget with the given text.
-    ///
-    /// By default, the text is styled with [`Style::default()`], not wrapped, and aligned to the
-    /// left.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use ratatui::style::{Style, Stylize};
-    /// use ratatui::text::{Line, Text};
-    /// use ratatui::widgets::Paragraph;
-    /// let text = Text::raw("Hello, world!");
-    /// let paragraph = Paragraph::from_cow_text(Cow::Borrowed(&text));
-    /// ```
-    pub const fn from_cow_text(text: Cow<'a, Text<'a>>) -> Self {
-        Self {
-            block: None,
-            style: Style::new(),
-            wrap: None,
-            text,
-            scroll: Position::ORIGIN,
-            alignment: Alignment::Left,
-        }
+        Self::from(Cow::Owned(text.into()))
     }
 
     /// Surrounds the [`Paragraph`] widget with a [`Block`].
@@ -531,6 +488,25 @@ impl Styled for Paragraph<'_> {
     }
 }
 
+impl<'a> From<Cow<'a, Text<'a>>> for Paragraph<'a> {
+    fn from(text: Cow<'a, Text<'a>>) -> Self {
+        Self {
+            block: None,
+            style: Style::new(),
+            wrap: None,
+            text,
+            scroll: Position::ORIGIN,
+            alignment: Alignment::Left,
+        }
+    }
+}
+
+impl<'a> From<&'a Text<'a>> for Paragraph<'a> {
+    fn from(text: &'a Text<'a>) -> Self {
+        Self::from(Cow::Borrowed(text))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::vec;
@@ -815,8 +791,8 @@ mod tests {
             .into_iter()
             .map(Line::from)
             .collect();
-        let paragraph = Paragraph::from_borrowed_text(&text).wrap(Wrap { trim: false });
-        let trimmed_paragraph = Paragraph::from_borrowed_text(&text).wrap(Wrap { trim: true });
+        let paragraph = Paragraph::from(&text).wrap(Wrap { trim: false });
+        let trimmed_paragraph = Paragraph::from(&text).wrap(Wrap { trim: true });
 
         test_case(
             &paragraph,
@@ -995,9 +971,9 @@ mod tests {
         );
 
         for paragraph in [
-            Paragraph::from_borrowed_text(&text),
-            Paragraph::from_borrowed_text(&text).wrap(Wrap { trim: false }),
-            Paragraph::from_borrowed_text(&text).wrap(Wrap { trim: true }),
+            Paragraph::from(&text),
+            Paragraph::from(&text).wrap(Wrap { trim: false }),
+            Paragraph::from(&text).wrap(Wrap { trim: true }),
         ] {
             test_case(
                 &paragraph.style(Style::default().bg(Color::Green)),


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
This pr sets the text field to `Cow<'a, Text<'a>>` and adds `from_cow_text` and `from_borrowed_text` methods in paragraph, and modifies examples and tests that clone a `Text` when passing it to a `Paragraph` to use the `from_borrowed_text` method
