### PR TITLE
revert(release): prepare for beta release (#2022)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.0-beta.0"
+version = "0.30.0-alpha.5"
 dependencies = [
  "color-eyre",
  "criterion",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0-beta.0"
+version = "0.1.0-alpha.6"
 dependencies = [
  "anstyle",
  "bitflags 2.9.4",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0-beta.0"
+version = "0.1.0-alpha.5"
 dependencies = [
  "cfg-if",
  "crossterm 0.28.1",
@@ -2558,7 +2558,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0-beta.0"
+version = "0.7.0-alpha.4"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-termion"
-version = "0.1.0-beta.0"
+version = "0.1.0-alpha.5"
 dependencies = [
  "document-features",
  "instability",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-termwiz"
-version = "0.1.0-beta.0"
+version = "0.1.0-alpha.5"
 dependencies = [
  "document-features",
  "ratatui",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0-beta.0"
+version = "0.3.0-alpha.5"
 dependencies = [
  "bitflags 2.9.4",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,13 +50,13 @@ palette = "0.7"
 pretty_assertions = "1"
 rand = "0.9"
 rand_chacha = "0.9"
-ratatui = { path = "ratatui", version = "0.30.0-beta.0" }
-ratatui-core = { path = "ratatui-core", version = "0.1.0-beta.0" }
-ratatui-crossterm = { path = "ratatui-crossterm", version = "0.1.0-beta.0" }
-ratatui-macros = { path = "ratatui-macros", version = "0.7.0-beta.0" }
-ratatui-termion = { path = "ratatui-termion", version = "0.1.0-beta.0" }
-ratatui-termwiz = { path = "ratatui-termwiz", version = "0.1.0-beta.0" }
-ratatui-widgets = { path = "ratatui-widgets", version = "0.3.0-beta.0" }
+ratatui = { path = "ratatui", version = "0.30.0-alpha.5" }
+ratatui-core = { path = "ratatui-core", version = "0.1.0-alpha.6" }
+ratatui-crossterm = { path = "ratatui-crossterm", version = "0.1.0-alpha.5" }
+ratatui-macros = { path = "ratatui-macros", version = "0.7.0-alpha.4" }
+ratatui-termion = { path = "ratatui-termion", version = "0.1.0-alpha.5" }
+ratatui-termwiz = { path = "ratatui-termwiz", version = "0.1.0-alpha.5" }
+ratatui-widgets = { path = "ratatui-widgets", version = "0.3.0-alpha.5" }
 rstest = "0.26"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -4,7 +4,7 @@ description = """
     Core types and traits for the Ratatui Terminal UI library.
     Widget libraries should use this crate. Applications should use the main Ratatui crate.
 """
-version = "0.1.0-beta.0"
+version = "0.1.0-alpha.6"
 readme = "README.md"
 authors.workspace = true
 documentation.workspace = true

--- a/ratatui-crossterm/Cargo.toml
+++ b/ratatui-crossterm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratatui-crossterm"
-version = "0.1.0-beta.0"
+version = "0.1.0-alpha.5"
 description = "Crossterm backend for the Ratatui Terminal UI library."
 documentation = "https://docs.rs/ratatui-crossterm/"
 readme = "README.md"

--- a/ratatui-macros/Cargo.toml
+++ b/ratatui-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratatui-macros"
-version = "0.7.0-beta.0"
+version = "0.7.0-alpha.4"
 edition.workspace = true
 authors = ["The Ratatui Developers"]
 description = "Macros for Ratatui"

--- a/ratatui-termion/Cargo.toml
+++ b/ratatui-termion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratatui-termion"
-version = "0.1.0-beta.0"
+version = "0.1.0-alpha.5"
 description = "Termion backend for the Ratatui Terminal UI library."
 documentation = "https://docs.rs/ratatui-termion/"
 readme = "README.md"

--- a/ratatui-termwiz/Cargo.toml
+++ b/ratatui-termwiz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ratatui-termwiz"
-version = "0.1.0-beta.0"
+version = "0.1.0-alpha.5"
 description = "Termwiz backend for the Ratatui Terminal UI library."
 documentation = "https://docs.rs/ratatui-termwiz/"
 readme = "README.md"

--- a/ratatui-widgets/Cargo.toml
+++ b/ratatui-widgets/Cargo.toml
@@ -3,7 +3,7 @@ name = "ratatui-widgets"
 description = "A collection of Ratatui widgets for building terminal user interfaces using Ratatui."
 # Note that this started at 0.3.0 as there was a previous crate using the name `ratatui-widgets`.
 # <https://github.com/joshka/ratatui-widgets/issues/46>
-version = "0.3.0-beta.0"
+version = "0.3.0-alpha.5"
 readme = "README.md"
 authors.workspace = true
 documentation.workspace = true

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ratatui"
 description = "A library that's all about cooking up terminal user interfaces"
-version = "0.30.0-beta.0"
+version = "0.30.0-alpha.5"
 authors.workspace = true
 documentation.workspace = true
 repository.workspace = true


### PR DESCRIPTION
This reverts commit 5ae224b244a61d9d1460d7e1b0c448dd7cf72933.

See https://github.com/ratatui/ratatui/pull/2022#issuecomment-3349094310 for rationale.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
