### PR TITLE
ci: fix toolchain override in CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,8 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
       - run: cargo xtask clippy
+        env:
+          RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
 
   # Run markdownlint on all markdown files in the repository.
   lint-markdown:


### PR DESCRIPTION
### Summary
Fixes an issue where the beta CI jobs were unintentionally using the stable
toolchain from `rust-toolchain.toml` instead of the matrix-specified toolchain.
This caused clippy to run against the wrong version.

### Details
- Added `RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}` to the CI configuration

### Additional Context
- https://rust-lang.github.io/rustup/overrides.html#overrides