### PR TITLE
feat(table): add support for configuring borders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           tool: taplo-cli
       - run: cargo xtask format --check
+        shell: bash
 
   # Check for typos in the codebase.
   # See <https://github.com/crate-ci/typos/>
@@ -109,6 +110,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - run: cargo xtask clippy
+        shell: bash
         env:
           RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
 
@@ -144,6 +146,7 @@ jobs:
           tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - run: cargo xtask coverage
+        shell: bash
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -170,6 +173,7 @@ jobs:
           tool: cargo-hack
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - run: cargo xtask check --all-features
+        shell: bash
         env:
           RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
 
@@ -203,11 +207,15 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
+      - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # master
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - uses: taiki-e/install-action@0e76c5c569f13f7eb21e8e5b26fe710062b57b62 # v2
         with:
           tool: cargo-rdme
       - run: cargo xtask readme --check
+        shell: bash
 
   # Run cargo rustdoc with the same options that would be used by docs.rs, taking into account the
   # package.metadata.docs.rs configured in Cargo.toml. https://github.com/dtolnay/cargo-docs-rs
@@ -231,6 +239,7 @@ jobs:
           tool: cargo-hack
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - run: cargo xtask docs
+        shell: bash
 
   # Run cargo test on the documentation of the crate. This will catch any code examples that don't
   # compile, or any other issues in the documentation.
@@ -249,6 +258,7 @@ jobs:
           tool: cargo-hack
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - run: cargo xtask test-docs
+        shell: bash
 
   # Run cargo test on the libraries of the crate.
   test-libs:
@@ -264,12 +274,13 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
       - uses: taiki-e/install-action@0e76c5c569f13f7eb21e8e5b26fe710062b57b62 # v2
         with:
           tool: cargo-hack
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - run: cargo xtask test-libs
+        shell: bash
 
   # Run cargo test on all the backends.
   test-backends:
@@ -293,3 +304,4 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - run: cargo xtask test-backend ${{ matrix.backend }}
+        shell: bash

--- a/ratatui-widgets/examples/table-borders.rs
+++ b/ratatui-widgets/examples/table-borders.rs
@@ -8,12 +8,10 @@
 
 use color_eyre::Result;
 use crossterm::event::{self, KeyCode};
-use ratatui::{
-    Frame,
-    layout::{Constraint, Layout},
-    style::{Modifier, Style},
-    widgets::{Block, Cell, Row, Table, TableBorders, TableState},
-};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout};
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Block, Cell, Row, Table, TableBorders, TableState};
 
 fn main() -> Result<()> {
     color_eyre::install()?;

--- a/ratatui-widgets/examples/table-borders.rs
+++ b/ratatui-widgets/examples/table-borders.rs
@@ -1,0 +1,90 @@
+//! # [Ratatui] `Table` borders example
+//!
+//! The latest version of this example is available in the [widget examples] folder in the
+//! repository.
+//!
+//! [Ratatui]: https://github.com/ratatui/ratatui
+//! [widget examples]: https://github.com/ratatui/ratatui/blob/main/ratatui-widgets/examples
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::{
+    layout::{Constraint, Layout},
+    style::{Modifier, Style, Stylize},
+    widgets::{Block, Cell, Row, Table, TableBorders, TableState},
+    Frame,
+};
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut state = TableState::default();
+    state.select_first();
+
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|f| render(f, &mut state))?;
+
+            if let Some(key) = event::read()?.as_key_press_event() {
+                match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                    KeyCode::Down | KeyCode::Char('j') => state.select_next(),
+                    KeyCode::Up | KeyCode::Char('k') => state.select_previous(),
+                    _ => {}
+                }
+            }
+        }
+    })
+}
+
+fn render(f: &mut Frame, state: &mut TableState) {
+    let area = f.area();
+    let chunks = Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(area);
+
+    let items = (0..20)
+        .map(|i| {
+            vec![
+                format!("Row{} Col1", i),
+                format!("Row{} Col2", i),
+                format!("Row{} Col3", i),
+            ]
+        })
+        .collect::<Vec<_>>();
+
+    let rows = items.iter().map(|item| Row::new(item.iter().map(|c| Cell::from(c.as_str()))));
+
+    // Left Table: ALL borders, row_spacing 1, column_spacing 1
+    let table1 = Table::new(
+        rows.clone(),
+        [
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+        ],
+    )
+    .header(Row::new(vec!["Col 1", "Col 2", "Col 3"]).bottom_margin(1))
+    .block(Block::bordered().title("Table: ALL borders, spacing 1"))
+    .borders(TableBorders::ALL)
+    .row_spacing(1)
+    .column_spacing(1)
+    .row_highlight_style(Style::new().add_modifier(Modifier::REVERSED));
+
+    f.render_stateful_widget(table1, chunks[0], state);
+
+    // Right Table: VERTICAL borders only, column_spacing 1
+    let table2 = Table::new(
+        rows.clone(),
+        [
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+        ],
+    )
+    .header(Row::new(vec!["Col 1", "Col 2", "Col 3"]))
+    .block(Block::bordered().title("Table: VERTICAL only, spacing 1"))
+    .borders(TableBorders::VERTICAL)
+    .column_spacing(1)
+    .row_highlight_style(Style::new().add_modifier(Modifier::REVERSED));
+
+    f.render_stateful_widget(table2, chunks[1], state);
+}

--- a/ratatui-widgets/examples/table-borders.rs
+++ b/ratatui-widgets/examples/table-borders.rs
@@ -9,10 +9,10 @@
 use color_eyre::Result;
 use crossterm::event::{self, KeyCode};
 use ratatui::{
-    layout::{Constraint, Layout},
-    style::{Modifier, Style, Stylize},
-    widgets::{Block, Cell, Row, Table, TableBorders, TableState},
     Frame,
+    layout::{Constraint, Layout},
+    style::{Modifier, Style},
+    widgets::{Block, Cell, Row, Table, TableBorders, TableState},
 };
 
 fn main() -> Result<()> {
@@ -39,7 +39,8 @@ fn main() -> Result<()> {
 
 fn render(f: &mut Frame, state: &mut TableState) {
     let area = f.area();
-    let chunks = Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(area);
+    let chunks =
+        Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(area);
 
     let items = (0..20)
         .map(|i| {
@@ -51,7 +52,9 @@ fn render(f: &mut Frame, state: &mut TableState) {
         })
         .collect::<Vec<_>>();
 
-    let rows = items.iter().map(|item| Row::new(item.iter().map(|c| Cell::from(c.as_str()))));
+    let rows = items
+        .iter()
+        .map(|item| Row::new(item.iter().map(|c| Cell::from(c.as_str()))));
 
     // Left Table: ALL borders, row_spacing 1, column_spacing 1
     let table1 = Table::new(

--- a/ratatui-widgets/src/lib.rs
+++ b/ratatui-widgets/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![allow(rustdoc::broken_intra_doc_links)]
 // show the feature flags in the generated documentation
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -8,7 +8,7 @@ use bitflags::bitflags;
 use itertools::Itertools;
 use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::{Constraint, Flex, Layout, Rect};
-use ratatui_core::style::{Style, Styled};
+use ratatui_core::style::{Color, Style, Styled};
 use ratatui_core::symbols::line;
 use ratatui_core::text::Text;
 use ratatui_core::widgets::{StatefulWidget, Widget};

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -4,12 +4,13 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
+use bitflags::bitflags;
 use itertools::Itertools;
 use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::{Constraint, Flex, Layout, Rect};
 use ratatui_core::style::{Style, Styled};
-use ratatui_core::text::Text;
 use ratatui_core::symbols::line;
+use ratatui_core::text::Text;
 use ratatui_core::widgets::{StatefulWidget, Widget};
 
 pub use self::cell::Cell;
@@ -17,7 +18,6 @@ pub use self::highlight_spacing::HighlightSpacing;
 pub use self::row::Row;
 pub use self::state::TableState;
 use crate::block::{Block, BlockExt};
-use bitflags::bitflags;
 
 mod cell;
 mod highlight_spacing;

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -869,7 +869,10 @@ impl StatefulWidget for &Table<'_> {
                         .set_style(self.border_style);
                 }
                 if self.borders.contains(TableBorders::VERTICAL) && self.column_spacing > 0 {
-                    let x_coords = column_widths.windows(2).map(|w| table_area.x + w[0].right()).filter(|&x| x < table_area.right());
+                    let x_coords = column_widths
+                        .windows(2)
+                        .map(|w| table_area.x + w[0].right())
+                        .filter(|&x| x < table_area.right());
                     for x in x_coords {
                         buf[(x, y)].set_symbol(line::CROSS);
                         buf[(x, y)].set_style(self.border_style);
@@ -890,7 +893,10 @@ impl StatefulWidget for &Table<'_> {
                         .set_style(self.border_style);
                 }
                 if self.borders.contains(TableBorders::VERTICAL) && self.column_spacing > 0 {
-                    let x_coords = column_widths.windows(2).map(|w| table_area.x + w[0].right()).filter(|&x| x < table_area.right());
+                    let x_coords = column_widths
+                        .windows(2)
+                        .map(|w| table_area.x + w[0].right())
+                        .filter(|&x| x < table_area.right());
                     for x in x_coords {
                         buf[(x, y)].set_symbol(line::CROSS);
                         buf[(x, y)].set_style(self.border_style);
@@ -940,7 +946,10 @@ impl Table<'_> {
                 cell.render(area_to_render, buf);
             }
             if self.borders.contains(TableBorders::VERTICAL) && self.column_spacing > 0 {
-                let x_coords = column_widths.windows(2).map(|w| area.x + w[0].right()).filter(|&x| x < area.right());
+                let x_coords = column_widths
+                    .windows(2)
+                    .map(|w| area.x + w[0].right())
+                    .filter(|&x| x < area.right());
                 for x in x_coords {
                     for y in area.top()..area.bottom() {
                         buf[(x, y)].set_symbol(line::VERTICAL);
@@ -964,7 +973,10 @@ impl Table<'_> {
                 cell.render(area_to_render, buf);
             }
             if self.borders.contains(TableBorders::VERTICAL) && self.column_spacing > 0 {
-                let x_coords = column_widths.windows(2).map(|w| area.x + w[0].right()).filter(|&x| x < area.right());
+                let x_coords = column_widths
+                    .windows(2)
+                    .map(|w| area.x + w[0].right())
+                    .filter(|&x| x < area.right());
                 for x in x_coords {
                     for y in area.top()..area.bottom() {
                         buf[(x, y)].set_symbol(line::VERTICAL);
@@ -1017,7 +1029,10 @@ impl Table<'_> {
 
             // Vertical borders
             if self.borders.contains(TableBorders::VERTICAL) && self.column_spacing > 0 {
-                let x_coords = columns_widths.windows(2).map(|w| area.x + w[0].right()).filter(|&x| x < area.right());
+                let x_coords = columns_widths
+                    .windows(2)
+                    .map(|w| area.x + w[0].right())
+                    .filter(|&x| x < area.right());
                 for x in x_coords {
                     for row_y in y..y + height {
                         buf[(x, row_y)].set_symbol(line::VERTICAL);

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -8,7 +8,7 @@ use bitflags::bitflags;
 use itertools::Itertools;
 use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::{Constraint, Flex, Layout, Rect};
-use ratatui_core::style::{Color, Style, Styled};
+use ratatui_core::style::{Style, Styled};
 use ratatui_core::symbols::line;
 use ratatui_core::text::Text;
 use ratatui_core::widgets::{StatefulWidget, Widget};

--- a/ratatui/src/widgets.rs
+++ b/ratatui/src/widgets.rs
@@ -681,7 +681,7 @@ pub use ratatui_widgets::scrollbar::{
     ScrollDirection, Scrollbar, ScrollbarOrientation, ScrollbarState,
 };
 pub use ratatui_widgets::sparkline::{RenderDirection, Sparkline, SparklineBar};
-pub use ratatui_widgets::table::{Cell, HighlightSpacing, Row, Table, TableState};
+pub use ratatui_widgets::table::{Cell, HighlightSpacing, Row, Table, TableBorders, TableState};
 pub use ratatui_widgets::tabs::Tabs;
 #[instability::unstable(feature = "widget-ref")]
 pub use {stateful_widget_ref::StatefulWidgetRef, widget_ref::WidgetRef};


### PR DESCRIPTION
## Description
This PR adds the ability to configure borders on the Table widget. 
It introduces a new configuration to draw borders around the table (All, Vertical, None, etc.), using standard Unicode box-drawing characters.

## Demo
(Glisse et dépose ton image ici ! C'est vital pour prouver que ça marche)

## Related Issue
Closes ratatui/ratatui-table#2
<img width="799" height="170" alt="image" src="https://github.com/user-attachments/assets/7cec0a5c-0ea8-4b32-ad4b-ce438c307e59" />
