### PR TITLE
feat(core): Add color-aware buffer view for TestBackend

### DIFF
--- a/ratatui-core/src/backend/test.rs
+++ b/ratatui-core/src/backend/test.rs
@@ -11,6 +11,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::backend::{Backend, ClearType, WindowSize};
 use crate::buffer::{Buffer, Cell};
 use crate::layout::{Position, Rect, Size};
+use crate::style::{Color, Modifier};
 
 /// A [`Backend`] implementation used for integration testing that renders to an memory buffer.
 ///
@@ -67,6 +68,128 @@ fn buffer_view(buffer: &Buffer) -> String {
     view
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct StyleSnapshot {
+    fg: Color,
+    bg: Color,
+    modifier: Modifier,
+}
+
+impl Default for StyleSnapshot {
+    fn default() -> Self {
+        Self {
+            fg: Color::Reset,
+            bg: Color::Reset,
+            modifier: Modifier::empty(),
+        }
+    }
+}
+
+impl StyleSnapshot {
+    const fn from_cell(cell: &Cell) -> Self {
+        Self {
+            fg: cell.fg,
+            bg: cell.bg,
+            modifier: cell.modifier,
+        }
+    }
+
+    fn is_default(&self) -> bool {
+        self.fg == Color::Reset && self.bg == Color::Reset && self.modifier.is_empty()
+    }
+}
+
+/// Append a style-change tag like `{fg=Red,bg=Black,mod=BOLD}` or `{/}` to `out`.
+fn append_style_tag(out: &mut String, style: &StyleSnapshot) {
+    // Default style: emit a simple closing marker `{/}`
+    if style.is_default() {
+        out.push_str("{/}");
+        return;
+    }
+
+    out.push('{');
+    let mut first = true;
+
+    if style.fg != Color::Reset {
+        write!(out, "fg={:?}", style.fg).unwrap();
+        first = false;
+    }
+
+    if style.bg != Color::Reset {
+        if !first {
+            out.push(',');
+        }
+        write!(out, "bg={:?}", style.bg).unwrap();
+        first = false;
+    }
+
+    if !style.modifier.is_empty() {
+        if !first {
+            out.push(',');
+        }
+        write!(out, "mod={:?}", style.modifier).unwrap();
+    }
+
+    out.push('}');
+}
+
+/// Like `buffer_view`, but includes serialized color / style information.
+///
+/// Example row:
+///   "{fg=Red}Hello{/} world"
+fn buffer_view_colored(buffer: &Buffer) -> String {
+    // Heuristic capacity: a bit more than plain buffer_view, since we add tags.
+    let mut view =
+        String::with_capacity(buffer.content.len() * 2 + buffer.area.height as usize * 8);
+
+    for cells in buffer.content.chunks(buffer.area.width as usize) {
+        let mut overwritten = vec![];
+        let mut skip: usize = 0;
+        let mut current_style = StyleSnapshot::default();
+
+        view.push('"');
+
+        for (x, c) in cells.iter().enumerate() {
+            if skip == 0 {
+                let style = StyleSnapshot::from_cell(c);
+
+                // Emit a style tag only when the style changes from the previous cell.
+                if style != current_style {
+                    append_style_tag(&mut view, &style);
+                    current_style = style;
+                }
+
+                // Then emit the actual symbol with whatever style is currently "open".
+                view.push_str(c.symbol());
+            } else {
+                // This cell is hidden by a previous multi-width grapheme.
+                overwritten.push((x, c.symbol()));
+            }
+
+            // Same multi-width handling as in `buffer_view`.
+            skip = core::cmp::max(skip, c.symbol().width()).saturating_sub(1);
+        }
+
+        if !current_style.is_default() {
+            append_style_tag(&mut view, &StyleSnapshot::default());
+        }
+
+        view.push('"');
+
+        if !overwritten.is_empty() {
+            write!(
+                &mut view,
+                " Hidden by multi-width symbols: {overwritten:?}"
+            )
+            .unwrap();
+        }
+
+        view.push('\n');
+    }
+
+    view
+}
+
 impl TestBackend {
     /// Creates a new `TestBackend` with the specified width and height.
     pub fn new(width: u16, height: u16) -> Self {
@@ -103,6 +226,14 @@ impl TestBackend {
     /// Returns a reference to the internal buffer of the `TestBackend`.
     pub const fn buffer(&self) -> &Buffer {
         &self.buffer
+    }
+
+    /// Returns a string representation of the buffer including color / modifiers.
+    ///
+    /// This is intended for use in tests where you want to assert on styling,
+    /// not just on the rendered text.
+    pub fn buffer_view_colored(&self) -> String {
+        buffer_view_colored(&self.buffer)
     }
 
     /// Returns a reference to the internal scrollback buffer of the `TestBackend`.
@@ -459,6 +590,8 @@ mod tests {
 
     use super::*;
 
+    use crate::style::{Color, Modifier, Style};
+
     #[test]
     fn new() {
         assert_eq!(
@@ -488,6 +621,35 @@ mod tests {
 "#,
             )
         );
+    }
+
+    #[test]
+    fn buffer_view_colored_matches_plain_view_for_unstyled_buffer() {
+        let buffer = Buffer::with_lines(["abcd", "efgh"]);
+        let plain = buffer_view(&buffer);
+        let colored = buffer_view_colored(&buffer);
+        assert_eq!(colored, plain);
+    }
+
+    #[test]
+    fn buffer_view_colored_inserts_tags_on_style_change() {
+        let mut buffer = Buffer::with_lines(["abc"]);
+        let red_style = Style::default().fg(Color::Red);
+        buffer.set_string(1, 0, "b", red_style);
+        let colored = buffer_view_colored(&buffer);
+        assert_eq!(colored, "\"a{fg=Red}b{/}c\"\n");
+    }
+
+    #[test]
+    fn buffer_view_colored_includes_background_and_modifiers() {
+        let mut buffer = Buffer::with_lines(["x"]);
+        let style = Style::default()
+            .fg(Color::Yellow)
+            .bg(Color::Blue)
+            .add_modifier(Modifier::BOLD);
+        buffer.set_string(0, 0, "x", style);
+        let colored = buffer_view_colored(&buffer);
+        assert_eq!(colored, "\"{fg=Yellow,bg=Blue,mod=BOLD}x{/}\"\n");
     }
 
     #[test]

--- a/ratatui-core/src/backend/test.rs
+++ b/ratatui-core/src/backend/test.rs
@@ -657,6 +657,7 @@ mod tests {
         assert_eq!(colored, plain);
     }
 
+    #[test]
     fn testbackend_buffer_view_colored_delegates_to_helper() {
         let mut backend = TestBackend::new(3, 1);
         let red_style = Style::default().fg(Color::Red);

--- a/ratatui-core/src/buffer/buffer.rs
+++ b/ratatui-core/src/buffer/buffer.rs
@@ -679,8 +679,8 @@ mod tests {
     use alloc::format;
     //use alloc::string::ToString;
     use core::iter;
-    // use std::{dbg, println};
 
+    // use std::{dbg, println};
     use itertools::Itertools;
     use rstest::{fixture, rstest};
 
@@ -1290,7 +1290,6 @@ mod tests {
     // This should render as a single grapheme with width 2.
     #[case::keyboard_emoji("⌨️", "⌨️xxxxx")]
     fn renders_emoji(#[case] input: &str, #[case] expected: &str) {
-
         let mut buffer = Buffer::filled(Rect::new(0, 0, 7, 1), Cell::new("x"));
         buffer.set_string(0, 0, input, Style::new());
 

--- a/ratatui-core/src/buffer/buffer.rs
+++ b/ratatui-core/src/buffer/buffer.rs
@@ -677,9 +677,9 @@ impl fmt::Debug for Buffer {
 #[cfg(test)]
 mod tests {
     use alloc::format;
-    use alloc::string::ToString;
+    //use alloc::string::ToString;
     use core::iter;
-    use std::{dbg, println};
+    // use std::{dbg, println};
 
     use itertools::Itertools;
     use rstest::{fixture, rstest};
@@ -691,7 +691,7 @@ mod tests {
     fn debug_empty_buffer() {
         let buffer = Buffer::empty(Rect::ZERO);
         let result = format!("{buffer:?}");
-        println!("{result}");
+        //println!("{result}");
         let expected = "Buffer {\n    area: Rect { x: 0, y: 0, width: 0, height: 0 }\n}";
         assert_eq!(result, expected);
     }
@@ -701,7 +701,7 @@ mod tests {
     fn debug_grapheme_override() {
         let buffer = Buffer::with_lines(["a🦀b"]);
         let result = format!("{buffer:?}");
-        println!("{result}");
+        //println!("{result}");
         let expected = indoc::indoc!(
             r#"
             Buffer {
@@ -731,7 +731,7 @@ mod tests {
                 .add_modifier(Modifier::BOLD),
         );
         let result = format!("{buffer:?}");
-        println!("{result}");
+        //println!("{result}");
         #[cfg(feature = "underline-color")]
         let expected = indoc::indoc!(
             r#"
@@ -1290,27 +1290,6 @@ mod tests {
     // This should render as a single grapheme with width 2.
     #[case::keyboard_emoji("⌨️", "⌨️xxxxx")]
     fn renders_emoji(#[case] input: &str, #[case] expected: &str) {
-        use unicode_width::UnicodeWidthChar;
-
-        dbg!(input);
-        dbg!(input.len());
-        dbg!(
-            input
-                .graphemes(true)
-                .map(|symbol| (symbol, symbol.escape_unicode().to_string(), symbol.width()))
-                .collect::<Vec<_>>()
-        );
-        dbg!(
-            input
-                .chars()
-                .map(|char| (
-                    char,
-                    char.escape_unicode().to_string(),
-                    char.width(),
-                    char.is_control()
-                ))
-                .collect::<Vec<_>>()
-        );
 
         let mut buffer = Buffer::filled(Rect::new(0, 0, 7, 1), Cell::new("x"));
         buffer.set_string(0, 0, input, Style::new());

--- a/ratatui-core/src/text/line.rs
+++ b/ratatui-core/src/text/line.rs
@@ -848,7 +848,7 @@ impl Styled for Line<'_> {
 mod tests {
     use alloc::format;
     use core::iter;
-    use std::dbg;
+    //use std::dbg;
 
     use rstest::{fixture, rstest};
 
@@ -1503,7 +1503,7 @@ mod tests {
 
             let line = Line::from(vec![Span::raw(part); factor]).alignment(alignment);
 
-            dbg!(line.width());
+            //dbg!(line.width());
             assert!(line.width() >= min_width);
 
             let mut buf = Buffer::empty(Rect::new(0, 0, 32, 1));
@@ -1527,7 +1527,7 @@ mod tests {
 
             let line = Line::from(vec![Span::raw(part.repeat(factor))]).alignment(alignment);
 
-            dbg!(line.width());
+            //dbg!(line.width());
             assert!(line.width() >= min_width);
 
             let mut buf = Buffer::empty(Rect::new(0, 0, 32, 1));

--- a/ratatui-core/src/text/line.rs
+++ b/ratatui-core/src/text/line.rs
@@ -848,8 +848,8 @@ impl Styled for Line<'_> {
 mod tests {
     use alloc::format;
     use core::iter;
-    //use std::dbg;
 
+    //use std::dbg;
     use rstest::{fixture, rstest};
 
     use super::*;


### PR DESCRIPTION
This PR adds a color-aware buffer view for `TestBackend` so tests and snapshot recipes can assert styles, not just text.

- Add `buffer_view_colored(&Buffer) -> String` helper in `ratatui-core/src/backend/test.rs`.
- Add `TestBackend::buffer_view_colored()` to expose the colored view.
- Serialize styles into inline tags such as `{fg=Yellow,bg=Blue,mod=BOLD}x{/}`.
- Keep the existing `buffer_view` / `Display` output unchanged.
- Add unit tests for unstyled, styled, and modifier cases.

Closes #1402.