### PR TITLE
test(bench): Added a benchmark for constraints

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -24,7 +24,11 @@ body = """
 {%- if not version %}
 ## [unreleased]
 {% else -%}
+{%- if package -%} {# release-plz specific variable #}
 ## {{ package }} - [{{ version }}]({{ release_link }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+{%- else -%}
+## [{{ version }}]({{ self::remote_url() }}/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+{%- endif %}
 {% endif -%}
 
 {% macro commit(commit) -%}
@@ -59,14 +63,22 @@ body = """
 
 {% if version %}
 {% if previous.version %}
-**Full Changelog**: {{ release_link }}
+{%- if release_link -%}
+**Full Changelog**: {{ release_link }} {# release-plz specific variable #}
+{%- else -%}
+**Full Changelog**: {{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }}
+{% endif %}
 {% endif %}
 {% else -%}
   {% raw %}\n{% endraw %}
 {% endif %}
 
 {%- macro remote_url() -%}
+{%- if remote.owner -%} {# release-plz specific variable #}
 https://github.com/{{ remote.owner }}/{{ remote.repo }}\
+{%- else -%}
+https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+{%- endif -%}
 {% endmacro %}
 """
 # remove the leading and trailing whitespace from the template
@@ -114,9 +126,9 @@ commit_parsers = [
   { message = "^chore\\(deps\\)", skip = true },
   { message = "^chore\\(changelog\\)", skip = true },
   { message = "^[cC]hore", group = "<!-- 07 -->Miscellaneous Tasks" },
-  { body = ".*security", group = "<!-- 08 -->Security" },
   { message = "^build\\(deps\\)", skip = true },
-  { message = "^build", group = "<!-- 09 -->Build" },
+  { message = "^build", group = "<!-- 08 -->Build" },
+  { body = ".*security", group = "<!-- 09 -->Security" },
   { message = "^ci", group = "<!-- 10 -->Continuous Integration" },
   { message = "^revert", group = "<!-- 11 -->Reverted Commits" },
   # handle some old commits styles from pre 0.4

--- a/ratatui/benches/main.rs
+++ b/ratatui/benches/main.rs
@@ -2,6 +2,7 @@ pub mod main {
     pub mod barchart;
     pub mod block;
     pub mod buffer;
+    pub mod constraints;
     pub mod line;
     pub mod list;
     pub mod paragraph;
@@ -21,4 +22,5 @@ criterion::criterion_main!(
     rect::benches,
     sparkline::benches,
     table::benches,
+    constraints::benches,
 );

--- a/ratatui/benches/main/constraints.rs
+++ b/ratatui/benches/main/constraints.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 use std::rc::Rc;
 
-use criterion::{criterion_group, Criterion};
+use criterion::{Criterion, criterion_group};
 use ratatui::layout::Constraint::{Fill, Length, Max, Min, Percentage, Ratio};
 use ratatui::layout::{Layout, Rect};
 

--- a/ratatui/benches/main/constraints.rs
+++ b/ratatui/benches/main/constraints.rs
@@ -1,59 +1,60 @@
 use std::hint::black_box;
 use std::rc::Rc;
 
-use criterion::{Criterion, criterion_group};
+use criterion::{criterion_group, Criterion};
 use ratatui::layout::Constraint::{Fill, Length, Max, Min, Percentage, Ratio};
-use ratatui::layout::{Direction, Layout, Rect};
+use ratatui::layout::{Layout, Rect};
 
 const SPLIT_BY: u16 = 10;
 
-fn generate_layout(constraint: &str, area: Rect) -> Rc<[Rect]> {
-    Layout::default()
-        .direction(Direction::Vertical)
-        .constraints({
-            let mut cs = Vec::new();
-            for _ in 0..SPLIT_BY {
-                match constraint {
-                    "Fill" => {
-                        cs.push(Fill(1));
-                    }
-                    "Length" => {
-                        cs.push(Length(area.width / SPLIT_BY));
-                    }
-                    "Max" => {
-                        cs.push(Max(area.width / SPLIT_BY));
-                    }
-                    "Min" => {
-                        cs.push(Min(area.width / SPLIT_BY));
-                    }
-                    "Percentage" => {
-                        cs.push(Percentage(100 / SPLIT_BY));
-                    }
-                    "Ratio" => {
-                        cs.push(Ratio(1, SPLIT_BY.into()));
-                    }
-                    _ => todo!(),
-                }
-            }
-            cs
-        })
-        .split(area)
-}
-
-fn constraints_render(criterion: &mut Criterion) {
-    for size in [16, 64, 255] {
+fn layout_split(criterion: &mut Criterion) {
+    for size in [16, 64, 256] {
         let mut group = criterion.benchmark_group(format!("constraints {size}x{size}"));
-        group.sample_size(1000);
         let area = Rect::new(0, 0, size, size);
-        for constraint in ["Fill", "Length", "Max", "Min", "Percentage", "Ratio"] {
-            group.bench_function(constraint.to_string(), |bencher| {
-                bencher.iter(|| {
-                    _ = black_box(generate_layout(constraint, area));
-                });
-            });
-        }
+        group.bench_function("Fill", |bencher| {
+            bencher.iter(|| layout_fill(black_box(area)));
+        });
+        group.bench_function("Length", |bencher| {
+            bencher.iter(|| layout_length(black_box(area)));
+        });
+        group.bench_function("Max", |bencher| {
+            bencher.iter(|| layout_max(black_box(area)));
+        });
+        group.bench_function("Min", |bencher| {
+            bencher.iter(|| layout_min(black_box(area)));
+        });
+        group.bench_function("Percentage", |bencher| {
+            bencher.iter(|| layout_percentage(black_box(area)));
+        });
+        group.bench_function("Ratio", |bencher| {
+            bencher.iter(|| layout_ratio(black_box(area)));
+        });
         group.finish();
     }
 }
 
-criterion_group!(benches, constraints_render);
+fn layout_fill(area: Rect) -> Rc<[Rect]> {
+    Layout::vertical([Fill(1); SPLIT_BY as usize]).split(area)
+}
+
+fn layout_length(area: Rect) -> Rc<[Rect]> {
+    Layout::vertical([Length(area.width / SPLIT_BY); SPLIT_BY as usize]).split(area)
+}
+
+fn layout_max(area: Rect) -> Rc<[Rect]> {
+    Layout::vertical([Max(area.width / SPLIT_BY); SPLIT_BY as usize]).split(area)
+}
+
+fn layout_min(area: Rect) -> Rc<[Rect]> {
+    Layout::vertical([Min(area.width / SPLIT_BY); SPLIT_BY as usize]).split(area)
+}
+
+fn layout_percentage(area: Rect) -> Rc<[Rect]> {
+    Layout::vertical([Percentage(100 / SPLIT_BY); SPLIT_BY as usize]).split(area)
+}
+
+fn layout_ratio(area: Rect) -> Rc<[Rect]> {
+    Layout::vertical([Ratio(1, SPLIT_BY.into()); SPLIT_BY as usize]).split(area)
+}
+
+criterion_group!(benches, layout_split);

--- a/ratatui/benches/main/constraints.rs
+++ b/ratatui/benches/main/constraints.rs
@@ -1,0 +1,59 @@
+use std::hint::black_box;
+use std::rc::Rc;
+
+use criterion::{Criterion, criterion_group};
+use ratatui::layout::Constraint::{Fill, Length, Max, Min, Percentage, Ratio};
+use ratatui::layout::{Direction, Layout, Rect};
+
+const SPLIT_BY: u16 = 10;
+
+fn generate_layout(constraint: &str, area: Rect) -> Rc<[Rect]> {
+    Layout::default()
+        .direction(Direction::Vertical)
+        .constraints({
+            let mut cs = Vec::new();
+            for _ in 0..SPLIT_BY {
+                match constraint {
+                    "Fill" => {
+                        cs.push(Fill(1));
+                    }
+                    "Length" => {
+                        cs.push(Length(area.width / SPLIT_BY));
+                    }
+                    "Max" => {
+                        cs.push(Max(area.width / SPLIT_BY));
+                    }
+                    "Min" => {
+                        cs.push(Min(area.width / SPLIT_BY));
+                    }
+                    "Percentage" => {
+                        cs.push(Percentage(100 / SPLIT_BY));
+                    }
+                    "Ratio" => {
+                        cs.push(Ratio(1, SPLIT_BY.into()));
+                    }
+                    _ => todo!(),
+                }
+            }
+            cs
+        })
+        .split(area)
+}
+
+fn constraints_render(criterion: &mut Criterion) {
+    for size in [16, 64, 255] {
+        let mut group = criterion.benchmark_group(format!("constraints {size}x{size}"));
+        group.sample_size(1000);
+        let area = Rect::new(0, 0, size, size);
+        for constraint in ["Fill", "Length", "Max", "Min", "Percentage", "Ratio"] {
+            group.bench_function(constraint.to_string(), |bencher| {
+                bencher.iter(|| {
+                    _ = black_box(generate_layout(constraint, area));
+                });
+            });
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(benches, constraints_render);


### PR DESCRIPTION
I've added a new benchmark for constraints, which only takes into account the time it takes to generate a full layout using a single type of constraints only. Avoided rendering here as it resulted in more inaccurate benchmarks, and i believe it should be separated nonetheless. 

<img width="1190" height="440" alt="image" src="https://github.com/user-attachments/assets/fc18defa-6811-4e17-b2a4-f81fe333307b" />

<img width="398" height="151" alt="image" src="https://github.com/user-attachments/assets/299aa85c-4cb2-488b-8915-2d5ddca4a138" />
