### PR TITLE
feat: implement UnicodeWidthStr for Text/Line/Span

### DIFF
--- a/ratatui-core/src/text/line.rs
+++ b/ratatui-core/src/text/line.rs
@@ -7,6 +7,7 @@ use alloc::vec::Vec;
 use core::fmt;
 
 use unicode_truncate::UnicodeTruncateStr;
+use unicode_width::UnicodeWidthStr;
 
 use crate::buffer::Buffer;
 use crate::layout::{Alignment, Rect};
@@ -435,8 +436,9 @@ impl<'a> Line<'a> {
     /// let line = Line::from(vec!["Hello".blue(), " world!".green()]);
     /// assert_eq!(12, line.width());
     /// ```
+    #[must_use]
     pub fn width(&self) -> usize {
-        self.spans.iter().map(Span::width).sum()
+        UnicodeWidthStr::width(self)
     }
 
     /// Returns an iterator over the graphemes held by this line.
@@ -559,6 +561,16 @@ impl<'a> Line<'a> {
     /// ```
     pub fn push_span<T: Into<Span<'a>>>(&mut self, span: T) {
         self.spans.push(span.into());
+    }
+}
+
+impl UnicodeWidthStr for Line<'_> {
+    fn width(&self) -> usize {
+        self.spans.iter().map(UnicodeWidthStr::width).sum()
+    }
+
+    fn width_cjk(&self) -> usize {
+        self.spans.iter().map(UnicodeWidthStr::width_cjk).sum()
     }
 }
 

--- a/ratatui-core/src/text/span.rs
+++ b/ratatui-core/src/text/span.rs
@@ -269,7 +269,7 @@ impl<'a> Span<'a> {
 
     /// Returns the unicode width of the content held by this span.
     pub fn width(&self) -> usize {
-        self.content.width()
+        UnicodeWidthStr::width(self)
     }
 
     /// Returns an iterator over the graphemes held by this span.
@@ -373,6 +373,16 @@ impl<'a> Span<'a> {
     #[deprecated = "use `into_right_aligned_line()` instead"]
     pub fn to_right_aligned_line(self) -> Line<'a> {
         self.into_right_aligned_line()
+    }
+}
+
+impl UnicodeWidthStr for Span<'_> {
+    fn width(&self) -> usize {
+        self.content.width()
+    }
+
+    fn width_cjk(&self) -> usize {
+        self.content.width_cjk()
     }
 }
 

--- a/ratatui-core/src/text/text.rs
+++ b/ratatui-core/src/text/text.rs
@@ -5,6 +5,8 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt;
 
+use unicode_width::UnicodeWidthStr;
+
 use crate::buffer::Buffer;
 use crate::layout::{Alignment, Rect};
 use crate::style::{Style, Styled};
@@ -284,7 +286,7 @@ impl<'a> Text<'a> {
     /// assert_eq!(15, text.width());
     /// ```
     pub fn width(&self) -> usize {
-        self.iter().map(Line::width).max().unwrap_or_default()
+        UnicodeWidthStr::width(self)
     }
 
     /// Returns the height.
@@ -556,6 +558,25 @@ impl<'a> Text<'a> {
         } else {
             self.lines.push(Line::from(span));
         }
+    }
+}
+
+impl UnicodeWidthStr for Text<'_> {
+    /// Returns the max width of all the lines.
+    fn width(&self) -> usize {
+        self.lines
+            .iter()
+            .map(UnicodeWidthStr::width)
+            .max()
+            .unwrap_or_default()
+    }
+
+    fn width_cjk(&self) -> usize {
+        self.lines
+            .iter()
+            .map(UnicodeWidthStr::width_cjk)
+            .max()
+            .unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
You can now calculate the width of any Text/Line/Span using the UnicodeWidthStr trait instead of the width method on the type. This also makes it possible to use the width_cjk() method if needed.

---

From https://github.com/joshka/tui-widgets/pull/94#discussion_r2241178372
