### PR TITLE
docs(ratatui-core): fix terminal rendering grammar

### DIFF
--- a/ratatui-core/src/terminal.rs
+++ b/ratatui-core/src/terminal.rs
@@ -4,7 +4,7 @@
 //! This module contains Ratatui's rendering surface abstraction. [`Terminal`] ties together a
 //! backend, a viewport, and a double-buffered renderer. In a typical application you create a
 //! `Terminal`, render by calling [`Terminal::draw`] or [`Terminal::try_draw`] in a loop, and let
-//! Ratatui diff successive frames so only changed cells are sent to the backend.
+//! Ratatui diffs successive frames so only changed cells are sent to the backend.
 //!
 //! [`Frame`] is the mutable view used during one render pass. Widgets write into the current
 //! buffer through it, and cursor state for the end of the pass is requested through


### PR DESCRIPTION
Fixes a small grammar issue in the `ratatui-core` terminal module docs:

- `Ratatui diff successive frames` -> `Ratatui diffs successive frames`

Verification run locally:

- `git diff --check`
- `cargo check -p ratatui-core`

AI assistance: this PR was prepared with Codex. I reviewed the single-line change and ran the verification above locally.
