### PR TITLE
feat: add conversion from Size to Rect

### DIFF
--- a/ratatui-core/src/layout/rect.rs
+++ b/ratatui-core/src/layout/rect.rs
@@ -646,6 +646,18 @@ impl From<(Position, Size)> for Rect {
     }
 }
 
+impl From<Size> for Rect {
+    /// Creates a new `Rect` with the given size at [`Position::ORIGIN`] (0, 0).
+    fn from(size: Size) -> Self {
+        Self {
+            x: 0,
+            y: 0,
+            width: size.width,
+            height: size.height,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::string::ToString;
@@ -950,6 +962,23 @@ mod tests {
             Rect {
                 x: 1,
                 y: 2,
+                width: 3,
+                height: 4
+            }
+        );
+    }
+
+    #[test]
+    fn from_size() {
+        let size = Size {
+            width: 3,
+            height: 4,
+        };
+        assert_eq!(
+            Rect::from(size),
+            Rect {
+                x: 0,
+                y: 0,
                 width: 3,
                 height: 4
             }

--- a/ratatui-core/src/terminal/terminal.rs
+++ b/ratatui-core/src/terminal/terminal.rs
@@ -164,9 +164,7 @@ where
     /// ```
     pub fn with_options(mut backend: B, options: TerminalOptions) -> Result<Self, B::Error> {
         let area = match options.viewport {
-            Viewport::Fullscreen | Viewport::Inline(_) => {
-                Rect::from((Position::ORIGIN, backend.size()?))
-            }
+            Viewport::Fullscreen | Viewport::Inline(_) => backend.size()?.into(),
             Viewport::Fixed(area) => area,
         };
         let (viewport_area, cursor_pos) = match options.viewport {
@@ -265,7 +263,7 @@ where
     pub fn autoresize(&mut self) -> Result<(), B::Error> {
         // fixed viewports do not get autoresized
         if matches!(self.viewport, Viewport::Fullscreen | Viewport::Inline(_)) {
-            let area = Rect::from((Position::ORIGIN, self.size()?));
+            let area = self.size()?.into();
             if area != self.last_known_area {
                 self.resize(area)?;
             }


### PR DESCRIPTION
`Rect::from(size)` returns a new Rect at the origin (0, 0) with the specified `Size`

