### PR TITLE
chore: update comment for Rect.area()

### DIFF
--- a/ratatui-core/src/layout/rect.rs
+++ b/ratatui-core/src/layout/rect.rs
@@ -164,8 +164,7 @@ impl Rect {
         }
     }
 
-    /// The area of the `Rect`. If the area is larger than the maximum value of `u16`, it will be
-    /// clamped to `u16::MAX`.
+    /// The area of the `Rect`.
     pub const fn area(self) -> u32 {
         (self.width as u32) * (self.height as u32)
     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
The return value of Rect.area() is no longer of u16 type, and the value is not being clumped anymore.