### PR TITLE
perf(ratatui-core): add `buffer::diff` benchmarks to get a performance baseline

### DIFF
--- a/ratatui/benches/main/buffer.rs
+++ b/ratatui/benches/main/buffer.rs
@@ -2,7 +2,7 @@ use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion};
 use ratatui::buffer::{Buffer, Cell};
-use ratatui::layout::Rect;
+use ratatui::layout::{Rect, Size};
 use ratatui::style::Style;
 use ratatui::text::Line;
 
@@ -18,13 +18,20 @@ criterion::criterion_group!(
     diff_emoji
 );
 
-const fn rect(size: u16) -> Rect {
-    Rect::new(0, 0, size, size)
+const fn rect(size: Size) -> Rect {
+    Rect {
+        x: 0,
+        y: 0,
+        width: size.width,
+        height: size.height,
+    }
 }
+
+const SIZES: [Size; 2] = [Size::new(200, 50), Size::new(1000, 250)];
 
 fn empty(c: &mut Criterion) {
     let mut group = c.benchmark_group("buffer/empty");
-    for size in [16, 64, 255] {
+    for size in SIZES {
         let area = rect(size);
         group.bench_with_input(BenchmarkId::from_parameter(size), &area, |b, &area| {
             b.iter(|| {
@@ -39,7 +46,7 @@ fn empty(c: &mut Criterion) {
 /// and to catch any potential performance regressions.
 fn filled(c: &mut Criterion) {
     let mut group = c.benchmark_group("buffer/filled");
-    for size in [16, 64, 255] {
+    for size in SIZES {
         let area = rect(size);
         let cell = Cell::new("AAAA"); // simulate a multi-byte character
         group.bench_with_input(
@@ -57,7 +64,7 @@ fn filled(c: &mut Criterion) {
 
 fn with_lines(c: &mut Criterion) {
     let mut group = c.benchmark_group("buffer/with_lines");
-    for size in [16, 64, 255] {
+    for size in SIZES {
         let word_count = 50;
         let lines = fakeit::words::sentence(word_count);
         let lines = lines.lines().map(Line::from);
@@ -72,7 +79,7 @@ fn with_lines(c: &mut Criterion) {
 
 fn diff_no_change(c: &mut Criterion) {
     let mut group = c.benchmark_group("buffer/diff_no_change");
-    for size in [16, 64, 255] {
+    for size in SIZES {
         let area = rect(size);
         let buffer = Buffer::filled(area, Cell::new("x"));
         group.bench_with_input(BenchmarkId::from_parameter(size), &buffer, |b, buffer| {
@@ -88,7 +95,7 @@ fn diff_no_change(c: &mut Criterion) {
 /// This tests maximum update cost with every cell needing an update
 fn diff_full_change(c: &mut Criterion) {
     let mut group = c.benchmark_group("buffer/diff_full_change");
-    for size in [16, 64, 255] {
+    for size in SIZES {
         let area = rect(size);
         let prev = Buffer::filled(area, Cell::new("a"));
         let next = Buffer::filled(area, Cell::new("b"));
@@ -109,12 +116,12 @@ fn diff_full_change(c: &mut Criterion) {
 /// This simulates typical incremental updates in a TUI
 fn diff_partial_change(c: &mut Criterion) {
     let mut group = c.benchmark_group("buffer/diff_partial_change");
-    for size in [16, 64, 255] {
+    for size in SIZES {
         let area = rect(size);
         let prev = Buffer::filled(area, Cell::new("a"));
         let mut next = Buffer::filled(area, Cell::new("a"));
 
-        let total_cells = (size * size) as usize;
+        let total_cells = (size.width as usize) * (size.height as usize);
         for i in (0..total_cells).step_by(10) {
             if i < next.content.len() {
                 next.content[i].set_symbol("b");
@@ -137,16 +144,16 @@ fn diff_partial_change(c: &mut Criterion) {
 
 fn diff_multi_width(c: &mut Criterion) {
     let mut group = c.benchmark_group("buffer/diff_multi_width");
-    for size in [16, 64, 255] {
+    for size in SIZES {
         let area = rect(size);
-        let prev = Buffer::with_lines(vec!["a".repeat(size as usize); size as usize]);
+        let prev = Buffer::with_lines(vec!["a".repeat(size.width as usize); size.height as usize]);
         let mut next = Buffer::filled(area, Cell::new(" "));
 
-        for y in 0..size {
+        for y in 0..size.height {
             next.set_string(
                 0,
                 y,
-                "日本語中文한국어".repeat(size as usize / 6),
+                "日本語中文한국어".repeat(size.width as usize / 6),
                 Style::default(),
             );
         }
@@ -168,13 +175,18 @@ fn diff_multi_width(c: &mut Criterion) {
 /// Tests the emoji-specific VS16 clearing path for complex emoji sequences
 fn diff_emoji(c: &mut Criterion) {
     let mut group = c.benchmark_group("buffer/diff_emoji");
-    for size in [16, 64, 255] {
+    for size in SIZES {
         let area = rect(size);
         let prev = Buffer::filled(area, Cell::new("a"));
         let mut next = Buffer::filled(area, Cell::new(" "));
 
-        for y in 0..size {
-            next.set_string(0, y, "⌨️👁️‍🗨️🐻‍❄️".repeat(size as usize / 6), Style::default());
+        for y in 0..size.height {
+            next.set_string(
+                0,
+                y,
+                "⌨️👁️‍🗨️🐻‍❄️".repeat(size.width as usize / 6),
+                Style::default(),
+            );
         }
 
         group.bench_with_input(

--- a/ratatui/benches/main/buffer.rs
+++ b/ratatui/benches/main/buffer.rs
@@ -3,9 +3,20 @@ use std::hint::black_box;
 use criterion::{BenchmarkId, Criterion};
 use ratatui::buffer::{Buffer, Cell};
 use ratatui::layout::Rect;
+use ratatui::style::Style;
 use ratatui::text::Line;
 
-criterion::criterion_group!(benches, empty, filled, with_lines);
+criterion::criterion_group!(
+    benches,
+    empty,
+    filled,
+    with_lines,
+    diff_no_change,
+    diff_full_change,
+    diff_partial_change,
+    diff_multi_width,
+    diff_emoji
+);
 
 const fn rect(size: u16) -> Rect {
     Rect::new(0, 0, size, size)
@@ -55,6 +66,127 @@ fn with_lines(c: &mut Criterion) {
                 let _buffer = Buffer::with_lines(black_box(lines.clone()));
             });
         });
+    }
+    group.finish();
+}
+
+fn diff_no_change(c: &mut Criterion) {
+    let mut group = c.benchmark_group("buffer/diff_no_change");
+    for size in [16, 64, 255] {
+        let area = rect(size);
+        let buffer = Buffer::filled(area, Cell::new("x"));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &buffer, |b, buffer| {
+            b.iter(|| {
+                let diff = black_box(buffer).diff(black_box(buffer));
+                black_box(diff);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// This tests maximum update cost with every cell needing an update
+fn diff_full_change(c: &mut Criterion) {
+    let mut group = c.benchmark_group("buffer/diff_full_change");
+    for size in [16, 64, 255] {
+        let area = rect(size);
+        let prev = Buffer::filled(area, Cell::new("a"));
+        let next = Buffer::filled(area, Cell::new("b"));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &(prev, next),
+            |b, (prev, next)| {
+                b.iter(|| {
+                    let diff = black_box(prev).diff(black_box(next));
+                    black_box(diff);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// This simulates typical incremental updates in a TUI
+fn diff_partial_change(c: &mut Criterion) {
+    let mut group = c.benchmark_group("buffer/diff_partial_change");
+    for size in [16, 64, 255] {
+        let area = rect(size);
+        let prev = Buffer::filled(area, Cell::new("a"));
+        let mut next = Buffer::filled(area, Cell::new("a"));
+
+        let total_cells = (size * size) as usize;
+        for i in (0..total_cells).step_by(10) {
+            if i < next.content.len() {
+                next.content[i].set_symbol("b");
+            }
+        }
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &(prev, next),
+            |b, (prev, next)| {
+                b.iter(|| {
+                    let diff = black_box(prev).diff(black_box(next));
+                    black_box(diff);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn diff_multi_width(c: &mut Criterion) {
+    let mut group = c.benchmark_group("buffer/diff_multi_width");
+    for size in [16, 64, 255] {
+        let area = rect(size);
+        let prev = Buffer::with_lines(vec!["a".repeat(size as usize); size as usize]);
+        let mut next = Buffer::filled(area, Cell::new(" "));
+
+        for y in 0..size {
+            next.set_string(
+                0,
+                y,
+                "日本語中文한국어".repeat(size as usize / 6),
+                Style::default(),
+            );
+        }
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &(prev, next),
+            |b, (prev, next)| {
+                b.iter(|| {
+                    let diff = black_box(prev).diff(black_box(next));
+                    black_box(diff);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Tests the emoji-specific VS16 clearing path for complex emoji sequences
+fn diff_emoji(c: &mut Criterion) {
+    let mut group = c.benchmark_group("buffer/diff_emoji");
+    for size in [16, 64, 255] {
+        let area = rect(size);
+        let prev = Buffer::filled(area, Cell::new("a"));
+        let mut next = Buffer::filled(area, Cell::new(" "));
+
+        for y in 0..size {
+            next.set_string(0, y, "⌨️👁️‍🗨️🐻‍❄️".repeat(size as usize / 6), Style::default());
+        }
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &(prev, next),
+            |b, (prev, next)| {
+                b.iter(|| {
+                    let diff = black_box(prev).diff(black_box(next));
+                    black_box(diff);
+                });
+            },
+        );
     }
     group.finish();
 }


### PR DESCRIPTION
I've been taking a look at the buffer diff implementation while investigating potential performance improvements for [tv](https://github.com/alexpasmantier/television).

The `buffer::diff` function is used by ratatui to compute the minimal amount of cells it needs to update to render the new frame which aims to minimizes terminal IO while flushing the buffer.

This PR adds benchmarks for that method for various typical cases:
- no changes between current and new buffer
- full change (every cell changed)
- partial change (10%, which I figured is an ok estimate of real world behavior)
- special cases (multi-width characters, emojis, which exercise specific paths of the code)

I'll be opening other PR(s) on the subject if this one makes it through.

<details>
<summary>benchmark baseline</summary>

```
buffer/diff_no_change/16
                        time:   [2.3110 µs 2.3139 µs 2.3170 µs]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
buffer/diff_no_change/64
                        time:   [36.982 µs 37.062 µs 37.158 µs]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
buffer/diff_no_change/255
                        time:   [587.66 µs 588.53 µs 589.45 µs]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe

buffer/diff_full_change/16
                        time:   [3.2975 µs 3.3037 µs 3.3102 µs]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
buffer/diff_full_change/64
                        time:   [49.387 µs 49.492 µs 49.592 µs]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
buffer/diff_full_change/255
                        time:   [782.01 µs 783.64 µs 785.44 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

buffer/diff_partial_change/16
                        time:   [2.7496 µs 2.7523 µs 2.7549 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
buffer/diff_partial_change/64
                        time:   [43.037 µs 43.113 µs 43.188 µs]
buffer/diff_partial_change/255
                        time:   [679.42 µs 680.53 µs 681.73 µs]
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

buffer/diff_multi_width/16
                        time:   [3.0544 µs 3.0596 µs 3.0652 µs]
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  1 (1.00%) high severe
buffer/diff_multi_width/64
                        time:   [45.483 µs 45.564 µs 45.655 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
buffer/diff_multi_width/255
                        time:   [727.50 µs 728.36 µs 729.42 µs]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

buffer/diff_emoji/16    time:   [5.4288 µs 5.4377 µs 5.4479 µs]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
buffer/diff_emoji/64    time:   [89.526 µs 89.655 µs 89.839 µs]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
Benchmarking buffer/diff_emoji/255: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.3s, enable flat sampling, or reduce sample count to 50.
buffer/diff_emoji/255   time:   [1.4329 ms 1.4341 ms 1.4354 ms]
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe

```

</details>