### PR TITLE
docs(sparkline): fix duplicate "a" in doc comment

### DIFF
--- a/ratatui-widgets/src/sparkline.rs
+++ b/ratatui-widgets/src/sparkline.rs
@@ -190,7 +190,7 @@ impl<'a> Sparkline<'a> {
     /// # }
     /// ```
     ///
-    /// Create a [`Sparkline`] from a a Vec of [`SparklineBar`] such that some bars are styled:
+    /// Create a [`Sparkline`] from a Vec of [`SparklineBar`] such that some bars are styled:
     ///
     /// ```
     /// # use ratatui::{prelude::*, widgets::*};


### PR DESCRIPTION
> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fix a duplicate `a` in a doc comment on `Sparkline::from_styled_bars`-style example
in `ratatui-widgets/src/sparkline.rs` —
`Create a [`Sparkline`] from a a Vec of [`SparklineBar`]` →
`Create a [`Sparkline`] from a Vec of [`SparklineBar`]`.

## Why

Tiny `///` doc-comment cleanup.

## How verified

Single-line change inside a `///` doc comment for the public `Sparkline` impl.
No code paths or tests touched.

## Maintainer note

Feel free to close if not worth the review cycle.
