### PR TITLE
fix(core): Make autoresize query the backend's window size rather than the cached value

### DIFF
--- a/ratatui-core/src/terminal/resize.rs
+++ b/ratatui-core/src/terminal/resize.rs
@@ -55,7 +55,7 @@ impl<B: Backend> Terminal<B> {
     pub fn autoresize(&mut self) -> Result<(), B::Error> {
         // fixed viewports do not get autoresized
         if matches!(self.viewport, Viewport::Fullscreen | Viewport::Inline(_)) {
-            let area = self.size()?.into();
+            let area = self.backend.window_size()?.columns_rows.into();
             if area != self.last_known_area {
                 self.resize(area)?;
             }


### PR DESCRIPTION
In the default crossterm backend, this won't change anything, but the termwiz backend just [queries the cached size](https://github.com/ratatui/ratatui/blob/main/ratatui-termwiz/src/lib.rs#L261), which will incorrectly never change.

I would love to be able to change the termwiz backend `size` to effectively just be `window_size().columns_rows`, however [`Terminal::get_screen_size()`](https://docs.rs/termwiz/latest/termwiz/terminal/trait.Terminal.html#tymethod.get_screen_size) takes the receiver by `&mut`, and thus we'd need `size` to do so as well. 

Crossterm gets around this by not attaching the request for size to any state-tracking, and instead just calling a [standalone function](https://github.com/ratatui/ratatui/blob/main/ratatui-crossterm/src/lib.rs#L331).