### PR TITLE
refactor(xtask): use cargo-hack for cargo-rdme checks

### DIFF
--- a/xtask/src/commands/rdme.rs
+++ b/xtask/src/commands/rdme.rs
@@ -10,31 +10,30 @@ pub struct Readme {
     check: bool,
 }
 
-/// The projects that should have their README.md generated from the source code.
-///
-/// Notably, we removed `ratatui` from this list as we have a more specifically crafted README for
-/// the main crate.
-const PROJECTS: &[&str] = &[
-    "ratatui-core",
-    "ratatui-crossterm",
-    "ratatui-macros",
-    "ratatui-termion",
-    "ratatui-termwiz",
-    "ratatui-widgets",
-];
-
 impl Run for Readme {
     fn run(self) -> Result<()> {
-        // This would be simpler perhaps with cargo-hack, however cargo-rdme does not support the
-        // `--manifest-path` option that is required for this to work, so it's easiest to hard code
-        // the package names here. See https://github.com/orium/cargo-rdme/issues/261
-        for package in PROJECTS {
-            let mut args = vec!["rdme", "--workspace-project", package];
-            if self.check {
-                args.push("--check");
-            }
-            run_cargo(args)?;
+        // `ratatui` is excluded: it has a hand-written README. Other library crates use cargo-rdme.
+        // cargo-rdme 1.5.0+ supports `--manifest-path`, which cargo-hack sets per `-p` package.
+        let mut args = vec![
+            "hack",
+            "-p",
+            "ratatui-core",
+            "-p",
+            "ratatui-crossterm",
+            "-p",
+            "ratatui-macros",
+            "-p",
+            "ratatui-termion",
+            "-p",
+            "ratatui-termwiz",
+            "-p",
+            "ratatui-widgets",
+            "rdme",
+        ];
+        if self.check {
+            args.push("--check");
         }
+        run_cargo(args)?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Replace the hard-coded per-package `cargo rdme` loop with `cargo hack -p ... rdme`
- cargo-rdme 1.5.0+ supports `--manifest-path`, which cargo-hack sets per package

## Test plan
- [ ] `cargo xtask rdme --check` (requires cargo-rdme and cargo-hack)

Fixes #2178