### PR TITLE
feat(list): truncate

### DIFF
--- a/ratatui-widgets/src/list.rs
+++ b/ratatui-widgets/src/list.rs
@@ -125,6 +125,8 @@ pub struct List<'a> {
     pub(crate) highlight_spacing: HighlightSpacing,
     /// How many items to try to keep visible before and after the selected item
     pub(crate) scroll_padding: usize,
+    /// Whether to truncate the last item if too large to fit in frame
+    pub(crate) truncate: bool,
 }
 
 /// Defines the direction in which the list will be rendered.
@@ -414,6 +416,17 @@ impl<'a> List<'a> {
     #[must_use = "method moves the value of self and returns the modified value"]
     pub const fn scroll_padding(mut self, padding: usize) -> Self {
         self.scroll_padding = padding;
+        self
+    }
+
+    /// Indicates whether the last item should be truncated if it is too long to fit in the frame.
+    /// 
+    /// This is `false` by default.
+    /// 
+    /// The direction of the list will determine which side gets truncated.
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn truncate(mut self, truncate: bool) -> List<'a> {
+        self.truncate = truncate;
         self
     }
 

--- a/ratatui-widgets/src/list.rs
+++ b/ratatui-widgets/src/list.rs
@@ -420,12 +420,12 @@ impl<'a> List<'a> {
     }
 
     /// Indicates whether the last item should be truncated if it is too long to fit in the frame.
-    /// 
+    ///
     /// This is `false` by default.
-    /// 
+    ///
     /// The direction of the list will determine which side gets truncated.
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub fn truncate(mut self, truncate: bool) -> List<'a> {
+    pub const fn truncate(mut self, truncate: bool) -> Self {
         self.truncate = truncate;
         self
     }

--- a/ratatui-widgets/src/list/rendering.rs
+++ b/ratatui-widgets/src/list/rendering.rs
@@ -203,6 +203,23 @@ impl List<'_> {
             }
         }
 
+        // After ensuring the selected item is visible we may have left a gap, greedily include
+        // more items at the bottom as long as they fully fit into `max_height`
+        while last_visible_index < self.items.len()
+            && height_from_offset + self.items[last_visible_index].height() <= max_height
+        {
+            height_from_offset += self.items[last_visible_index].height();
+            last_visible_index += 1;
+        }
+
+        // Include the next overflowing item if truncating
+        if self.truncate
+            && last_visible_index < self.items.len()
+            && height_from_offset < max_height
+        {
+            last_visible_index += 1;
+        }
+
         (first_visible_index, last_visible_index)
     }
 

--- a/ratatui-widgets/src/list/rendering.rs
+++ b/ratatui-widgets/src/list/rendering.rs
@@ -1,6 +1,6 @@
 use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::Rect;
-use ratatui_core::text::{Line, Text, ToLine};
+use ratatui_core::text::{Line, ToLine};
 use ratatui_core::widgets::{StatefulWidget, Widget};
 
 use crate::block::BlockExt;
@@ -286,7 +286,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use ratatui_core::layout::{Alignment, Rect};
     use ratatui_core::style::{Color, Modifier, Style, Stylize};
-    use ratatui_core::text::Line;
+    use ratatui_core::text::{Line, Text};
     use ratatui_core::widgets::{StatefulWidget, Widget};
     use rstest::{fixture, rstest};
 

--- a/ratatui-widgets/src/list/rendering.rs
+++ b/ratatui-widgets/src/list/rendering.rs
@@ -84,7 +84,10 @@ impl StatefulWidget for &List<'_> {
 
             let (x, y) = if self.direction == ListDirection::BottomToTop {
                 current_height += item_height;
-                (list_area.left(), list_area.bottom().saturating_sub(current_height as u16))
+                (
+                    list_area.left(),
+                    list_area.bottom().saturating_sub(current_height as u16),
+                )
             } else {
                 let pos = (list_area.left(), list_area.top() + current_height as u16);
                 current_height += item_height;
@@ -219,9 +222,7 @@ impl List<'_> {
         }
 
         // Include the next overflowing item if truncating
-        if self.truncate
-            && last_visible_index < self.items.len()
-            && height_from_offset < max_height
+        if self.truncate && last_visible_index < self.items.len() && height_from_offset < max_height
         {
             last_visible_index += 1;
         }

--- a/ratatui-widgets/src/list/rendering.rs
+++ b/ratatui-widgets/src/list/rendering.rs
@@ -1,6 +1,6 @@
 use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::Rect;
-use ratatui_core::text::{Line, ToLine};
+use ratatui_core::text::{Line, Text, ToLine};
 use ratatui_core::widgets::{StatefulWidget, Widget};
 
 use crate::block::BlockExt;
@@ -965,6 +965,47 @@ mod tests {
             state.offset, 4,
             "did not scroll the selected item into view"
         );
+    }
+
+    #[test]
+    fn ensuring_selected_item_is_visible_fills_remaining_space() {
+        let list = List::new([
+            Text::from(vec!["Multiline".into(), "Item".into()]),
+            "Item 1".into(),
+            "Item 2".into(),
+        ]);
+        let mut state = ListState::default().with_offset(0).with_selected(Some(1));
+        let buffer = stateful_widget(list, &mut state, 9, 2);
+
+        let expected = Buffer::with_lines(["Item 1   ", "Item 2  "]);
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn show_last_item_truncated_when_enabled_and_overflowing() {
+        let list = List::new([
+            "Item 1".into(),
+            Text::from(vec!["Multiline".into(), "Item".into()]),
+        ])
+        .truncate(true);
+        let mut state = ListState::default();
+        let buffer = stateful_widget(list, &mut state, 9, 2);
+
+        let expected = Buffer::with_lines(["Item 1   ", "Multiline"]);
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn does_not_show_last_item_truncated_when_disabled_and_overflowing() {
+        let list = List::new([
+            "Item 1".into(),
+            Text::from(vec!["Multiline".into(), "Item".into()]),
+        ]);
+        let mut state = ListState::default();
+        let buffer = stateful_widget(list, &mut state, 9, 2);
+
+        let expected = Buffer::with_lines(["Item 1   ", "         "]);
+        assert_eq!(buffer, expected);
     }
 
     #[test]


### PR DESCRIPTION
Makes better use of the available list area without changing any semantics.

- Fixes a bug where items get excluded despite fitting fully within the list area as shown in test `ensuring_selected_item_is_visible_fills_remaining_space`
- Currently (and now by default) any overflowing items are not shown.  Now you can optionally enable truncation to include of the final overflowing list item when its full height does not fit within the available list area.   