### PR TITLE
docs(Terminal::get_frame): Made usage of Terminal::get_frame() clearer

### DIFF
--- a/ratatui-core/src/layout/layout.rs
+++ b/ratatui-core/src/layout/layout.rs
@@ -130,7 +130,7 @@ impl From<i16> for Spacing {
 ///
 /// When the layout is computed, the result is cached in a thread-local cache, so that subsequent
 /// calls with the same parameters are faster. The cache is a `LruCache`, and the size of the cache
-/// can be configured using [`Layout::init_cache()`].
+/// can be configured using `Layout::init_cache()` when the `layout-cache` feature is enabled.
 ///
 /// # Construction
 ///
@@ -160,7 +160,7 @@ impl From<i16> for Spacing {
 ///
 /// # Cache Management
 ///
-/// - [`init_cache`](Self::init_cache) - Initialize layout cache with custom size
+/// - `init_cache` - Initialize layout cache with custom size (requires the `layout-cache` feature)
 ///
 /// # Example
 ///
@@ -203,8 +203,8 @@ impl Layout {
     /// on my laptop's terminal (171+51 = 222) and doubling it for good measure and then adding a
     /// bit more to make it a round number. This gives enough entries to store a layout for every
     /// row and every column, twice over, which should be enough for most apps. For those that need
-    /// more, the cache size can be set with [`Layout::init_cache()`].
-    /// This const is unused if layout cache is disabled.
+    /// more, the cache size can be set with `Layout::init_cache()` (requires the `layout-cache`
+    /// feature). This const is unused if layout cache is disabled.
     #[cfg(feature = "layout-cache")]
     pub const DEFAULT_CACHE_SIZE: usize = 500;
 
@@ -297,7 +297,7 @@ impl Layout {
     /// that subsequent calls with the same parameters are faster. The cache is a `LruCache`, and
     /// grows until `cache_size` is reached.
     ///
-    /// By default, the cache size is [`Self::DEFAULT_CACHE_SIZE`].
+    /// By default, the cache size is `DEFAULT_CACHE_SIZE`.
     #[cfg(feature = "layout-cache")]
     pub fn init_cache(cache_size: NonZeroUsize) {
         LAYOUT_CACHE.with_borrow_mut(|cache| cache.resize(cache_size));
@@ -636,8 +636,8 @@ impl Layout {
     ///
     /// This method stores the result of the computation in a thread-local cache keyed on the layout
     /// and area, so that subsequent calls with the same parameters are faster. The cache is a
-    /// `LruCache`, and grows until [`Self::DEFAULT_CACHE_SIZE`] is reached by default, if the cache
-    /// is initialized with the [`Layout::init_cache()`] grows until the initialized cache size.
+    /// `LruCache`, and grows until `DEFAULT_CACHE_SIZE` is reached by default. If the cache is
+    /// initialized with `Layout::init_cache()`, it grows until the initialized cache size.
     ///
     /// There is a helper method that can be used to split the whole area into smaller ones based on
     /// the layout: [`Layout::areas()`]. That method is a shortcut for calling this method. It
@@ -673,8 +673,8 @@ impl Layout {
     ///
     /// This method stores the result of the computation in a thread-local cache keyed on the layout
     /// and area, so that subsequent calls with the same parameters are faster. The cache is a
-    /// `LruCache`, and grows until [`Self::DEFAULT_CACHE_SIZE`] is reached by default, if the cache
-    /// is initialized with the [`Layout::init_cache()`] grows until the initialized cache size.
+    /// `LruCache`, and grows until `DEFAULT_CACHE_SIZE` is reached by default. If the cache is
+    /// initialized with `Layout::init_cache()`, it grows until the initialized cache size.
     ///
     /// # Examples
     ///

--- a/ratatui-core/src/layout/layout.rs
+++ b/ratatui-core/src/layout/layout.rs
@@ -130,7 +130,7 @@ impl From<i16> for Spacing {
 ///
 /// When the layout is computed, the result is cached in a thread-local cache, so that subsequent
 /// calls with the same parameters are faster. The cache is a `LruCache`, and the size of the cache
-/// can be configured using `Layout::init_cache()` when the `layout-cache` feature is enabled.
+/// can be configured using [`Layout::init_cache()`] when the `layout-cache` feature is enabled.
 ///
 /// # Construction
 ///
@@ -160,7 +160,7 @@ impl From<i16> for Spacing {
 ///
 /// # Cache Management
 ///
-/// - `init_cache` - Initialize layout cache with custom size (requires the `layout-cache` feature)
+/// - [`init_cache`](Self::init_cache) - Initialize layout cache with custom size
 ///
 /// # Example
 ///
@@ -297,7 +297,7 @@ impl Layout {
     /// that subsequent calls with the same parameters are faster. The cache is a `LruCache`, and
     /// grows until `cache_size` is reached.
     ///
-    /// By default, the cache size is `DEFAULT_CACHE_SIZE`.
+    /// By default, the cache size is [`Self::DEFAULT_CACHE_SIZE`].
     #[cfg(feature = "layout-cache")]
     pub fn init_cache(cache_size: NonZeroUsize) {
         LAYOUT_CACHE.with_borrow_mut(|cache| cache.resize(cache_size));
@@ -636,8 +636,8 @@ impl Layout {
     ///
     /// This method stores the result of the computation in a thread-local cache keyed on the layout
     /// and area, so that subsequent calls with the same parameters are faster. The cache is a
-    /// `LruCache`, and grows until `DEFAULT_CACHE_SIZE` is reached by default. If the cache is
-    /// initialized with `Layout::init_cache()`, it grows until the initialized cache size.
+    /// `LruCache`, and grows until [`Self::DEFAULT_CACHE_SIZE`] is reached by default. If the cache is
+    /// initialized with [`Layout::init_cache()`], it grows until the initialized cache size.
     ///
     /// There is a helper method that can be used to split the whole area into smaller ones based on
     /// the layout: [`Layout::areas()`]. That method is a shortcut for calling this method. It
@@ -673,8 +673,8 @@ impl Layout {
     ///
     /// This method stores the result of the computation in a thread-local cache keyed on the layout
     /// and area, so that subsequent calls with the same parameters are faster. The cache is a
-    /// `LruCache`, and grows until `DEFAULT_CACHE_SIZE` is reached by default. If the cache is
-    /// initialized with `Layout::init_cache()`, it grows until the initialized cache size.
+    /// `LruCache`, and grows until [`Self::DEFAULT_CACHE_SIZE`] is reached by default. If the cache is
+    /// initialized with [`Layout::init_cache()`], it grows until the initialized cache size.
     ///
     /// # Examples
     ///

--- a/ratatui-core/src/layout/layout.rs
+++ b/ratatui-core/src/layout/layout.rs
@@ -204,7 +204,7 @@ impl Layout {
     /// bit more to make it a round number. This gives enough entries to store a layout for every
     /// row and every column, twice over, which should be enough for most apps. For those that need
     /// more, the cache size can be set with `Layout::init_cache()` (requires the `layout-cache`
-    /// feature). This const is unused if layout cache is disabled.
+    /// feature).
     #[cfg(feature = "layout-cache")]
     pub const DEFAULT_CACHE_SIZE: usize = 500;
 

--- a/ratatui-core/src/layout/layout.rs
+++ b/ratatui-core/src/layout/layout.rs
@@ -636,8 +636,8 @@ impl Layout {
     ///
     /// This method stores the result of the computation in a thread-local cache keyed on the layout
     /// and area, so that subsequent calls with the same parameters are faster. The cache is a
-    /// `LruCache`, and grows until [`Self::DEFAULT_CACHE_SIZE`] is reached by default. If the cache is
-    /// initialized with [`Layout::init_cache()`], it grows until the initialized cache size.
+    /// `LruCache`, and grows until [`Self::DEFAULT_CACHE_SIZE`] is reached by default. If the cache
+    /// is initialized with [`Layout::init_cache()`], it grows until the initialized cache size.
     ///
     /// There is a helper method that can be used to split the whole area into smaller ones based on
     /// the layout: [`Layout::areas()`]. That method is a shortcut for calling this method. It
@@ -673,8 +673,8 @@ impl Layout {
     ///
     /// This method stores the result of the computation in a thread-local cache keyed on the layout
     /// and area, so that subsequent calls with the same parameters are faster. The cache is a
-    /// `LruCache`, and grows until [`Self::DEFAULT_CACHE_SIZE`] is reached by default. If the cache is
-    /// initialized with [`Layout::init_cache()`], it grows until the initialized cache size.
+    /// `LruCache`, and grows until [`Self::DEFAULT_CACHE_SIZE`] is reached by default. If the cache
+    /// is initialized with [`Layout::init_cache()`], it grows until the initialized cache size.
     ///
     /// # Examples
     ///

--- a/ratatui-core/src/terminal/terminal.rs
+++ b/ratatui-core/src/terminal/terminal.rs
@@ -189,8 +189,9 @@ where
 
     /// Get a Frame object which provides a consistent view into the terminal state for rendering.
     ///
-    /// Note that this exists to support more advanced use cases. Most cases should be fine using
-    /// [`Terminal::draw`].
+    /// # Note
+    ///
+    /// This exists to support more advanced use cases. Most cases should be fine using [`Terminal::draw`].
     ///
     /// `get_frame` should be used when you need direct access to the frame buffer
     /// outside of draw closure, for example:

--- a/ratatui-core/src/terminal/terminal.rs
+++ b/ratatui-core/src/terminal/terminal.rs
@@ -191,7 +191,8 @@ where
     ///
     /// # Note
     ///
-    /// This exists to support more advanced use cases. Most cases should be fine using [`Terminal::draw`].
+    /// This exists to support more advanced use cases. Most cases should be fine using
+    /// [`Terminal::draw`].
     ///
     /// [`Terminal::get_frame`] should be used when you need direct access to the frame buffer
     /// outside of draw closure, for example:

--- a/ratatui-core/src/terminal/terminal.rs
+++ b/ratatui-core/src/terminal/terminal.rs
@@ -203,9 +203,9 @@ where
     /// - Multiple rendering passes/Buffer Manipulation
     /// - Custom frame lifecycle management
     /// - Buffer exporting
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// Getting the buffer and asserting on some cells after rendering a widget.
     /// ```rust,ignore
     /// use ratatui::{backend::TestBackend, Terminal};

--- a/ratatui-core/src/terminal/terminal.rs
+++ b/ratatui-core/src/terminal/terminal.rs
@@ -222,6 +222,7 @@ where
     /// # Example
     ///
     /// Getting the buffer and asserting on some cells after rendering a widget.
+    ///
     /// ```rust,ignore
     /// use ratatui::{backend::TestBackend, Terminal};
     /// use ratatui::widgets::Paragraph;

--- a/ratatui-core/src/terminal/terminal.rs
+++ b/ratatui-core/src/terminal/terminal.rs
@@ -203,38 +203,23 @@ where
     /// - Multiple rendering passes/Buffer Manipulation
     /// - Custom frame lifecycle management
     /// - Buffer exporting
+    /// 
     /// # Example
+    /// 
     /// Getting the buffer and asserting on some cells after rendering a widget.
     /// ```rust,ignore
-    /// #[cfg(test)]
-    /// mod tests {
-    ///     use ratatui::{
-    ///         backend::TestBackend,
-    ///         widgets::{Block, Borders, Paragraph},
-    ///         Terminal,
-    ///     };
-    ///
-    ///     #[test]
-    ///     fn test_paragraph_with_get_frame() {
-    ///         let backend = TestBackend::new(30, 5);
-    ///         let mut terminal = Terminal::new(backend).unwrap();
-    ///
-    ///         {
-    ///             let mut frame = terminal.get_frame();
-    ///             let para = Paragraph::new("Hello World!")
-    ///                 .block(Block::default().title("Demo").borders(Borders::ALL));
-    ///             frame.render_widget(para, frame.area());
-    ///
-    ///             let buf = frame.buffer_mut();
-    ///
-    ///             // cell assertions
-    ///             assert_eq!(buf[(0, 0)].symbol(), "┌");
-    ///             assert_eq!(buf[(29, 0)].symbol(), "┐");
-    ///             assert_eq!(buf[(1, 0)].symbol(), "D");
-    ///             assert_eq!(buf[(1, 1)].symbol(), "H");
-    ///         }
-    ///     }
+    /// use ratatui::{backend::TestBackend, Terminal};
+    /// use ratatui::widgets::Paragraph;
+    /// let backend = TestBackend::new(30, 5);
+    /// let mut terminal = Terminal::new(backend).unwrap();
+    /// {
+    ///     let mut frame = terminal.get_frame();
+    ///     frame.render_widget(Paragraph::new("Hello"), frame.area());
     /// }
+    /// // When not using `draw`, present the buffer manually:
+    /// terminal.flush().unwrap();
+    /// terminal.swap_buffers();
+    /// terminal.backend_mut().flush().unwrap();
     /// ```
     pub const fn get_frame(&mut self) -> Frame<'_> {
         let count = self.frame_count;

--- a/ratatui-core/src/terminal/terminal.rs
+++ b/ratatui-core/src/terminal/terminal.rs
@@ -204,8 +204,38 @@ where
     /// - Custom frame lifecycle management
     /// - Buffer exporting
     /// # Example
-    /// The [Dioxus CLI `output.rs`](https://github.com/DioxusLabs/dioxus/blob/ed568be4cb44be33dddbc20fb0425c83ff489522/packages/cli/src/serve/output.rs#L1072)
-    /// demonstrates how the function is used to manipulate the cursor position
+    /// Getting the buffer and asserting on some cells after rendering a widget.
+    /// ```rust,ignore
+    /// #[cfg(test)]
+    /// mod tests {
+    ///     use ratatui::{
+    ///         backend::TestBackend,
+    ///         widgets::{Block, Borders, Paragraph},
+    ///         Terminal,
+    ///     };
+    ///
+    ///     #[test]
+    ///     fn test_paragraph_with_get_frame() {
+    ///         let backend = TestBackend::new(30, 5);
+    ///         let mut terminal = Terminal::new(backend).unwrap();
+    ///
+    ///         {
+    ///             let mut frame = terminal.get_frame();
+    ///             let para = Paragraph::new("Hello World!")
+    ///                 .block(Block::default().title("Demo").borders(Borders::ALL));
+    ///             frame.render_widget(para, frame.area());
+    ///
+    ///             let buf = frame.buffer_mut();
+    ///
+    ///             // cell assertions
+    ///             assert_eq!(buf[(0, 0)].symbol(), "┌");
+    ///             assert_eq!(buf[(29, 0)].symbol(), "┐");
+    ///             assert_eq!(buf[(1, 0)].symbol(), "D");
+    ///             assert_eq!(buf[(1, 1)].symbol(), "H");
+    ///         }
+    ///     }
+    /// }
+    /// ```
     pub const fn get_frame(&mut self) -> Frame<'_> {
         let count = self.frame_count;
         Frame {

--- a/ratatui-core/src/terminal/terminal.rs
+++ b/ratatui-core/src/terminal/terminal.rs
@@ -188,6 +188,21 @@ where
     }
 
     /// Get a Frame object which provides a consistent view into the terminal state for rendering.
+    ///
+    /// Note that this exists to support more advanced use cases. Most cases should be fine using
+    /// [`Terminal::draw`].
+    ///
+    /// `get_frame` should be used when you need direct access to the frame buffer
+    /// outside of draw closure, for example:
+    /// - Unit testing widgets
+    /// - Buffer state inspection
+    /// - Cursor manipulation
+    /// - Multiple rendering passes/Buffer Manipulation
+    /// - Custom frame lifecycle management
+    /// - Buffer exporting
+    /// # Example
+    /// The [Dioxus CLI `output.rs`](https://github.com/DioxusLabs/dioxus/blob/ed568be4cb44be33dddbc20fb0425c83ff489522/packages/cli/src/serve/output.rs#L1072)
+    /// demonstrates how the function is used to manipulate the cursor position
     pub const fn get_frame(&mut self) -> Frame<'_> {
         let count = self.frame_count;
         Frame {

--- a/ratatui-core/src/terminal/terminal.rs
+++ b/ratatui-core/src/terminal/terminal.rs
@@ -193,8 +193,9 @@ where
     ///
     /// This exists to support more advanced use cases. Most cases should be fine using [`Terminal::draw`].
     ///
-    /// `get_frame` should be used when you need direct access to the frame buffer
+    /// [`Terminal::get_frame`] should be used when you need direct access to the frame buffer
     /// outside of draw closure, for example:
+    ///
     /// - Unit testing widgets
     /// - Buffer state inspection
     /// - Cursor manipulation


### PR DESCRIPTION
Updated the Terminal::get_frame section and added use cases, including an example from Dioxus showing how get_frame() can/should be used.

Also mentioned/pointed, that most people should be fine using Terminal::draw()

Closes : https://github.com/ratatui/ratatui/issues/1200