### PR TITLE
fix(backend): correct cursor positioning for wide characters in draw,…

### DIFF
--- a/ratatui-crossterm/src/lib.rs
+++ b/ratatui-crossterm/src/lib.rs
@@ -239,9 +239,10 @@ where
         let mut underline_color = Color::Reset;
         let mut modifier = Modifier::empty();
         let mut next_pos: Option<Position> = None;
+        let mut skip_covered_cells = false;
         for (x, y, cell) in content {
             // Ignore updates for cells covered by the previous wide symbol.
-            if matches!(next_pos, Some(pos) if y == pos.y && x < pos.x) {
+            if skip_covered_cells && matches!(next_pos, Some(pos) if y == pos.y && x < pos.x) {
                 continue;
             }
             // Move the cursor if the terminal is not expected to already be at this position.
@@ -275,10 +276,12 @@ where
             }
 
             queue!(self.writer, Print(cell.symbol()))?;
+            let cell_width = cell.cell_width();
             next_pos = Some(Position {
-                x: x.saturating_add(cell.cell_width()),
+                x: x.saturating_add(cell_width),
                 y,
             });
+            skip_covered_cells = cell_width > 1 && !cell.symbol().contains('\u{FE0F}');
         }
 
         #[cfg(feature = "underline-color")]
@@ -1208,6 +1211,24 @@ mod tests {
         let output = std::str::from_utf8(&writer).expect("crossterm output should be utf-8");
         assert!(output.contains("中x"));
         assert_eq!(count_occurrences(&writer, &move_to(1, 0)?), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn draw_keeps_vs16_trailing_cell_updates() -> io::Result<()> {
+        let emoji = Cell::new("⌨️");
+        let trailing = Cell::new(" ");
+        let next = Cell::new("x");
+        let mut writer = Vec::new();
+        let mut backend = CrosstermBackend::new(&mut writer);
+
+        backend.draw([(0, 0, &emoji), (1, 0, &trailing), (2, 0, &next)].into_iter())?;
+
+        let output = std::str::from_utf8(&writer).expect("crossterm output should be utf-8");
+        assert!(output.contains("⌨️"));
+        assert_eq!(count_occurrences(&writer, &move_to(1, 0)?), 1);
+        assert_eq!(count_occurrences(&writer, &move_to(2, 0)?), 0);
 
         Ok(())
     }

--- a/ratatui-crossterm/src/lib.rs
+++ b/ratatui-crossterm/src/lib.rs
@@ -97,7 +97,7 @@ cfg_if::cfg_if! {
     }
 }
 use ratatui_core::backend::{Backend, ClearType, WindowSize};
-use ratatui_core::buffer::Cell;
+use ratatui_core::buffer::{Cell, CellWidth};
 use ratatui_core::layout::{Position, Size};
 use ratatui_core::style::{Color, Modifier, Style};
 
@@ -238,13 +238,16 @@ where
         #[cfg(feature = "underline-color")]
         let mut underline_color = Color::Reset;
         let mut modifier = Modifier::empty();
-        let mut last_pos: Option<Position> = None;
+        let mut next_pos: Option<Position> = None;
         for (x, y, cell) in content {
-            // Move the cursor if the previous location was not (x - 1, y)
-            if !matches!(last_pos, Some(p) if x == p.x + 1 && y == p.y) {
+            // Ignore updates for cells covered by the previous wide symbol.
+            if matches!(next_pos, Some(pos) if y == pos.y && x < pos.x) {
+                continue;
+            }
+            // Move the cursor if the terminal is not expected to already be at this position.
+            if next_pos != Some(Position { x, y }) {
                 queue!(self.writer, MoveTo(x, y))?;
             }
-            last_pos = Some(Position { x, y });
             if cell.modifier != modifier {
                 let diff = ModifierDiff {
                     from: modifier,
@@ -272,6 +275,10 @@ where
             }
 
             queue!(self.writer, Print(cell.symbol()))?;
+            next_pos = Some(Position {
+                x: x.saturating_add(cell.cell_width()),
+                y,
+            });
         }
 
         #[cfg(feature = "underline-color")]
@@ -1167,5 +1174,70 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(style.into_crossterm(), content_style);
+    }
+
+    #[test]
+    fn draw_does_not_move_cursor_between_adjacent_wide_cells() -> io::Result<()> {
+        let first = Cell::new("中");
+        let second = Cell::new("文");
+        let third = Cell::new("x");
+        let mut writer = Vec::new();
+        let mut backend = CrosstermBackend::new(&mut writer);
+
+        backend.draw([(0, 0, &first), (2, 0, &second), (4, 0, &third)].into_iter())?;
+
+        let output = std::str::from_utf8(&writer).expect("crossterm output should be utf-8");
+        assert!(output.contains("中文x"));
+        assert_eq!(count_occurrences(&writer, &move_to(0, 0)?), 1);
+        assert_eq!(count_occurrences(&writer, &move_to(2, 0)?), 0);
+        assert_eq!(count_occurrences(&writer, &move_to(4, 0)?), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn draw_skips_cells_covered_by_a_previous_wide_cell() -> io::Result<()> {
+        let wide = Cell::new("中");
+        let trailing = Cell::new(" ");
+        let next = Cell::new("x");
+        let mut writer = Vec::new();
+        let mut backend = CrosstermBackend::new(&mut writer);
+
+        backend.draw([(0, 0, &wide), (1, 0, &trailing), (2, 0, &next)].into_iter())?;
+
+        let output = std::str::from_utf8(&writer).expect("crossterm output should be utf-8");
+        assert!(output.contains("中x"));
+        assert_eq!(count_occurrences(&writer, &move_to(1, 0)?), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn draw_moves_cursor_after_wide_cell_when_next_position_is_not_adjacent() -> io::Result<()> {
+        let first = Cell::new("中");
+        let second = Cell::new("x");
+        let mut writer = Vec::new();
+        let mut backend = CrosstermBackend::new(&mut writer);
+
+        backend.draw([(0, 0, &first), (3, 0, &second)].into_iter())?;
+
+        assert_eq!(count_occurrences(&writer, &move_to(0, 0)?), 1);
+        assert_eq!(count_occurrences(&writer, &move_to(2, 0)?), 0);
+        assert_eq!(count_occurrences(&writer, &move_to(3, 0)?), 1);
+
+        Ok(())
+    }
+
+    fn move_to(x: u16, y: u16) -> io::Result<Vec<u8>> {
+        let mut bytes = Vec::new();
+        queue!(&mut bytes, MoveTo(x, y))?;
+        Ok(bytes)
+    }
+
+    fn count_occurrences(haystack: &[u8], needle: &[u8]) -> usize {
+        haystack
+            .windows(needle.len())
+            .filter(|window| *window == needle)
+            .count()
     }
 }

--- a/ratatui-termion/src/lib.rs
+++ b/ratatui-termion/src/lib.rs
@@ -219,9 +219,10 @@ where
         let mut bg = Color::Reset;
         let mut modifier = Modifier::empty();
         let mut next_pos: Option<Position> = None;
+        let mut skip_covered_cells = false;
         for (x, y, cell) in content {
             // Ignore updates for cells covered by the previous wide symbol.
-            if matches!(next_pos, Some(pos) if y == pos.y && x < pos.x) {
+            if skip_covered_cells && matches!(next_pos, Some(pos) if y == pos.y && x < pos.x) {
                 continue;
             }
             // Move the cursor if the terminal is not expected to already be at this position.
@@ -249,10 +250,12 @@ where
                 bg = cell.bg;
             }
             string.push_str(cell.symbol());
+            let cell_width = cell.cell_width();
             next_pos = Some(Position {
-                x: x.saturating_add(cell.cell_width()),
+                x: x.saturating_add(cell_width),
                 y,
             });
+            skip_covered_cells = cell_width > 1 && !cell.symbol().contains('\u{FE0F}');
         }
         write!(
             self.writer,
@@ -782,6 +785,24 @@ mod tests {
         let output = std::str::from_utf8(&writer).expect("termion output should be utf-8");
         assert!(output.contains("中x"));
         assert_eq!(output.matches(&goto(1, 0)).count(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn draw_keeps_vs16_trailing_cell_updates() -> io::Result<()> {
+        let emoji = Cell::new("⌨️");
+        let trailing = Cell::new(" ");
+        let next = Cell::new("x");
+        let mut writer = Vec::new();
+        let mut backend = TermionBackend::new(&mut writer);
+
+        backend.draw([(0, 0, &emoji), (1, 0, &trailing), (2, 0, &next)].into_iter())?;
+
+        let output = std::str::from_utf8(&writer).expect("termion output should be utf-8");
+        assert!(output.contains("⌨️"));
+        assert_eq!(output.matches(&goto(1, 0)).count(), 1);
+        assert_eq!(output.matches(&goto(2, 0)).count(), 0);
 
         Ok(())
     }

--- a/ratatui-termion/src/lib.rs
+++ b/ratatui-termion/src/lib.rs
@@ -41,7 +41,7 @@ use std::fmt;
 use std::io::{self, Write};
 
 use ratatui_core::backend::{Backend, ClearType, WindowSize};
-use ratatui_core::buffer::Cell;
+use ratatui_core::buffer::{Cell, CellWidth};
 use ratatui_core::layout::{Position, Size};
 use ratatui_core::style::{Color, Modifier, Style};
 pub use termion;
@@ -218,13 +218,16 @@ where
         let mut fg = Color::Reset;
         let mut bg = Color::Reset;
         let mut modifier = Modifier::empty();
-        let mut last_pos: Option<Position> = None;
+        let mut next_pos: Option<Position> = None;
         for (x, y, cell) in content {
-            // Move the cursor if the previous location was not (x - 1, y)
-            if !matches!(last_pos, Some(p) if x == p.x + 1 && y == p.y) {
+            // Ignore updates for cells covered by the previous wide symbol.
+            if matches!(next_pos, Some(pos) if y == pos.y && x < pos.x) {
+                continue;
+            }
+            // Move the cursor if the terminal is not expected to already be at this position.
+            if next_pos != Some(Position { x, y }) {
                 write!(string, "{}", termion::cursor::Goto(x + 1, y + 1)).unwrap();
             }
-            last_pos = Some(Position { x, y });
             if cell.modifier != modifier {
                 write!(
                     string,
@@ -246,6 +249,10 @@ where
                 bg = cell.bg;
             }
             string.push_str(cell.symbol());
+            next_pos = Some(Position {
+                x: x.saturating_add(cell.cell_width()),
+                y,
+            });
         }
         write!(
             self.writer,
@@ -741,5 +748,62 @@ mod tests {
         );
         assert_eq!(Modifier::from_termion(tstyle::Blink), Modifier::SLOW_BLINK);
         assert_eq!(Modifier::from_termion(tstyle::Reset), Modifier::empty());
+    }
+
+    #[test]
+    fn draw_does_not_move_cursor_between_adjacent_wide_cells() -> io::Result<()> {
+        let first = Cell::new("中");
+        let second = Cell::new("文");
+        let third = Cell::new("x");
+        let mut writer = Vec::new();
+        let mut backend = TermionBackend::new(&mut writer);
+
+        backend.draw([(0, 0, &first), (2, 0, &second), (4, 0, &third)].into_iter())?;
+
+        let output = std::str::from_utf8(&writer).expect("termion output should be utf-8");
+        assert!(output.contains("中文x"));
+        assert_eq!(output.matches(&goto(0, 0)).count(), 1);
+        assert_eq!(output.matches(&goto(2, 0)).count(), 0);
+        assert_eq!(output.matches(&goto(4, 0)).count(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn draw_skips_cells_covered_by_a_previous_wide_cell() -> io::Result<()> {
+        let wide = Cell::new("中");
+        let trailing = Cell::new(" ");
+        let next = Cell::new("x");
+        let mut writer = Vec::new();
+        let mut backend = TermionBackend::new(&mut writer);
+
+        backend.draw([(0, 0, &wide), (1, 0, &trailing), (2, 0, &next)].into_iter())?;
+
+        let output = std::str::from_utf8(&writer).expect("termion output should be utf-8");
+        assert!(output.contains("中x"));
+        assert_eq!(output.matches(&goto(1, 0)).count(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn draw_moves_cursor_after_wide_cell_when_next_position_is_not_adjacent() -> io::Result<()> {
+        let first = Cell::new("中");
+        let second = Cell::new("x");
+        let mut writer = Vec::new();
+        let mut backend = TermionBackend::new(&mut writer);
+
+        backend.draw([(0, 0, &first), (3, 0, &second)].into_iter())?;
+
+        let output = std::str::from_utf8(&writer).expect("termion output should be utf-8");
+        assert_eq!(output.matches(&goto(0, 0)).count(), 1);
+        assert_eq!(output.matches(&goto(2, 0)).count(), 0);
+        assert_eq!(output.matches(&goto(3, 0)).count(), 1);
+
+        Ok(())
+    }
+
+    fn goto(x: u16, y: u16) -> String {
+        format!("{}", termion::cursor::Goto(x + 1, y + 1))
     }
 }

--- a/ratatui-termwiz/src/lib.rs
+++ b/ratatui-termwiz/src/lib.rs
@@ -149,81 +149,7 @@ impl Backend for TermwizBackend {
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {
-        let mut next_pos: Option<Position> = None;
-        for (x, y, cell) in content {
-            // Ignore updates for cells covered by the previous wide symbol.
-            if matches!(next_pos, Some(pos) if y == pos.y && x < pos.x) {
-                continue;
-            }
-            if next_pos != Some(Position { x, y }) {
-                self.buffered_terminal.add_change(Change::CursorPosition {
-                    x: TermwizPosition::Absolute(x as usize),
-                    y: TermwizPosition::Absolute(y as usize),
-                });
-            }
-
-            self.buffered_terminal.add_changes(vec![
-                Change::Attribute(AttributeChange::Foreground(cell.fg.into_termwiz())),
-                Change::Attribute(AttributeChange::Background(cell.bg.into_termwiz())),
-            ]);
-
-            self.buffered_terminal
-                .add_change(Change::Attribute(AttributeChange::Intensity(
-                    if cell.modifier.contains(Modifier::BOLD) {
-                        Intensity::Bold
-                    } else if cell.modifier.contains(Modifier::DIM) {
-                        Intensity::Half
-                    } else {
-                        Intensity::Normal
-                    },
-                )));
-
-            self.buffered_terminal
-                .add_change(Change::Attribute(AttributeChange::Italic(
-                    cell.modifier.contains(Modifier::ITALIC),
-                )));
-
-            self.buffered_terminal
-                .add_change(Change::Attribute(AttributeChange::Underline(
-                    if cell.modifier.contains(Modifier::UNDERLINED) {
-                        Underline::Single
-                    } else {
-                        Underline::None
-                    },
-                )));
-
-            self.buffered_terminal
-                .add_change(Change::Attribute(AttributeChange::Reverse(
-                    cell.modifier.contains(Modifier::REVERSED),
-                )));
-
-            self.buffered_terminal
-                .add_change(Change::Attribute(AttributeChange::Invisible(
-                    cell.modifier.contains(Modifier::HIDDEN),
-                )));
-
-            self.buffered_terminal
-                .add_change(Change::Attribute(AttributeChange::StrikeThrough(
-                    cell.modifier.contains(Modifier::CROSSED_OUT),
-                )));
-
-            self.buffered_terminal
-                .add_change(Change::Attribute(AttributeChange::Blink(
-                    if cell.modifier.contains(Modifier::SLOW_BLINK) {
-                        Blink::Slow
-                    } else if cell.modifier.contains(Modifier::RAPID_BLINK) {
-                        Blink::Rapid
-                    } else {
-                        Blink::None
-                    },
-                )));
-
-            self.buffered_terminal.add_change(cell.symbol());
-            next_pos = Some(Position {
-                x: x.saturating_add(cell.cell_width()),
-                y,
-            });
-        }
+        draw_content(&mut self.buffered_terminal, content);
         Ok(())
     }
 
@@ -349,6 +275,83 @@ impl Backend for TermwizBackend {
             },
         ]);
         Ok(())
+    }
+}
+
+fn draw_content<'a, I>(surface: &mut termwiz::surface::Surface, content: I)
+where
+    I: Iterator<Item = (u16, u16, &'a Cell)>,
+{
+    let mut next_pos: Option<Position> = None;
+    let mut skip_covered_cells = false;
+    for (x, y, cell) in content {
+        // Ignore updates for cells covered by the previous wide symbol.
+        if skip_covered_cells && matches!(next_pos, Some(pos) if y == pos.y && x < pos.x) {
+            continue;
+        }
+        if next_pos != Some(Position { x, y }) {
+            surface.add_change(Change::CursorPosition {
+                x: TermwizPosition::Absolute(x as usize),
+                y: TermwizPosition::Absolute(y as usize),
+            });
+        }
+
+        surface.add_changes(vec![
+            Change::Attribute(AttributeChange::Foreground(cell.fg.into_termwiz())),
+            Change::Attribute(AttributeChange::Background(cell.bg.into_termwiz())),
+        ]);
+
+        surface.add_change(Change::Attribute(AttributeChange::Intensity(
+            if cell.modifier.contains(Modifier::BOLD) {
+                Intensity::Bold
+            } else if cell.modifier.contains(Modifier::DIM) {
+                Intensity::Half
+            } else {
+                Intensity::Normal
+            },
+        )));
+
+        surface.add_change(Change::Attribute(AttributeChange::Italic(
+            cell.modifier.contains(Modifier::ITALIC),
+        )));
+
+        surface.add_change(Change::Attribute(AttributeChange::Underline(
+            if cell.modifier.contains(Modifier::UNDERLINED) {
+                Underline::Single
+            } else {
+                Underline::None
+            },
+        )));
+
+        surface.add_change(Change::Attribute(AttributeChange::Reverse(
+            cell.modifier.contains(Modifier::REVERSED),
+        )));
+
+        surface.add_change(Change::Attribute(AttributeChange::Invisible(
+            cell.modifier.contains(Modifier::HIDDEN),
+        )));
+
+        surface.add_change(Change::Attribute(AttributeChange::StrikeThrough(
+            cell.modifier.contains(Modifier::CROSSED_OUT),
+        )));
+
+        surface.add_change(Change::Attribute(AttributeChange::Blink(
+            if cell.modifier.contains(Modifier::SLOW_BLINK) {
+                Blink::Slow
+            } else if cell.modifier.contains(Modifier::RAPID_BLINK) {
+                Blink::Rapid
+            } else {
+                Blink::None
+            },
+        )));
+
+        surface.add_change(cell.symbol());
+        let cell_width = cell.cell_width();
+        next_pos = Some(Position {
+            x: x.saturating_add(cell_width),
+            y,
+        });
+        skip_covered_cells = cell_width > 1 && !cell.symbol().contains('\u{FE0F}');
     }
 }
 
@@ -899,5 +902,124 @@ mod tests {
             ),
             STYLE.underline_color(Color::Indexed(9))
         );
+    }
+
+    #[test]
+    fn draw_does_not_move_cursor_between_adjacent_wide_cells() {
+        let first = Cell::new("中");
+        let second = Cell::new("文");
+        let third = Cell::new("x");
+
+        let changes = draw_changes([(0, 0, &first), (2, 0, &second), (4, 0, &third)]);
+
+        assert!(changes.contains(&text("中")));
+        assert!(changes.contains(&text("文")));
+        assert!(changes.contains(&text("x")));
+        assert_eq!(count_changes(&changes, &cursor_position(0, 0)), 1);
+        assert_eq!(count_changes(&changes, &cursor_position(2, 0)), 0);
+        assert_eq!(count_changes(&changes, &cursor_position(4, 0)), 0);
+    }
+
+    #[test]
+    fn draw_skips_cells_covered_by_a_previous_wide_cell() {
+        let wide = Cell::new("中");
+        let trailing = Cell::new(" ");
+        let next = Cell::new("x");
+
+        let changes = draw_changes([(0, 0, &wide), (1, 0, &trailing), (2, 0, &next)]);
+
+        assert!(changes.contains(&text("中")));
+        assert!(changes.contains(&text("x")));
+        assert!(!changes.contains(&text(" ")));
+        assert_eq!(count_changes(&changes, &cursor_position(1, 0)), 0);
+    }
+
+    #[test]
+    fn draw_keeps_vs16_trailing_cell_updates() {
+        let emoji = Cell::new("⌨️");
+        let trailing = Cell::new(" ");
+        let next = Cell::new("x");
+
+        let changes = draw_changes([(0, 0, &emoji), (1, 0, &trailing), (2, 0, &next)]);
+
+        assert!(changes.contains(&text("⌨️")));
+        assert!(changes.contains(&text(" ")));
+        assert!(changes.contains(&text("x")));
+        assert_eq!(count_changes(&changes, &cursor_position(1, 0)), 1);
+        assert_eq!(count_changes(&changes, &cursor_position(2, 0)), 0);
+    }
+
+    #[test]
+    fn draw_moves_cursor_after_wide_cell_when_next_position_is_not_adjacent() {
+        let first = Cell::new("中");
+        let second = Cell::new("x");
+
+        let changes = draw_changes([(0, 0, &first), (3, 0, &second)]);
+
+        assert_eq!(count_changes(&changes, &cursor_position(0, 0)), 1);
+        assert_eq!(count_changes(&changes, &cursor_position(2, 0)), 0);
+        assert_eq!(count_changes(&changes, &cursor_position(3, 0)), 1);
+    }
+
+    #[test]
+    fn draw_applies_modifier_attributes() {
+        let mut styled = Cell::new("a");
+        styled.set_style(
+            Style::new()
+                .bold()
+                .italic()
+                .underlined()
+                .reversed()
+                .hidden()
+                .crossed_out()
+                .slow_blink(),
+        );
+        let mut dim = Cell::new("b");
+        dim.set_style(Style::new().dim().rapid_blink());
+
+        let changes = draw_changes([(0, 0, &styled), (1, 0, &dim)]);
+
+        assert!(changes.contains(&attribute(AttributeChange::Intensity(Intensity::Bold))));
+        assert!(changes.contains(&attribute(AttributeChange::Intensity(Intensity::Half))));
+        assert!(changes.contains(&attribute(AttributeChange::Italic(true))));
+        assert!(changes.contains(&attribute(AttributeChange::Underline(Underline::Single))));
+        assert!(changes.contains(&attribute(AttributeChange::Reverse(true))));
+        assert!(changes.contains(&attribute(AttributeChange::Invisible(true))));
+        assert!(changes.contains(&attribute(AttributeChange::StrikeThrough(true))));
+        assert!(changes.contains(&attribute(AttributeChange::Blink(Blink::Slow))));
+        assert!(changes.contains(&attribute(AttributeChange::Blink(Blink::Rapid))));
+    }
+
+    fn draw_changes<'a, I>(content: I) -> Vec<Change>
+    where
+        I: IntoIterator<Item = (u16, u16, &'a Cell)>,
+    {
+        let mut surface = termwiz::surface::Surface::new(80, 24);
+        surface.add_change(Change::Title("seed".into()));
+        let seqno = surface.current_seqno();
+
+        draw_content(&mut surface, content.into_iter());
+
+        let (_, changes) = surface.get_changes(seqno);
+        changes.into_owned()
+    }
+
+    fn cursor_position(x: usize, y: usize) -> Change {
+        Change::CursorPosition {
+            x: TermwizPosition::Absolute(x),
+            y: TermwizPosition::Absolute(y),
+        }
+    }
+
+    fn text(text: &str) -> Change {
+        Change::Text(text.to_string())
+    }
+
+    fn attribute(attribute: AttributeChange) -> Change {
+        Change::Attribute(attribute)
+    }
+
+    fn count_changes(changes: &[Change], needle: &Change) -> usize {
+        changes.iter().filter(|change| *change == needle).count()
     }
 }

--- a/ratatui-termwiz/src/lib.rs
+++ b/ratatui-termwiz/src/lib.rs
@@ -42,7 +42,7 @@ use std::error::Error;
 use std::io;
 
 use ratatui_core::backend::{Backend, ClearType, WindowSize};
-use ratatui_core::buffer::Cell;
+use ratatui_core::buffer::{Cell, CellWidth};
 use ratatui_core::layout::{Position, Size};
 use ratatui_core::style::{Color, Modifier, Style};
 pub use termwiz;
@@ -149,12 +149,20 @@ impl Backend for TermwizBackend {
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {
+        let mut next_pos: Option<Position> = None;
         for (x, y, cell) in content {
-            self.buffered_terminal.add_changes(vec![
-                Change::CursorPosition {
+            // Ignore updates for cells covered by the previous wide symbol.
+            if matches!(next_pos, Some(pos) if y == pos.y && x < pos.x) {
+                continue;
+            }
+            if next_pos != Some(Position { x, y }) {
+                self.buffered_terminal.add_change(Change::CursorPosition {
                     x: TermwizPosition::Absolute(x as usize),
                     y: TermwizPosition::Absolute(y as usize),
-                },
+                });
+            }
+
+            self.buffered_terminal.add_changes(vec![
                 Change::Attribute(AttributeChange::Foreground(cell.fg.into_termwiz())),
                 Change::Attribute(AttributeChange::Background(cell.bg.into_termwiz())),
             ]);
@@ -211,6 +219,10 @@ impl Backend for TermwizBackend {
                 )));
 
             self.buffered_terminal.add_change(cell.symbol());
+            next_pos = Some(Position {
+                x: x.saturating_add(cell.cell_width()),
+                y,
+            });
         }
         Ok(())
     }


### PR DESCRIPTION
This PR fixes issue https://github.com/ratatui/ratatui/issues/1745 where Chinese characters and other multi-width characters were being rendered with additional unwanted whitespace between them.

Replace `last_pos` (previous cell position) with `next_pos` (predicted
cursor position after rendering the current cell) in the draw loop
across all three terminal backends. The old logic used the wrong
reference point, causing unnecessary cursor moves for the trailing cell
of wide characters (CJK, emoji), which led to rendering artifacts such
as overlapping text and missing characters.

The new logic:
- Uses `cell.cell_width()` to compute where the cursor will be after
  printing the cell
- Skips cells that are covered by a previous wide character
  (`x < next_pos.x` on the same row)
- Only moves the cursor when the terminal will not already be at the
  expected position (`next_pos != Some(current)`)
- Avoids redundant `MoveTo`/`Goto`/`CursorPosition` commands

It is now working fine at https://github.com/ldclabs/anda-bot
<img width="1707" height="1271" alt="image" src="https://github.com/user-attachments/assets/6768158b-8ec4-47ce-8ab1-ff7c6f969b94" />
