### PR TITLE
ci: set RUSTUP_TOOLCHAIN from matrix.toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,8 @@ jobs:
           tool: cargo-hack
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
       - run: cargo xtask check --all-features
+        env:
+          RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
 
   build-no-std:
     name: Build No-Std


### PR DESCRIPTION
Summary
Fixes an issue where the "check" CI jobs for MSRV and stable were unintentionally using the stable toolchain from `rust-toolchain.toml` instead of the matrix-specified toolchain.

Details
- Added `RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}` to the "check" job in CI configuration.

Additional Context
- https://github.com/ratatui/ratatui/pull/2106
- https://discord.com/channels/1070692720437383208/1072879985762762812/1422345357131780177
- https://rust-lang.github.io/rustup/overrides.html#overrides