### PR TITLE
chore(changelog): allow running git-cliff without release-plz

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -127,8 +127,8 @@ commit_parsers = [
   { message = "^chore\\(changelog\\)", skip = true },
   { message = "^[cC]hore", group = "<!-- 07 -->Miscellaneous Tasks" },
   { message = "^build\\(deps\\)", skip = true },
-  { message = "^build", group = "<!-- 09 -->Build" },
-  { body = ".*security", group = "<!-- 08 -->Security" },
+  { message = "^build", group = "<!-- 08 -->Build" },
+  { body = ".*security", group = "<!-- 09 -->Security" },
   { message = "^ci", group = "<!-- 10 -->Continuous Integration" },
   { message = "^revert", group = "<!-- 11 -->Reverted Commits" },
   # handle some old commits styles from pre 0.4

--- a/cliff.toml
+++ b/cliff.toml
@@ -24,7 +24,11 @@ body = """
 {%- if not version %}
 ## [unreleased]
 {% else -%}
+{%- if package -%}
 ## {{ package }} - [{{ version }}]({{ release_link }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+{%- else -%}
+## [{{ version }}]({{ self::remote_url() }}/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+{%- endif %}
 {% endif -%}
 
 {% macro commit(commit) -%}
@@ -59,14 +63,22 @@ body = """
 
 {% if version %}
 {% if previous.version %}
+{%- if release_link -%}
 **Full Changelog**: {{ release_link }}
+{%- else -%}
+**Full Changelog**: {{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}
+{% endif %}
 {% endif %}
 {% else -%}
   {% raw %}\n{% endraw %}
 {% endif %}
 
 {%- macro remote_url() -%}
+{%- if remote.owner -%}
 https://github.com/{{ remote.owner }}/{{ remote.repo }}\
+{%- else -%}
+https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+{%- endif -%}
 {% endmacro %}
 """
 # remove the leading and trailing whitespace from the template

--- a/cliff.toml
+++ b/cliff.toml
@@ -24,7 +24,7 @@ body = """
 {%- if not version %}
 ## [unreleased]
 {% else -%}
-{%- if package -%}
+{%- if package -%} {# release-plz specific variable #}
 ## {{ package }} - [{{ version }}]({{ release_link }}) - {{ timestamp | date(format="%Y-%m-%d") }}
 {%- else -%}
 ## [{{ version }}]({{ self::remote_url() }}/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
@@ -64,7 +64,7 @@ body = """
 {% if version %}
 {% if previous.version %}
 {%- if release_link -%}
-**Full Changelog**: {{ release_link }}
+**Full Changelog**: {{ release_link }} {# release-plz specific variable #}
 {%- else -%}
 **Full Changelog**: {{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}
 {% endif %}
@@ -74,7 +74,7 @@ body = """
 {% endif %}
 
 {%- macro remote_url() -%}
-{%- if remote.owner -%}
+{%- if remote.owner -%} {# release-plz specific variable #}
 https://github.com/{{ remote.owner }}/{{ remote.repo }}\
 {%- else -%}
 https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\

--- a/cliff.toml
+++ b/cliff.toml
@@ -126,9 +126,9 @@ commit_parsers = [
   { message = "^chore\\(deps\\)", skip = true },
   { message = "^chore\\(changelog\\)", skip = true },
   { message = "^[cC]hore", group = "<!-- 07 -->Miscellaneous Tasks" },
-  { body = ".*security", group = "<!-- 08 -->Security" },
   { message = "^build\\(deps\\)", skip = true },
   { message = "^build", group = "<!-- 09 -->Build" },
+  { body = ".*security", group = "<!-- 08 -->Security" },
   { message = "^ci", group = "<!-- 10 -->Continuous Integration" },
   { message = "^revert", group = "<!-- 11 -->Reverted Commits" },
   # handle some old commits styles from pre 0.4


### PR DESCRIPTION
This is probably not optimal because we won't have access to the current `{package}` while running `git-cliff` but at least it will run _just_ fine.

While at it, I changed something in the commit parsers to avoid adding dependency updates to the changelog. So maybe rebase this PR instead of squashing.