### PR TITLE
fix(deps): update slab and zerovec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3048,9 +3048,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -4373,9 +4373,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbb9122ea75b11bf96e7492afb723e8a7fbe12c67417aa95e7e3d18144d37cd"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",


### PR DESCRIPTION
## Summary
This PR updates the `slab` dependency from 0.4.10 to 0.4.11 to fix
[RUSTSEC-2025-0047](https://rustsec.org/advisories/RUSTSEC-2025-0047), a security
advisory about a bounds check bug in `get_disjoint_mut` that could lead to reading
uninitialized memory. Also updates `zerovec` to the latest non-yanked version to resolve cargo-deny warnings.

## Changes
- Updated `slab` to 0.4.11
- Updated `zerovec` to latest available version
- Regenerated `Cargo.lock`

## References
- https://rustsec.org/advisories/RUSTSEC-2025-0047
- https://github.com/ratatui/ratatui/actions/runs/16983398723/job/48147754711?pr=1963
