### PR TITLE
feat(widgets): implement widget for char and Cell

### DIFF
--- a/ratatui-core/src/widgets/widget.rs
+++ b/ratatui-core/src/widgets/widget.rs
@@ -1,7 +1,7 @@
 use alloc::string::String;
 
-use crate::buffer::Buffer;
-use crate::layout::Rect;
+use crate::buffer::{Buffer, Cell};
+use crate::layout::{Position, Rect};
 use crate::style::Style;
 
 /// A `Widget` is a type that can be drawn on a [`Buffer`] in a given [`Rect`].

--- a/ratatui-core/src/widgets/widget.rs
+++ b/ratatui-core/src/widgets/widget.rs
@@ -105,6 +105,41 @@ impl<W: Widget> Widget for Option<W> {
     }
 }
 
+/// Renders a `Cell` as a widget.
+///
+/// This implementation enables an owned `Cell` to be treated as a widget, which can be printed
+/// directly into the [`Buffer`], at the position given by the [`Rect`].
+impl Widget for Cell {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        let Some(cell) = buf.cell_mut(Position {
+            x: area.x,
+            y: area.y,
+        }) else {
+            return;
+        };
+
+        *cell = self;
+    }
+}
+
+/// Renders a `char` as a widget.
+///
+/// This implementation enables a `char` to be treated as a widget, which can be printed
+/// directly into the [`Buffer`], at the position given by the [`Rect`] with the default [`Style`].
+impl Widget for char {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        let mut cell = Cell::default();
+        cell.set_char(self);
+        cell.render(area, buf);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::{fixture, rstest};


### PR DESCRIPTION
This allows the rendering of `char` and `buffer::Cell` through the `Widget` trait without an additional `String` allocation.

Todo:
- [x] implementation
- [x] docs
- [ ] widget-ref?
- [ ] tests
