### PR TITLE
feat(widgets): separate HighlightSpacing into ListHighlightSpacing and TableHighlightSpacing (#1767)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -30,6 +30,8 @@ This is a quick summary of the sections below:
   - `Marker` is now non-exhaustive
   - `symbols::braille::BLANK` and `symbols::braille::DOTS` have been removed in favor of an ordered
     array of all Braille characters
+  - `widgets::HighlightSpacing` has been separated into `widgets::ListHighlightSpacing` and
+    `widgets::TableHighlightSpacing`
 - [v0.29.0](#v0290)
   - `Sparkline::data` takes `IntoIterator<Item = SparklineBar>` instead of `&[u64]` and is no longer
     const

--- a/examples/apps/async-github/src/main.rs
+++ b/examples/apps/async-github/src/main.rs
@@ -39,7 +39,9 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Style, Stylize};
 use ratatui::text::Line;
-use ratatui::widgets::{Block, HighlightSpacing, Row, StatefulWidget, Table, TableState, Widget};
+use ratatui::widgets::{
+    Block, Row, StatefulWidget, Table, TableHighlightSpacing, TableState, Widget,
+};
 use ratatui::{DefaultTerminal, Frame};
 use tokio_stream::StreamExt;
 
@@ -220,7 +222,7 @@ impl Widget for &PullRequestListWidget {
         ];
         let table = Table::new(rows, widths)
             .block(block)
-            .highlight_spacing(HighlightSpacing::Always)
+            .highlight_spacing(TableHighlightSpacing::Always)
             .highlight_symbol(">>")
             .row_highlight_style(Style::new().on_blue());
 

--- a/examples/apps/table/src/main.rs
+++ b/examples/apps/table/src/main.rs
@@ -12,8 +12,8 @@ use ratatui::layout::{Constraint, Layout, Margin, Rect};
 use ratatui::style::{self, Color, Modifier, Style, Stylize};
 use ratatui::text::Text;
 use ratatui::widgets::{
-    Block, BorderType, Cell, HighlightSpacing, Paragraph, Row, Scrollbar, ScrollbarOrientation,
-    ScrollbarState, Table, TableState,
+    Block, BorderType, Cell, Paragraph, Row, Scrollbar, ScrollbarOrientation, ScrollbarState,
+    Table, TableHighlightSpacing, TableState,
 };
 use ratatui::{DefaultTerminal, Frame};
 use style::palette::tailwind;
@@ -247,7 +247,7 @@ impl App {
             "".into(),
         ]))
         .bg(self.colors.buffer_bg)
-        .highlight_spacing(HighlightSpacing::Always);
+        .highlight_spacing(TableHighlightSpacing::Always);
         frame.render_stateful_widget(t, area, &mut self.state);
     }
 

--- a/examples/apps/todo-list/src/main.rs
+++ b/examples/apps/todo-list/src/main.rs
@@ -13,7 +13,7 @@ use ratatui::style::palette::tailwind::{BLUE, GREEN, SLATE};
 use ratatui::style::{Color, Modifier, Style, Stylize};
 use ratatui::text::Line;
 use ratatui::widgets::{
-    Block, Borders, HighlightSpacing, List, ListItem, ListState, Padding, Paragraph,
+    Block, Borders, List, ListHighlightSpacing, ListItem, ListState, Padding, Paragraph,
     StatefulWidget, Widget, Wrap,
 };
 use ratatui::{DefaultTerminal, symbols};
@@ -235,7 +235,7 @@ impl App {
             .block(block)
             .highlight_style(SELECTED_STYLE)
             .highlight_symbol(">")
-            .highlight_spacing(HighlightSpacing::Always);
+            .highlight_spacing(ListHighlightSpacing::Always);
 
         // We need to disambiguate this trait method as both `Widget` and `StatefulWidget` share the
         // same method name `render`.

--- a/ratatui-widgets/src/list.rs
+++ b/ratatui-widgets/src/list.rs
@@ -7,11 +7,12 @@ use ratatui_core::style::{Style, Styled};
 use ratatui_core::text::Line;
 use strum::{Display, EnumString};
 
+pub use self::highlight_spacing::ListHighlightSpacing;
 pub use self::item::ListItem;
 pub use self::state::ListState;
 use crate::block::Block;
-use crate::table::HighlightSpacing;
 
+mod highlight_spacing;
 mod item;
 mod rendering;
 mod state;
@@ -122,7 +123,7 @@ pub struct List<'a> {
     /// Whether to repeat the highlight symbol for each line of the selected item
     pub(crate) repeat_highlight_symbol: bool,
     /// Decides when to allocate spacing for the selection symbol
-    pub(crate) highlight_spacing: HighlightSpacing,
+    pub(crate) highlight_spacing: ListHighlightSpacing,
     /// How many items to try to keep visible before and after the selected item
     pub(crate) scroll_padding: usize,
 }
@@ -348,28 +349,28 @@ impl<'a> List<'a> {
     /// and is used to shift the list when an item is selected. This method allows you to configure
     /// when this spacing is allocated.
     ///
-    /// - [`HighlightSpacing::Always`] will always allocate the spacing, regardless of whether an
-    ///   item is selected or not. This means that the table will never change size, regardless of
-    ///   if an item is selected or not.
-    /// - [`HighlightSpacing::WhenSelected`] will only allocate the spacing if an item is selected.
-    ///   This means that the table will shift when an item is selected. This is the default setting
-    ///   for backwards compatibility, but it is recommended to use `HighlightSpacing::Always` for a
-    ///   better user experience.
-    /// - [`HighlightSpacing::Never`] will never allocate the spacing, regardless of whether an item
-    ///   is selected or not. This means that the highlight symbol will never be drawn.
+    /// - [`ListHighlightSpacing::Always`] will always allocate the spacing, regardless of whether
+    ///   an item is selected or not. This means that the table will never change size, regardless
+    ///   of if an item is selected or not.
+    /// - [`ListHighlightSpacing::WhenSelected`] will only allocate the spacing if an item is
+    ///   selected. This means that the table will shift when an item is selected. This is the
+    ///   default setting for backwards compatibility, but it is recommended to use
+    ///   `ListHighlightSpacing::Always` for a better user experience.
+    /// - [`ListHighlightSpacing::Never`] will never allocate the spacing, regardless of whether an
+    ///   item is selected or not. This means that the highlight symbol will never be drawn.
     ///
     /// This is a fluent setter method which must be chained or used as it consumes self
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use ratatui::widgets::{HighlightSpacing, List};
+    /// use ratatui::widgets::{List, ListHighlightSpacing};
     ///
     /// let items = ["Item 1"];
-    /// let list = List::new(items).highlight_spacing(HighlightSpacing::Always);
+    /// let list = List::new(items).highlight_spacing(ListHighlightSpacing::Always);
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub const fn highlight_spacing(mut self, value: HighlightSpacing) -> Self {
+    pub const fn highlight_spacing(mut self, value: ListHighlightSpacing) -> Self {
         self.highlight_spacing = value;
         self
     }
@@ -503,7 +504,7 @@ mod tests {
         let text = Text::from("Item 1");
         let list = List::new([ListItem::new(text)])
             .highlight_symbol(">>")
-            .highlight_spacing(HighlightSpacing::Always);
+            .highlight_spacing(ListHighlightSpacing::Always);
         let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 1));
 
         list.render(buffer.area, &mut buffer, &mut ListState::default());
@@ -516,7 +517,7 @@ mod tests {
         let text = Text::from("Item 1").bold();
         let list = List::new([ListItem::new(text)])
             .highlight_symbol(">>")
-            .highlight_spacing(HighlightSpacing::Always);
+            .highlight_spacing(ListHighlightSpacing::Always);
         let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 1));
 
         list.render(buffer.area, &mut buffer, &mut ListState::default());
@@ -535,7 +536,7 @@ mod tests {
         let item = ListItem::new(text).style(Modifier::ITALIC);
         let list = List::new([item])
             .highlight_symbol(">>")
-            .highlight_spacing(HighlightSpacing::Always);
+            .highlight_spacing(ListHighlightSpacing::Always);
         let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 1));
 
         list.render(buffer.area, &mut buffer, &mut ListState::default());
@@ -554,7 +555,7 @@ mod tests {
         let item = ListItem::new(text).style(Modifier::ITALIC);
         let list = List::new([item])
             .highlight_symbol(">>")
-            .highlight_spacing(HighlightSpacing::Always);
+            .highlight_spacing(ListHighlightSpacing::Always);
         let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 1));
 
         list.render(buffer.area, &mut buffer, &mut ListState::default());

--- a/ratatui-widgets/src/list/highlight_spacing.rs
+++ b/ratatui-widgets/src/list/highlight_spacing.rs
@@ -3,7 +3,7 @@ use strum::{Display, EnumString};
 /// This option allows the user to configure the "highlight symbol" column width spacing
 #[derive(Debug, Display, EnumString, PartialEq, Eq, Clone, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum TableHighlightSpacing {
+pub enum ListHighlightSpacing {
     /// Always add spacing for the selection symbol column
     ///
     /// With this variant, the column for the selection symbol will always be allocated, and so the
@@ -24,7 +24,7 @@ pub enum TableHighlightSpacing {
     Never,
 }
 
-impl TableHighlightSpacing {
+impl ListHighlightSpacing {
     /// Determine if a selection column should be displayed
     ///
     /// `has_selection`: true if a row is selected in the table
@@ -48,35 +48,32 @@ mod tests {
     #[test]
     fn to_string() {
         assert_eq!(
-            TableHighlightSpacing::Always.to_string(),
+            ListHighlightSpacing::Always.to_string(),
             "Always".to_string()
         );
         assert_eq!(
-            TableHighlightSpacing::WhenSelected.to_string(),
+            ListHighlightSpacing::WhenSelected.to_string(),
             "WhenSelected".to_string()
         );
-        assert_eq!(
-            TableHighlightSpacing::Never.to_string(),
-            "Never".to_string()
-        );
+        assert_eq!(ListHighlightSpacing::Never.to_string(), "Never".to_string());
     }
 
     #[test]
     fn from_str() {
         assert_eq!(
-            "Always".parse::<TableHighlightSpacing>(),
-            Ok(TableHighlightSpacing::Always)
+            "Always".parse::<ListHighlightSpacing>(),
+            Ok(ListHighlightSpacing::Always)
         );
         assert_eq!(
-            "WhenSelected".parse::<TableHighlightSpacing>(),
-            Ok(TableHighlightSpacing::WhenSelected)
+            "WhenSelected".parse::<ListHighlightSpacing>(),
+            Ok(ListHighlightSpacing::WhenSelected)
         );
         assert_eq!(
-            "Never".parse::<TableHighlightSpacing>(),
-            Ok(TableHighlightSpacing::Never)
+            "Never".parse::<ListHighlightSpacing>(),
+            Ok(ListHighlightSpacing::Never)
         );
         assert_eq!(
-            "".parse::<TableHighlightSpacing>(),
+            "".parse::<ListHighlightSpacing>(),
             Err(strum::ParseError::VariantNotFound)
         );
     }

--- a/ratatui-widgets/src/list/rendering.rs
+++ b/ratatui-widgets/src/list/rendering.rs
@@ -268,8 +268,7 @@ mod tests {
 
     use super::*;
     use crate::block::Block;
-    use crate::list::ListItem;
-    use crate::table::HighlightSpacing;
+    use crate::list::{ListHighlightSpacing, ListItem};
 
     #[fixture]
     fn single_line_buf() -> Buffer {
@@ -728,7 +727,7 @@ mod tests {
         {
             let list = List::new(["Item 0", "Item 1", "Item 2"])
                 .highlight_symbol(">>")
-                .highlight_spacing(HighlightSpacing::Always);
+                .highlight_spacing(ListHighlightSpacing::Always);
             let mut state = ListState::default();
             let buffer = stateful_widget(list, &mut state, 10, 5);
             let expected = Buffer::with_lines([
@@ -745,7 +744,7 @@ mod tests {
         {
             let list = List::new(["Item 0", "Item 1", "Item 2"])
                 .highlight_symbol(">>")
-                .highlight_spacing(HighlightSpacing::Always);
+                .highlight_spacing(ListHighlightSpacing::Always);
             let mut state = ListState::default();
             state.select(Some(1));
             let buffer = stateful_widget(list, &mut state, 10, 5);
@@ -766,7 +765,7 @@ mod tests {
         {
             let list = List::new(["Item 0", "Item 1", "Item 2"])
                 .highlight_symbol(">>")
-                .highlight_spacing(HighlightSpacing::Never);
+                .highlight_spacing(ListHighlightSpacing::Never);
             let mut state = ListState::default();
             let buffer = stateful_widget(list, &mut state, 10, 5);
             let expected = Buffer::with_lines([
@@ -783,7 +782,7 @@ mod tests {
         {
             let list = List::new(["Item 0", "Item 1", "Item 2"])
                 .highlight_symbol(">>")
-                .highlight_spacing(HighlightSpacing::Never);
+                .highlight_spacing(ListHighlightSpacing::Never);
             let mut state = ListState::default();
             state.select(Some(1));
             let buffer = stateful_widget(list, &mut state, 10, 5);

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -12,7 +12,7 @@ use ratatui_core::text::Text;
 use ratatui_core::widgets::{StatefulWidget, Widget};
 
 pub use self::cell::Cell;
-pub use self::highlight_spacing::HighlightSpacing;
+pub use self::highlight_spacing::TableHighlightSpacing;
 pub use self::row::Row;
 pub use self::state::TableState;
 use crate::block::{Block, BlockExt};
@@ -265,7 +265,7 @@ pub struct Table<'a> {
     highlight_symbol: Text<'a>,
 
     /// Decides when to allocate spacing for the row selection
-    highlight_spacing: HighlightSpacing,
+    highlight_spacing: TableHighlightSpacing,
 
     /// Controls how to distribute extra space among the columns
     flex: Flex,
@@ -285,7 +285,7 @@ impl Default for Table<'_> {
             column_highlight_style: Style::new(),
             cell_highlight_style: Style::new(),
             highlight_symbol: Text::default(),
-            highlight_spacing: HighlightSpacing::default(),
+            highlight_spacing: TableHighlightSpacing::default(),
             flex: Flex::Start,
         }
     }
@@ -664,15 +664,15 @@ impl<'a> Table<'a> {
     /// enabled) and is used to shift the table when a row is selected. This method allows you to
     /// configure when this spacing is allocated.
     ///
-    /// - [`HighlightSpacing::Always`] will always allocate the spacing, regardless of whether a row
-    ///   is selected or not. This means that the table will never change size, regardless of if a
-    ///   row is selected or not.
-    /// - [`HighlightSpacing::WhenSelected`] will only allocate the spacing if a row is selected.
-    ///   This means that the table will shift when a row is selected. This is the default setting
-    ///   for backwards compatibility, but it is recommended to use `HighlightSpacing::Always` for a
-    ///   better user experience.
-    /// - [`HighlightSpacing::Never`] will never allocate the spacing, regardless of whether a row
-    ///   is selected or not. This means that the highlight symbol will never be drawn.
+    /// - [`TableHighlightSpacing::Always`] will always allocate the spacing, regardless of whether
+    ///   a row is selected or not. This means that the table will never change size, regardless of
+    ///   if a row is selected or not.
+    /// - [`TableHighlightSpacing::WhenSelected`] will only allocate the spacing if a row is
+    ///   selected. This means that the table will shift when a row is selected. This is the default
+    ///   setting for backwards compatibility, but it is recommended to use
+    ///   `TableHighlightSpacing::Always` for a better user experience.
+    /// - [`TableHighlightSpacing::Never`] will never allocate the spacing, regardless of whether a
+    ///   row is selected or not. This means that the highlight symbol will never be drawn.
     ///
     /// This is a fluent setter method which must be chained or used as it consumes self
     ///
@@ -680,14 +680,14 @@ impl<'a> Table<'a> {
     ///
     /// ```rust
     /// use ratatui::layout::Constraint;
-    /// use ratatui::widgets::{HighlightSpacing, Row, Table};
+    /// use ratatui::widgets::{Row, Table, TableHighlightSpacing};
     ///
     /// let rows = [Row::new(vec!["Cell1", "Cell2"])];
     /// let widths = [Constraint::Length(5), Constraint::Length(5)];
-    /// let table = Table::new(rows, widths).highlight_spacing(HighlightSpacing::Always);
+    /// let table = Table::new(rows, widths).highlight_spacing(TableHighlightSpacing::Always);
     /// ```
     #[must_use = "method moves the value of self and returns the modified value"]
-    pub const fn highlight_spacing(mut self, value: HighlightSpacing) -> Self {
+    pub const fn highlight_spacing(mut self, value: TableHighlightSpacing) -> Self {
         self.highlight_spacing = value;
         self
     }
@@ -1064,7 +1064,7 @@ mod tests {
         assert_eq!(table.style, Style::default());
         assert_eq!(table.row_highlight_style, Style::default());
         assert_eq!(table.highlight_symbol, Text::default());
-        assert_eq!(table.highlight_spacing, HighlightSpacing::WhenSelected);
+        assert_eq!(table.highlight_spacing, TableHighlightSpacing::WhenSelected);
         assert_eq!(table.flex, Flex::Start);
     }
 
@@ -1080,7 +1080,7 @@ mod tests {
         assert_eq!(table.style, Style::default());
         assert_eq!(table.row_highlight_style, Style::default());
         assert_eq!(table.highlight_symbol, Text::default());
-        assert_eq!(table.highlight_spacing, HighlightSpacing::WhenSelected);
+        assert_eq!(table.highlight_spacing, TableHighlightSpacing::WhenSelected);
         assert_eq!(table.flex, Flex::Start);
     }
 
@@ -1197,8 +1197,8 @@ mod tests {
 
     #[test]
     fn highlight_spacing() {
-        let table = Table::default().highlight_spacing(HighlightSpacing::Always);
-        assert_eq!(table.highlight_spacing, HighlightSpacing::Always);
+        let table = Table::default().highlight_spacing(TableHighlightSpacing::Always);
+        assert_eq!(table.highlight_spacing, TableHighlightSpacing::Always);
     }
 
     #[test]
@@ -1864,7 +1864,7 @@ mod tests {
 
         #[track_caller]
         fn test_table_with_selection<'line, Lines>(
-            highlight_spacing: HighlightSpacing,
+            highlight_spacing: TableHighlightSpacing,
             columns: u16,
             spacing: u16,
             selection: Option<usize>,
@@ -1889,7 +1889,7 @@ mod tests {
         fn excess_area_highlight_symbol_and_column_spacing_allocation() {
             // no highlight_symbol rendered ever
             test_table_with_selection(
-                HighlightSpacing::Never,
+                TableHighlightSpacing::Never,
                 15,   // width
                 0,    // spacing
                 None, // selection
@@ -1919,7 +1919,7 @@ mod tests {
 
             // no highlight_symbol rendered ever
             test_table_with_selection(
-                HighlightSpacing::Never,
+                TableHighlightSpacing::Never,
                 15,      // width
                 0,       // spacing
                 Some(0), // selection
@@ -1932,7 +1932,7 @@ mod tests {
 
             // no highlight_symbol rendered because no selection is made
             test_table_with_selection(
-                HighlightSpacing::WhenSelected,
+                TableHighlightSpacing::WhenSelected,
                 15,   // width
                 0,    // spacing
                 None, // selection
@@ -1944,7 +1944,7 @@ mod tests {
             );
             // highlight_symbol rendered because selection is made
             test_table_with_selection(
-                HighlightSpacing::WhenSelected,
+                TableHighlightSpacing::WhenSelected,
                 15,      // width
                 0,       // spacing
                 Some(0), // selection
@@ -1957,7 +1957,7 @@ mod tests {
 
             // highlight_symbol always rendered even no selection is made
             test_table_with_selection(
-                HighlightSpacing::Always,
+                TableHighlightSpacing::Always,
                 15,   // width
                 0,    // spacing
                 None, // selection
@@ -1970,7 +1970,7 @@ mod tests {
 
             // no highlight_symbol rendered because no selection is made
             test_table_with_selection(
-                HighlightSpacing::Always,
+                TableHighlightSpacing::Always,
                 15,      // width
                 0,       // spacing
                 Some(0), // selection
@@ -1987,7 +1987,7 @@ mod tests {
         fn insufficient_area_highlight_symbol_and_column_spacing_allocation() {
             // column spacing is prioritized over every other constraint
             test_table_with_selection(
-                HighlightSpacing::Never,
+                TableHighlightSpacing::Never,
                 10,   // width
                 1,    // spacing
                 None, // selection
@@ -1998,7 +1998,7 @@ mod tests {
                 ],
             );
             test_table_with_selection(
-                HighlightSpacing::WhenSelected,
+                TableHighlightSpacing::WhenSelected,
                 10,   // width
                 1,    // spacing
                 None, // selection
@@ -2018,7 +2018,7 @@ mod tests {
             // column spacing is prioritized when column widths are calculated and last column here
             // ends up with just 1 wide
             test_table_with_selection(
-                HighlightSpacing::Always,
+                TableHighlightSpacing::Always,
                 10,   // width
                 1,    // spacing
                 None, // selection
@@ -2031,7 +2031,7 @@ mod tests {
 
             // the following are specification tests
             test_table_with_selection(
-                HighlightSpacing::Always,
+                TableHighlightSpacing::Always,
                 9,    // width
                 1,    // spacing
                 None, // selection
@@ -2042,7 +2042,7 @@ mod tests {
                 ],
             );
             test_table_with_selection(
-                HighlightSpacing::Always,
+                TableHighlightSpacing::Always,
                 8,    // width
                 1,    // spacing
                 None, // selection
@@ -2053,7 +2053,7 @@ mod tests {
                 ],
             );
             test_table_with_selection(
-                HighlightSpacing::Always,
+                TableHighlightSpacing::Always,
                 7,    // width
                 1,    // spacing
                 None, // selection
@@ -2066,7 +2066,7 @@ mod tests {
 
             let table = Table::default()
                 .rows(vec![Row::new(vec!["ABCDE", "12345"])])
-                .highlight_spacing(HighlightSpacing::Always)
+                .highlight_spacing(TableHighlightSpacing::Always)
                 .flex(Flex::Legacy)
                 .highlight_symbol(">>>")
                 .column_spacing(1);
@@ -2084,7 +2084,7 @@ mod tests {
 
             let table = Table::default()
                 .rows(vec![Row::new(vec!["ABCDE", "12345"])])
-                .highlight_spacing(HighlightSpacing::Always)
+                .highlight_spacing(TableHighlightSpacing::Always)
                 .flex(Flex::Start)
                 .highlight_symbol(">>>")
                 .column_spacing(1);
@@ -2101,7 +2101,7 @@ mod tests {
             assert_eq!(buf, expected);
 
             test_table_with_selection(
-                HighlightSpacing::Never,
+                TableHighlightSpacing::Never,
                 10,      // width
                 1,       // spacing
                 Some(0), // selection
@@ -2113,7 +2113,7 @@ mod tests {
             );
 
             test_table_with_selection(
-                HighlightSpacing::WhenSelected,
+                TableHighlightSpacing::WhenSelected,
                 10,      // width
                 1,       // spacing
                 Some(0), // selection
@@ -2125,7 +2125,7 @@ mod tests {
             );
 
             test_table_with_selection(
-                HighlightSpacing::Always,
+                TableHighlightSpacing::Always,
                 10,      // width
                 1,       // spacing
                 Some(0), // selection
@@ -2140,7 +2140,7 @@ mod tests {
         #[test]
         fn insufficient_area_highlight_symbol_allocation_with_no_column_spacing() {
             test_table_with_selection(
-                HighlightSpacing::Never,
+                TableHighlightSpacing::Never,
                 10,   // width
                 0,    // spacing
                 None, // selection
@@ -2151,7 +2151,7 @@ mod tests {
                 ],
             );
             test_table_with_selection(
-                HighlightSpacing::WhenSelected,
+                TableHighlightSpacing::WhenSelected,
                 10,   // width
                 0,    // spacing
                 None, // selection
@@ -2166,7 +2166,7 @@ mod tests {
             // this is because highlight_symbol column is separated _before_ any of the constraint
             // widths are calculated
             test_table_with_selection(
-                HighlightSpacing::Always,
+                TableHighlightSpacing::Always,
                 10,   // width
                 0,    // spacing
                 None, // selection
@@ -2177,7 +2177,7 @@ mod tests {
                 ],
             );
             test_table_with_selection(
-                HighlightSpacing::Never,
+                TableHighlightSpacing::Never,
                 10,      // width
                 0,       // spacing
                 Some(0), // selection
@@ -2188,7 +2188,7 @@ mod tests {
                 ],
             );
             test_table_with_selection(
-                HighlightSpacing::WhenSelected,
+                TableHighlightSpacing::WhenSelected,
                 10,      // width
                 0,       // spacing
                 Some(0), // selection
@@ -2199,7 +2199,7 @@ mod tests {
                 ],
             );
             test_table_with_selection(
-                HighlightSpacing::Always,
+                TableHighlightSpacing::Always,
                 10,      // width
                 0,       // spacing
                 Some(0), // selection

--- a/ratatui/src/widgets.rs
+++ b/ratatui/src/widgets.rs
@@ -669,7 +669,7 @@ pub use ratatui_widgets::canvas;
 pub use ratatui_widgets::chart::{Axis, Chart, Dataset, GraphType, LegendPosition};
 pub use ratatui_widgets::clear::Clear;
 pub use ratatui_widgets::gauge::{Gauge, LineGauge};
-pub use ratatui_widgets::list::{List, ListDirection, ListItem, ListState};
+pub use ratatui_widgets::list::{List, ListDirection, ListHighlightSpacing, ListItem, ListState};
 pub use ratatui_widgets::logo::{RatatuiLogo, Size as RatatuiLogoSize};
 pub use ratatui_widgets::mascot::{MascotEyeColor, RatatuiMascot};
 pub use ratatui_widgets::paragraph::{Paragraph, Wrap};
@@ -677,7 +677,7 @@ pub use ratatui_widgets::scrollbar::{
     ScrollDirection, Scrollbar, ScrollbarOrientation, ScrollbarState,
 };
 pub use ratatui_widgets::sparkline::{RenderDirection, Sparkline, SparklineBar};
-pub use ratatui_widgets::table::{Cell, HighlightSpacing, Row, Table, TableState};
+pub use ratatui_widgets::table::{Cell, Row, Table, TableHighlightSpacing, TableState};
 pub use ratatui_widgets::tabs::Tabs;
 #[instability::unstable(feature = "widget-ref")]
 pub use {stateful_widget_ref::StatefulWidgetRef, widget_ref::WidgetRef};

--- a/ratatui/tests/widgets_list.rs
+++ b/ratatui/tests/widgets_list.rs
@@ -3,7 +3,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::text::Line;
-use ratatui::widgets::{Block, Borders, HighlightSpacing, List, ListItem, ListState};
+use ratatui::widgets::{Block, Borders, List, ListHighlightSpacing, ListItem, ListState};
 use ratatui::{Terminal, symbols};
 use rstest::rstest;
 
@@ -281,7 +281,7 @@ fn widget_list_should_not_ignore_empty_string_items() {
 }
 
 #[rstest]
-#[case::none_when_selected(None, HighlightSpacing::WhenSelected, [
+#[case::none_when_selected(None, ListHighlightSpacing::WhenSelected, [
     "┌─────────────┐",
     "│Item 1       │",
     "│Item 1a      │",
@@ -291,7 +291,7 @@ fn widget_list_should_not_ignore_empty_string_items() {
     "│Item 3c      │",
     "└─────────────┘",
 ])]
-#[case::none_always(None, HighlightSpacing::Always, [
+#[case::none_always(None, ListHighlightSpacing::Always, [
     "┌─────────────┐",
     "│   Item 1    │",
     "│   Item 1a   │",
@@ -301,7 +301,7 @@ fn widget_list_should_not_ignore_empty_string_items() {
     "│   Item 3c   │",
     "└─────────────┘",
 ])]
-#[case::none_never(None, HighlightSpacing::Never, [
+#[case::none_never(None, ListHighlightSpacing::Never, [
     "┌─────────────┐",
     "│Item 1       │",
     "│Item 1a      │",
@@ -311,7 +311,7 @@ fn widget_list_should_not_ignore_empty_string_items() {
     "│Item 3c      │",
     "└─────────────┘",
 ])]
-#[case::first_when_selected(Some(0), HighlightSpacing::WhenSelected, [
+#[case::first_when_selected(Some(0), ListHighlightSpacing::WhenSelected, [
     "┌─────────────┐",
     "│>> Item 1    │",
     "│   Item 1a   │",
@@ -321,7 +321,7 @@ fn widget_list_should_not_ignore_empty_string_items() {
     "│   Item 3c   │",
     "└─────────────┘",
 ])]
-#[case::first_always(Some(0), HighlightSpacing::Always, [
+#[case::first_always(Some(0), ListHighlightSpacing::Always, [
     "┌─────────────┐",
     "│>> Item 1    │",
     "│   Item 1a   │",
@@ -331,7 +331,7 @@ fn widget_list_should_not_ignore_empty_string_items() {
     "│   Item 3c   │",
     "└─────────────┘",
 ])]
-#[case::first_never(Some(0), HighlightSpacing::Never, [
+#[case::first_never(Some(0), ListHighlightSpacing::Never, [
     "┌─────────────┐",
     "│Item 1       │",
     "│Item 1a      │",
@@ -343,7 +343,7 @@ fn widget_list_should_not_ignore_empty_string_items() {
 ])]
 fn widgets_list_enable_always_highlight_spacing<'line, Lines>(
     #[case] selected: Option<usize>,
-    #[case] space: HighlightSpacing,
+    #[case] space: ListHighlightSpacing,
     #[case] expected: Lines,
 ) where
     Lines: IntoIterator,

--- a/ratatui/tests/widgets_table.rs
+++ b/ratatui/tests/widgets_table.rs
@@ -6,7 +6,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Constraint;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Cell, HighlightSpacing, Row, Table, TableState};
+use ratatui::widgets::{Block, Borders, Cell, Row, Table, TableHighlightSpacing, TableState};
 use rstest::rstest;
 
 #[rstest]
@@ -526,7 +526,7 @@ fn widgets_table_can_have_rows_with_multi_lines<'line, Lines>(
 }
 
 #[rstest]
-#[case::none_when_selected(None, HighlightSpacing::WhenSelected, [
+#[case::none_when_selected(None, TableHighlightSpacing::WhenSelected, [
     "┌────────────────────────────┐",
     "│Head1 Head2 Head3           │",
     "│                            │",
@@ -537,7 +537,7 @@ fn widgets_table_can_have_rows_with_multi_lines<'line, Lines>(
     "└────────────────────────────┘",
 ])]
 #[case::none_always(
-    None, HighlightSpacing::Always, [
+    None, TableHighlightSpacing::Always, [
     "┌────────────────────────────┐",
     "│   Head1 Head2 Head3        │",
     "│                            │",
@@ -547,7 +547,7 @@ fn widgets_table_can_have_rows_with_multi_lines<'line, Lines>(
     "│   Row31 Row32 Row33        │",
     "└────────────────────────────┘",
 ])]
-#[case::none_never(None, HighlightSpacing::Never, [
+#[case::none_never(None, TableHighlightSpacing::Never, [
     "┌────────────────────────────┐",
     "│Head1 Head2 Head3           │",
     "│                            │",
@@ -557,7 +557,7 @@ fn widgets_table_can_have_rows_with_multi_lines<'line, Lines>(
     "│Row31 Row32 Row33           │",
     "└────────────────────────────┘",
 ])]
-#[case::first_when_selected(Some(0), HighlightSpacing::WhenSelected, [
+#[case::first_when_selected(Some(0), TableHighlightSpacing::WhenSelected, [
     "┌────────────────────────────┐",
     "│   Head1 Head2 Head3        │",
     "│                            │",
@@ -567,7 +567,7 @@ fn widgets_table_can_have_rows_with_multi_lines<'line, Lines>(
     "│   Row31 Row32 Row33        │",
     "└────────────────────────────┘",
 ])]
-#[case::first_always(Some(0), HighlightSpacing::Always, [
+#[case::first_always(Some(0), TableHighlightSpacing::Always, [
     "┌────────────────────────────┐",
     "│   Head1 Head2 Head3        │",
     "│                            │",
@@ -577,7 +577,7 @@ fn widgets_table_can_have_rows_with_multi_lines<'line, Lines>(
     "│   Row31 Row32 Row33        │",
     "└────────────────────────────┘",
 ])]
-#[case::first_never(Some(0), HighlightSpacing::Never, [
+#[case::first_never(Some(0), TableHighlightSpacing::Never, [
     "┌────────────────────────────┐",
     "│Head1 Head2 Head3           │",
     "│                            │",
@@ -589,7 +589,7 @@ fn widgets_table_can_have_rows_with_multi_lines<'line, Lines>(
 ])]
 fn widgets_table_enable_always_highlight_spacing<'line, Lines>(
     #[case] selected: Option<usize>,
-    #[case] space: HighlightSpacing,
+    #[case] space: TableHighlightSpacing,
     #[case] expected: Lines,
 ) where
     Lines: IntoIterator,


### PR DESCRIPTION
This commit separates the `HighlightSpacing` enum into two different enums: `ListHighlightSpacing` and `TableHighlightSpacing`, each on their own separate module and should close #1767.

This is because, as stated by #1767, until now, both widgets `List` and `Table` used the `HighlightSpacing` under `crate::table::HighlightSpacing`. 

This is a BREAKING CHANGE, as it also changes the re-exports under `ratatui::widgets::HighlightSpacing` to `ratatui::widgets::ListHighlightSpacing` and `ratatui::widgets::TableHighlightSpacing`.