### PR TITLE
feat: add Termina backend

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -56,7 +56,7 @@ Add a description of the systems where you are observing the issue. For example:
 - Terminal Emulator: xterm
 - Font: Inconsolata (Patched)
 - Crate version: 0.7
-- Backend: termion
+- Backend: crossterm / termion / termina / termwiz
 -->
 
 - OS:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        backend: [crossterm, termion, termwiz]
+        backend: [crossterm, termion, termina, termwiz]
         exclude:
           # termion is not supported on windows
           - os: windows-latest

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -65,6 +65,13 @@ The Ratatui project is now organized as a Cargo workspace containing the followi
 - **Contents**: Unix-specific terminal backend using the `termion` crate
 - **Target Users**: Unix-specific applications requiring low-level control
 
+#### `ratatui-termina`
+
+- **Purpose**: Termina backend implementation
+- **Contents**: Backend for values implementing `termina::Terminal`
+- **Target Users**: Applications that use Termina events or typed escape sequences alongside
+  Ratatui rendering
+
 #### `ratatui-termwiz`
 
 - **Purpose**: Termwiz backend implementation
@@ -87,6 +94,7 @@ ratatui
 ├── ratatui-widgets → ratatui-core
 ├── ratatui-crossterm → ratatui-core
 ├── ratatui-termion → ratatui-core
+├── ratatui-termina → ratatui-core
 ├── ratatui-termwiz → ratatui-core
 └── ratatui-macros
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2849,6 +2849,7 @@ dependencies = [
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
+ "ratatui-termina",
  "ratatui-termion",
  "ratatui-termwiz",
  "ratatui-widgets",
@@ -2917,6 +2918,19 @@ dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
  "ratatui",
+]
+
+[[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+dependencies = [
+ "color-eyre",
+ "document-features",
+ "instability",
+ "ratatui",
+ "ratatui-core",
+ "rstest",
+ "termina",
 ]
 
 [[package]]
@@ -3667,6 +3681,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termina"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293183c87e43cc765b7210627e150b14f30609b214eba4a106e46a9954d41c5c"
+dependencies = [
+ "bitflags 2.12.1",
+ "parking_lot",
+ "rustix 1.0.8",
+ "signal-hook",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,7 +1074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3162,7 +3162,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3685,9 +3685,9 @@ dependencies = [
 
 [[package]]
 name = "termina"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293183c87e43cc765b7210627e150b14f30609b214eba4a106e46a9954d41c5c"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
  "bitflags 2.12.1",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ rstest = "0.26"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", default-features = false, features = ["derive"] }
-termina = "0.3.2"
+termina = "0.3"
 termion = "4"
 termwiz = "0.23"
 thiserror = { version = "2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,10 @@ default-members = [
   "ratatui",
   "ratatui-core",
   "ratatui-crossterm",
+  "ratatui-macros",
   # this is not included as it doesn't compile on windows
   # "ratatui-termion",
-  "ratatui-macros",
+  "ratatui-termina",
   "ratatui-termwiz",
   "ratatui-widgets",
 ]
@@ -55,6 +56,7 @@ ratatui = { path = "ratatui", version = "0.30.1" }
 ratatui-core = { path = "ratatui-core", version = "0.1.1" }
 ratatui-crossterm = { path = "ratatui-crossterm", version = "0.1.1" }
 ratatui-macros = { path = "ratatui-macros", version = "0.7.1" }
+ratatui-termina = { path = "ratatui-termina", version = "0.1.0" }
 ratatui-termion = { path = "ratatui-termion", version = "0.1.1" }
 ratatui-termwiz = { path = "ratatui-termwiz", version = "0.1.1" }
 ratatui-widgets = { path = "ratatui-widgets", version = "0.3.1", default-features = false }
@@ -62,6 +64,7 @@ rstest = "0.26"
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.28", default-features = false, features = ["derive"] }
+termina = "0.3.2"
 termion = "4"
 termwiz = "0.23"
 thiserror = { version = "2", default-features = false }

--- a/examples/apps/demo/Cargo.toml
+++ b/examples/apps/demo/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 [features]
 default = ["crossterm"]
 crossterm = ["dep:crossterm", "ratatui/crossterm"]
+termina = ["ratatui/termina"]
 termion = ["dep:termion", "ratatui/termion"]
 termwiz = ["dep:termwiz", "ratatui/termwiz"]
 

--- a/examples/apps/demo/README.md
+++ b/examples/apps/demo/README.md
@@ -18,6 +18,12 @@ cargo run -p demo
 cargo run -p demo --no-default-features --features termion
 ```
 
+## termina
+
+```shell
+cargo run -p demo --no-default-features --features termina
+```
+
 ## termwiz
 
 ```shell

--- a/examples/apps/demo/src/main.rs
+++ b/examples/apps/demo/src/main.rs
@@ -21,6 +21,8 @@ use clap::Parser;
 mod app;
 #[cfg(feature = "crossterm")]
 mod crossterm;
+#[cfg(feature = "termina")]
+mod termina;
 #[cfg(all(not(windows), feature = "termion"))]
 mod termion;
 #[cfg(feature = "termwiz")]
@@ -45,11 +47,19 @@ fn main() -> Result<(), Box<dyn Error>> {
     let tick_rate = Duration::from_millis(cli.tick_rate);
     #[cfg(feature = "crossterm")]
     crate::crossterm::run(tick_rate, cli.unicode)?;
-    #[cfg(all(not(windows), feature = "termion", not(feature = "crossterm")))]
+    #[cfg(all(feature = "termina", not(feature = "crossterm")))]
+    crate::termina::run(tick_rate, cli.unicode)?;
+    #[cfg(all(
+        not(windows),
+        feature = "termion",
+        not(feature = "crossterm"),
+        not(feature = "termina")
+    ))]
     crate::termion::run(tick_rate, cli.unicode)?;
     #[cfg(all(
         feature = "termwiz",
         not(feature = "crossterm"),
+        not(feature = "termina"),
         not(feature = "termion")
     ))]
     crate::termwiz::run(tick_rate, cli.unicode)?;

--- a/examples/apps/demo/src/termina.rs
+++ b/examples/apps/demo/src/termina.rs
@@ -1,0 +1,113 @@
+#![allow(dead_code)]
+use std::error::Error;
+use std::io::Write as _;
+use std::time::{Duration, Instant};
+
+use ratatui::Terminal;
+use ratatui::backend::TerminaBackend;
+use ratatui::termina::escape::csi::{self, Csi};
+use ratatui::termina::event::{KeyCode, KeyEventKind};
+use ratatui::termina::{Event, EventReader, PlatformTerminal, Terminal as _};
+
+use crate::app::App;
+use crate::ui;
+
+type AppTerminal = Terminal<TerminaBackend<PlatformTerminal>>;
+
+macro_rules! decset {
+    ($mode:ident) => {{
+        let mode = csi::DecPrivateMode::Code(csi::DecPrivateModeCode::$mode);
+        Csi::Mode(csi::Mode::SetDecPrivateMode(mode))
+    }};
+}
+
+macro_rules! decreset {
+    ($mode:ident) => {{
+        let mode = csi::DecPrivateMode::Code(csi::DecPrivateModeCode::$mode);
+        Csi::Mode(csi::Mode::ResetDecPrivateMode(mode))
+    }};
+}
+
+pub fn run(tick_rate: Duration, enhanced_graphics: bool) -> Result<(), Box<dyn Error>> {
+    let (mut terminal, events) = init_terminal()?;
+    let app = App::new("Termina Demo", enhanced_graphics);
+    let app_result = run_app(&mut terminal, &events, app, tick_rate);
+
+    restore_terminal(&mut terminal)?;
+
+    if let Err(err) = app_result {
+        println!("{err:?}");
+    }
+
+    Ok(())
+}
+
+fn init_terminal() -> Result<(AppTerminal, EventReader), Box<dyn Error>> {
+    let mut output = PlatformTerminal::new()?;
+    output.enter_raw_mode()?;
+
+    let enter_alternate_screen = decset!(ClearAndEnableAlternateScreen);
+    let show_cursor = decset!(ShowCursor);
+    write!(output, "{enter_alternate_screen}{show_cursor}")?;
+    output.flush()?;
+
+    let events = output.event_reader();
+    let backend = TerminaBackend::new(output);
+    let terminal = Terminal::new(backend)?;
+    Ok((terminal, events))
+}
+
+fn run_app(
+    terminal: &mut AppTerminal,
+    events: &EventReader,
+    mut app: App,
+    tick_rate: Duration,
+) -> Result<(), Box<dyn Error>> {
+    let mut last_tick = Instant::now();
+    loop {
+        terminal.draw(|frame| ui::render(frame, &mut app))?;
+
+        let timeout = tick_rate.saturating_sub(last_tick.elapsed());
+        if events.poll(Some(timeout), is_key_event)? {
+            let event = events.read(is_key_event)?;
+            handle_event(&event, &mut app);
+        }
+
+        if last_tick.elapsed() >= tick_rate {
+            app.on_tick();
+            last_tick = Instant::now();
+        }
+        if app.should_quit {
+            return Ok(());
+        }
+    }
+}
+
+fn is_key_event(event: &Event) -> bool {
+    matches!(event, Event::Key(_))
+}
+
+fn handle_event(event: &Event, app: &mut App) {
+    if let Event::Key(key) = event {
+        if key.kind != KeyEventKind::Press {
+            return;
+        }
+        match key.code {
+            KeyCode::Char('k') | KeyCode::Up => app.on_up(),
+            KeyCode::Char('j') | KeyCode::Down => app.on_down(),
+            KeyCode::Char('h') | KeyCode::Left => app.on_left(),
+            KeyCode::Char('l') | KeyCode::Right => app.on_right(),
+            KeyCode::Char(c) => app.on_key(c),
+            _ => {}
+        }
+    }
+}
+
+fn restore_terminal(terminal: &mut AppTerminal) -> Result<(), Box<dyn Error>> {
+    let leave_alternate_screen = decreset!(ClearAndEnableAlternateScreen);
+    let show_cursor = decset!(ShowCursor);
+    let backend = terminal.backend_mut();
+    write!(backend, "{leave_alternate_screen}{show_cursor}")?;
+    backend.flush()?;
+    Ok(())
+}

--- a/examples/apps/release-header/src/main.rs
+++ b/examples/apps/release-header/src/main.rs
@@ -31,9 +31,10 @@ const MAIN_DISHES: [&str; 4] = [
     "> ratatui-widgets",
     "> ratatui-macros",
 ];
-const BACKENDS: [&str; 3] = [
+const BACKENDS: [&str; 4] = [
     "> ratatui-crossterm",
     "> ratatui-termion",
+    "> ratatui-termina",
     "> ratatui-termwiz",
 ];
 

--- a/ratatui-core/src/backend.rs
+++ b/ratatui-core/src/backend.rs
@@ -7,6 +7,7 @@
 //! Supported terminal backends:
 //! - [Crossterm]: enable the `crossterm` feature (enabled by default) and use [`CrosstermBackend`]
 //! - [Termion]: enable the `termion` feature and use [`TermionBackend`]
+//! - [Termina]: enable the `termina` feature and use [`TerminaBackend`]
 //! - [Termwiz]: enable the `termwiz` feature and use [`TermwizBackend`]
 //!
 //! Additionally, a [`TestBackend`] is provided for testing purposes.
@@ -92,10 +93,12 @@
 //!
 //! [`CrosstermBackend`]: https://docs.rs/ratatui/latest/ratatui/backend/struct.CrosstermBackend.html
 //! [`TermionBackend`]: https://docs.rs/ratatui/latest/ratatui/backend/struct.TermionBackend.html
+//! [`TerminaBackend`]: https://docs.rs/ratatui/latest/ratatui/backend/struct.TerminaBackend.html
 //! [`TermwizBackend`]: https://docs.rs/ratatui/latest/ratatui/backend/struct.TermwizBackend.html
 //! [`Terminal`]: https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html
 //! [Crossterm]: https://crates.io/crates/crossterm
 //! [Termion]: https://crates.io/crates/termion
+//! [Termina]: https://crates.io/crates/termina
 //! [Termwiz]: https://crates.io/crates/termwiz
 //! [Examples]: https://github.com/ratatui/ratatui/tree/main/ratatui/examples/README.md
 //! [Backend Comparison]: https://ratatui.rs/concepts/backends/comparison/

--- a/ratatui-termina/Cargo.toml
+++ b/ratatui-termina/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "ratatui-termina"
+version = "0.1.0"
+description = "Termina backend for the Ratatui Terminal UI library."
+documentation = "https://docs.rs/ratatui-termina"
+readme = "README.md"
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+exclude.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = ["underline-color"]
+
+## Reserved for serde compatibility. Termina currently has no serde feature.
+serde = []
+
+## Enables SGR underline-color writes from cell underline colors.
+underline-color = ["ratatui-core/underline-color"]
+
+## Enables terminal scrolling regions for Terminal::insert_before.
+scrolling-regions = ["ratatui-core/scrolling-regions"]
+
+#! The following features are unstable and may change in the future:
+
+## Enable all unstable features.
+unstable = ["unstable-backend-writer"]
+
+## Enables accessors for the wrapped terminal.
+unstable-backend-writer = []
+
+[dependencies]
+document-features = { workspace = true, optional = true }
+instability.workspace = true
+ratatui-core = { workspace = true }
+termina.workspace = true
+
+[dev-dependencies]
+color-eyre.workspace = true
+ratatui = { path = "../ratatui", features = ["termina"], default-features = false }
+rstest.workspace = true
+
+[lints]
+workspace = true

--- a/ratatui-termina/README.md
+++ b/ratatui-termina/README.md
@@ -1,0 +1,21 @@
+# Ratatui Termina Backend
+
+<!-- cargo-rdme start -->
+
+Render Ratatui frames through a [`termina::Terminal`].
+
+[`TerminaBackend`] writes Termina CSI/SGR escape sequences for Ratatui's [`Backend`] contract:
+drawing cells, moving and querying the cursor, clearing regions, flushing output, and reading
+terminal size. It wraps a caller-provided [`termina::Terminal`], so applications can keep using
+Termina's event reader and typed terminal protocol surface alongside Ratatui rendering.
+The Termina crate is re-exported as `ratatui_termina::termina`, so callers can use the same
+Termina types as the backend.
+
+The backend does not enter raw mode, switch to the alternate screen, enable bracketed paste, or
+install cleanup by itself. Configure those terminal modes with Termina before creating the
+backend and restore them when the session ends. The `termina` example in this crate shows the
+direct setup path with a small key-event loop.
+
+[`Backend`]: ratatui_core::backend::Backend
+
+<!-- cargo-rdme end -->

--- a/ratatui-termina/examples/termina.rs
+++ b/ratatui-termina/examples/termina.rs
@@ -1,0 +1,82 @@
+use std::io::Write as _;
+
+use color_eyre::Result;
+use ratatui::style::Stylize;
+use ratatui::widgets::Paragraph;
+use ratatui::{Frame, Terminal};
+use ratatui_termina::TerminaBackend;
+use ratatui_termina::termina::escape::csi::{self, Csi};
+use ratatui_termina::termina::event::{KeyCode, KeyEventKind};
+use ratatui_termina::termina::{Event, EventReader, PlatformTerminal, Terminal as _};
+
+type AppTerminal = Terminal<TerminaBackend<PlatformTerminal>>;
+
+macro_rules! decset {
+    ($mode:ident) => {{
+        let mode = csi::DecPrivateMode::Code(csi::DecPrivateModeCode::$mode);
+        Csi::Mode(csi::Mode::SetDecPrivateMode(mode))
+    }};
+}
+
+macro_rules! decreset {
+    ($mode:ident) => {{
+        let mode = csi::DecPrivateMode::Code(csi::DecPrivateModeCode::$mode);
+        Csi::Mode(csi::Mode::ResetDecPrivateMode(mode))
+    }};
+}
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    let (mut terminal, events) = init_terminal()?;
+    run(&mut terminal, &events)?;
+    restore_terminal(&mut terminal)?;
+    Ok(())
+}
+
+fn init_terminal() -> Result<(AppTerminal, EventReader)> {
+    let mut output = PlatformTerminal::new()?;
+    output.enter_raw_mode()?;
+
+    let enter_alternate_screen = decset!(ClearAndEnableAlternateScreen);
+    let show_cursor = decset!(ShowCursor);
+    write!(output, "{enter_alternate_screen}{show_cursor}")?;
+    output.flush()?;
+
+    let events = output.event_reader();
+    let backend = TerminaBackend::new(output);
+    let terminal = Terminal::new(backend)?;
+    Ok((terminal, events))
+}
+
+fn run(terminal: &mut AppTerminal, events: &EventReader) -> Result<()> {
+    loop {
+        terminal.draw(render)?;
+        if should_quit(&events.read(|event| matches!(event, Event::Key(_)))?) {
+            break;
+        }
+    }
+    Ok(())
+}
+
+fn render(frame: &mut Frame) {
+    let text = "Ratatui + Termina\n\nPress q or Esc to quit";
+    frame.render_widget(Paragraph::new(text).cyan().centered(), frame.area());
+}
+
+fn restore_terminal(terminal: &mut AppTerminal) -> Result<()> {
+    let leave_alternate_screen = decreset!(ClearAndEnableAlternateScreen);
+    let show_cursor = decset!(ShowCursor);
+    let backend = terminal.backend_mut();
+    write!(backend, "{leave_alternate_screen}{show_cursor}")?;
+    backend.flush()?;
+    Ok(())
+}
+
+fn should_quit(event: &Event) -> bool {
+    matches!(
+        event,
+        Event::Key(key)
+            if key.kind == KeyEventKind::Press
+                && matches!(key.code, KeyCode::Char('q') | KeyCode::Escape)
+    )
+}

--- a/ratatui-termina/src/lib.rs
+++ b/ratatui-termina/src/lib.rs
@@ -1,0 +1,822 @@
+// show the feature flags in the generated documentation
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/ratatui/ratatui/main/assets/logo.png",
+    html_favicon_url = "https://raw.githubusercontent.com/ratatui/ratatui/main/assets/favicon.ico"
+)]
+#![warn(missing_docs)]
+//! Render Ratatui frames through a [`termina::Terminal`].
+//!
+//! [`TerminaBackend`] writes Termina CSI/SGR escape sequences for Ratatui's [`Backend`] contract:
+//! drawing cells, moving and querying the cursor, clearing regions, flushing output, and reading
+//! terminal size. It wraps a caller-provided [`termina::Terminal`], so applications can keep using
+//! Termina's event reader and typed terminal protocol surface alongside Ratatui rendering.
+//! The Termina crate is re-exported as `ratatui_termina::termina`, so callers can use the same
+//! Termina types as the backend.
+//!
+//! The backend does not enter raw mode, switch to the alternate screen, enable bracketed paste, or
+//! install cleanup by itself. Configure those terminal modes with Termina before creating the
+//! backend and restore them when the session ends. The `termina` example in this crate shows the
+//! direct setup path with a small key-event loop.
+//!
+//! [`Backend`]: ratatui_core::backend::Backend
+#![cfg_attr(feature = "document-features", doc = "\n## Features")]
+#![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
+
+use std::fmt::{self, Write as FmtWrite};
+use std::io::{self, Write};
+
+use ratatui_core::backend::{Backend, ClearType, WindowSize};
+use ratatui_core::buffer::Cell;
+use ratatui_core::layout::{Position, Size};
+use ratatui_core::style::{Color, Modifier, Style};
+pub use termina;
+use termina::escape::csi::{
+    Csi, Cursor, DecPrivateMode, DecPrivateModeCode, Edit, EraseInDisplay, EraseInLine, Mode, Sgr,
+    SgrAttributes, SgrModifiers,
+};
+use termina::style::{Blink, ColorSpec, Intensity, RgbColor, Underline};
+use termina::{Event, OneBased, Terminal};
+
+macro_rules! decset {
+    ($mode:ident) => {{
+        let mode = DecPrivateMode::Code(DecPrivateModeCode::$mode);
+        Csi::Mode(Mode::SetDecPrivateMode(mode))
+    }};
+}
+
+macro_rules! decreset {
+    ($mode:ident) => {{
+        let mode = DecPrivateMode::Code(DecPrivateModeCode::$mode);
+        Csi::Mode(Mode::ResetDecPrivateMode(mode))
+    }};
+}
+
+/// A [`Backend`] implementation that renders through a [`termina::Terminal`].
+///
+/// `TerminaBackend` writes typed Termina escape sequences for drawing, cursor control, clearing,
+/// and terminal-size queries.
+///
+/// This backend does not automatically enable raw mode or switch to the alternate screen. Use
+/// Termina's terminal APIs and typed escape sequences to configure those application-level modes
+/// before drawing.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use ratatui::Terminal;
+/// use ratatui::backend::TerminaBackend;
+/// use ratatui::termina::{PlatformTerminal, Terminal as _};
+///
+/// let mut output = PlatformTerminal::new()?;
+/// output.enter_raw_mode()?;
+///
+/// let backend = TerminaBackend::new(output);
+/// let mut terminal = Terminal::new(backend)?;
+///
+/// terminal.draw(|frame| {
+///     // -- snip --
+/// })?;
+/// # std::io::Result::Ok(())
+/// ```
+pub struct TerminaBackend<T>
+where
+    T: Terminal,
+{
+    terminal: T,
+}
+
+impl<T> TerminaBackend<T>
+where
+    T: Terminal,
+{
+    /// Creates a backend that writes to the given Termina terminal.
+    pub const fn new(terminal: T) -> Self {
+        Self { terminal }
+    }
+
+    /// Returns the wrapped terminal.
+    #[instability::unstable(
+        feature = "backend-writer",
+        issue = "https://github.com/ratatui/ratatui/pull/991"
+    )]
+    pub const fn terminal(&self) -> &T {
+        &self.terminal
+    }
+
+    /// Returns the wrapped terminal as a mutable reference.
+    ///
+    /// Direct writes can desynchronize Ratatui's diffing buffers from the visible terminal. Clear
+    /// the terminal or force a full redraw before relying on Ratatui's next diff.
+    #[instability::unstable(
+        feature = "backend-writer",
+        issue = "https://github.com/ratatui/ratatui/pull/991"
+    )]
+    pub const fn terminal_mut(&mut self) -> &mut T {
+        &mut self.terminal
+    }
+}
+
+impl<T> Write for TerminaBackend<T>
+where
+    T: Terminal,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.terminal.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.terminal.flush()
+    }
+}
+
+impl<T> Backend for TerminaBackend<T>
+where
+    T: Terminal,
+{
+    type Error = io::Error;
+
+    fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
+    where
+        I: Iterator<Item = (u16, u16, &'a Cell)>,
+    {
+        let mut string = String::with_capacity(content.size_hint().0 * 3);
+        let mut fg = Color::Reset;
+        let mut bg = Color::Reset;
+        #[cfg(feature = "underline-color")]
+        let mut underline_color = Color::Reset;
+        let mut modifier = Modifier::empty();
+        let mut last_pos: Option<Position> = None;
+        for (x, y, cell) in content {
+            if !matches!(last_pos, Some(p) if x == p.x + 1 && y == p.y) {
+                let command = Csi::Cursor(cursor_position(Position { x, y })?);
+                write!(string, "{command}").unwrap();
+            }
+            last_pos = Some(Position { x, y });
+
+            let mut attributes = SgrAttributes::default();
+            if cell.fg != fg {
+                attributes.foreground = Some(cell.fg.into_termina());
+                fg = cell.fg;
+            }
+            if cell.bg != bg {
+                attributes.background = Some(cell.bg.into_termina());
+                bg = cell.bg;
+            }
+            #[cfg(feature = "underline-color")]
+            if cell.underline_color != underline_color {
+                attributes.underline_color = Some(cell.underline_color.into_termina());
+                underline_color = cell.underline_color;
+            }
+            if cell.modifier != modifier {
+                attributes.modifiers = ModifierDiff {
+                    from: modifier,
+                    to: cell.modifier,
+                }
+                .into_termina();
+                modifier = cell.modifier;
+            }
+            if !attributes.is_empty() {
+                write!(string, "{}", Csi::Sgr(Sgr::Attributes(attributes))).unwrap();
+            }
+
+            string.push_str(cell.symbol());
+        }
+
+        write!(self.terminal, "{string}{}", Csi::Sgr(Sgr::Reset))
+    }
+
+    fn hide_cursor(&mut self) -> io::Result<()> {
+        let command = decreset!(ShowCursor);
+        write!(self.terminal, "{command}")?;
+        self.terminal.flush()
+    }
+
+    fn show_cursor(&mut self) -> io::Result<()> {
+        let command = decset!(ShowCursor);
+        write!(self.terminal, "{command}")?;
+        self.terminal.flush()
+    }
+
+    fn get_cursor_position(&mut self) -> io::Result<Position> {
+        let command = Csi::Cursor(Cursor::RequestActivePositionReport);
+        write!(self.terminal, "{command}")?;
+        self.terminal.flush()?;
+        let event = self.terminal.read(|event| {
+            matches!(
+                event,
+                Event::Csi(Csi::Cursor(Cursor::ActivePositionReport { .. }))
+            )
+        })?;
+        let Event::Csi(Csi::Cursor(Cursor::ActivePositionReport { line, col })) = event else {
+            return Err(io::Error::other(
+                "termina returned a non-cursor-position event",
+            ));
+        };
+        Ok(Position {
+            x: col.get_zero_based(),
+            y: line.get_zero_based(),
+        })
+    }
+
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+        let command = Csi::Cursor(cursor_position(position.into())?);
+        write!(self.terminal, "{command}")?;
+        self.terminal.flush()
+    }
+
+    fn clear(&mut self) -> io::Result<()> {
+        self.clear_region(ClearType::All)
+    }
+
+    fn clear_region(&mut self, clear_type: ClearType) -> io::Result<()> {
+        let edit = match clear_type {
+            ClearType::All => Edit::EraseInDisplay(EraseInDisplay::EraseDisplay),
+            ClearType::AfterCursor => Edit::EraseInDisplay(EraseInDisplay::EraseToEndOfDisplay),
+            ClearType::BeforeCursor => Edit::EraseInDisplay(EraseInDisplay::EraseToStartOfDisplay),
+            ClearType::CurrentLine => Edit::EraseInLine(EraseInLine::EraseLine),
+            ClearType::UntilNewLine => Edit::EraseInLine(EraseInLine::EraseToEndOfLine),
+        };
+        let command = Csi::Edit(edit);
+        write!(self.terminal, "{command}")?;
+        self.terminal.flush()
+    }
+
+    fn append_lines(&mut self, n: u16) -> io::Result<()> {
+        for _ in 0..n {
+            writeln!(self.terminal)?;
+        }
+        self.terminal.flush()
+    }
+
+    fn size(&self) -> io::Result<Size> {
+        let size = self.terminal.get_dimensions()?;
+        Ok(Size::new(size.cols, size.rows))
+    }
+
+    fn window_size(&mut self) -> io::Result<WindowSize> {
+        let size = self.terminal.get_dimensions()?;
+        Ok(WindowSize {
+            columns_rows: Size::new(size.cols, size.rows),
+            pixels: Size::new(
+                size.pixel_width.unwrap_or_default(),
+                size.pixel_height.unwrap_or_default(),
+            ),
+        })
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.terminal.flush()
+    }
+
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_up(&mut self, region: std::ops::Range<u16>, amount: u16) -> io::Result<()> {
+        let margins = Csi::Cursor(set_top_and_bottom_margins(region)?);
+        let scroll = Csi::Edit(Edit::ScrollUp(amount.into()));
+        let reset = Csi::Cursor(reset_top_and_bottom_margins());
+        write!(self.terminal, "{margins}{scroll}{reset}")?;
+        self.terminal.flush()
+    }
+
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_down(&mut self, region: std::ops::Range<u16>, amount: u16) -> io::Result<()> {
+        let margins = Csi::Cursor(set_top_and_bottom_margins(region)?);
+        let scroll = Csi::Edit(Edit::ScrollDown(amount.into()));
+        let reset = Csi::Cursor(reset_top_and_bottom_margins());
+        write!(self.terminal, "{margins}{scroll}{reset}")?;
+        self.terminal.flush()
+    }
+}
+
+fn cursor_position(position: Position) -> io::Result<Cursor> {
+    Ok(Cursor::Position {
+        line: one_based(position.y)?,
+        col: one_based(position.x)?,
+    })
+}
+
+fn one_based(n: u16) -> io::Result<OneBased> {
+    n.checked_add(1)
+        .and_then(OneBased::new)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "position exceeds u16::MAX - 1"))
+}
+
+#[cfg(feature = "scrolling-regions")]
+fn set_top_and_bottom_margins(region: std::ops::Range<u16>) -> io::Result<Cursor> {
+    Ok(Cursor::SetTopAndBottomMargins {
+        top: one_based(region.start)?,
+        bottom: OneBased::new(region.end).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "scroll region end cannot be 0")
+        })?,
+    })
+}
+
+#[cfg(feature = "scrolling-regions")]
+const fn reset_top_and_bottom_margins() -> Cursor {
+    Cursor::SetTopAndBottomMargins {
+        top: OneBased::from_zero_based(0),
+        bottom: OneBased::new(u16::MAX).expect("u16::MAX is non-zero"),
+    }
+}
+
+/// A trait for converting a Ratatui type to a Termina type.
+pub trait IntoTermina<T> {
+    /// Converts the ratatui type to a Termina type.
+    fn into_termina(self) -> T;
+}
+
+/// A trait for converting a Termina type to a Ratatui type.
+pub trait FromTermina<T> {
+    /// Converts the Termina type to a ratatui type.
+    fn from_termina(value: T) -> Self;
+}
+
+struct ModifierDiff {
+    from: Modifier,
+    to: Modifier,
+}
+
+impl IntoTermina<ColorSpec> for Color {
+    fn into_termina(self) -> ColorSpec {
+        match self {
+            Self::Reset => ColorSpec::Reset,
+            Self::Black => ColorSpec::BLACK,
+            Self::Red => ColorSpec::RED,
+            Self::Green => ColorSpec::GREEN,
+            Self::Yellow => ColorSpec::YELLOW,
+            Self::Blue => ColorSpec::BLUE,
+            Self::Magenta => ColorSpec::MAGENTA,
+            Self::Cyan => ColorSpec::CYAN,
+            Self::Gray => ColorSpec::WHITE,
+            Self::DarkGray => ColorSpec::BRIGHT_BLACK,
+            Self::LightRed => ColorSpec::BRIGHT_RED,
+            Self::LightGreen => ColorSpec::BRIGHT_GREEN,
+            Self::LightYellow => ColorSpec::BRIGHT_YELLOW,
+            Self::LightBlue => ColorSpec::BRIGHT_BLUE,
+            Self::LightMagenta => ColorSpec::BRIGHT_MAGENTA,
+            Self::LightCyan => ColorSpec::BRIGHT_CYAN,
+            Self::White => ColorSpec::BRIGHT_WHITE,
+            Self::Indexed(i) => ColorSpec::PaletteIndex(i),
+            Self::Rgb(r, g, b) => ColorSpec::TrueColor(RgbColor::new(r, g, b).into()),
+        }
+    }
+}
+
+impl IntoTermina<SgrAttributes> for Style {
+    fn into_termina(self) -> SgrAttributes {
+        SgrAttributes {
+            foreground: self.fg.map(IntoTermina::into_termina),
+            background: self.bg.map(IntoTermina::into_termina),
+            #[cfg(feature = "underline-color")]
+            underline_color: self.underline_color.map(IntoTermina::into_termina),
+            modifiers: ModifierDiff {
+                from: self.sub_modifier,
+                to: self.add_modifier,
+            }
+            .into_termina(),
+            ..Default::default()
+        }
+    }
+}
+
+impl FromTermina<ColorSpec> for Color {
+    fn from_termina(value: ColorSpec) -> Self {
+        match value {
+            ColorSpec::Reset => Self::Reset,
+            ColorSpec::PaletteIndex(i) => match i {
+                0 => Self::Black,
+                1 => Self::Red,
+                2 => Self::Green,
+                3 => Self::Yellow,
+                4 => Self::Blue,
+                5 => Self::Magenta,
+                6 => Self::Cyan,
+                7 => Self::Gray,
+                8 => Self::DarkGray,
+                9 => Self::LightRed,
+                10 => Self::LightGreen,
+                11 => Self::LightYellow,
+                12 => Self::LightBlue,
+                13 => Self::LightMagenta,
+                14 => Self::LightCyan,
+                15 => Self::White,
+                _ => Self::Indexed(i),
+            },
+            ColorSpec::TrueColor(color) => Self::Rgb(color.red, color.green, color.blue),
+        }
+    }
+}
+
+impl IntoTermina<SgrModifiers> for ModifierDiff {
+    fn into_termina(self) -> SgrModifiers {
+        let removed = self.from - self.to;
+        let added = self.to - self.from;
+        let mut modifiers = SgrModifiers::empty();
+
+        if removed.contains(Modifier::BOLD) || removed.contains(Modifier::DIM) {
+            modifiers |= SgrModifiers::INTENSITY_NORMAL;
+        }
+        if removed.contains(Modifier::ITALIC) {
+            modifiers |= SgrModifiers::NO_ITALIC;
+        }
+        if removed.contains(Modifier::UNDERLINED) {
+            modifiers |= SgrModifiers::UNDERLINE_NONE;
+        }
+        if removed.contains(Modifier::SLOW_BLINK) || removed.contains(Modifier::RAPID_BLINK) {
+            modifiers |= SgrModifiers::BLINK_NONE;
+        }
+        if removed.contains(Modifier::REVERSED) {
+            modifiers |= SgrModifiers::NO_REVERSE;
+        }
+        if removed.contains(Modifier::HIDDEN) {
+            modifiers |= SgrModifiers::NO_INVISIBLE;
+        }
+        if removed.contains(Modifier::CROSSED_OUT) {
+            modifiers |= SgrModifiers::NO_STRIKE_THROUGH;
+        }
+
+        if added.contains(Modifier::BOLD) {
+            modifiers |= SgrModifiers::INTENSITY_BOLD;
+        }
+        if added.contains(Modifier::DIM) {
+            modifiers |= SgrModifiers::INTENSITY_DIM;
+        }
+        if added.contains(Modifier::ITALIC) {
+            modifiers |= SgrModifiers::ITALIC;
+        }
+        if added.contains(Modifier::UNDERLINED) {
+            modifiers |= SgrModifiers::UNDERLINE_SINGLE;
+        }
+        if added.contains(Modifier::SLOW_BLINK) {
+            modifiers |= SgrModifiers::BLINK_SLOW;
+        }
+        if added.contains(Modifier::RAPID_BLINK) {
+            modifiers |= SgrModifiers::BLINK_RAPID;
+        }
+        if added.contains(Modifier::REVERSED) {
+            modifiers |= SgrModifiers::REVERSE;
+        }
+        if added.contains(Modifier::HIDDEN) {
+            modifiers |= SgrModifiers::INVISIBLE;
+        }
+        if added.contains(Modifier::CROSSED_OUT) {
+            modifiers |= SgrModifiers::STRIKE_THROUGH;
+        }
+
+        modifiers
+    }
+}
+
+impl FromTermina<Intensity> for Modifier {
+    fn from_termina(value: Intensity) -> Self {
+        match value {
+            Intensity::Normal => Self::empty(),
+            Intensity::Bold => Self::BOLD,
+            Intensity::Dim => Self::DIM,
+        }
+    }
+}
+
+impl FromTermina<Underline> for Modifier {
+    fn from_termina(value: Underline) -> Self {
+        match value {
+            Underline::None => Self::empty(),
+            _ => Self::UNDERLINED,
+        }
+    }
+}
+
+impl FromTermina<Blink> for Modifier {
+    fn from_termina(value: Blink) -> Self {
+        match value {
+            Blink::None => Self::empty(),
+            Blink::Slow => Self::SLOW_BLINK,
+            Blink::Rapid => Self::RAPID_BLINK,
+        }
+    }
+}
+
+impl<T> fmt::Debug for TerminaBackend<T>
+where
+    T: Terminal + fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TerminaBackend")
+            .field("terminal", &self.terminal)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use ratatui_core::buffer::Cell;
+    use termina::EventReader;
+    use termina::escape::csi::Csi;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct MockTerminal {
+        output: Vec<u8>,
+        size: termina::WindowSize,
+        events: Vec<Event>,
+    }
+
+    impl MockTerminal {
+        fn new() -> Self {
+            Self {
+                output: Vec::new(),
+                size: termina::WindowSize {
+                    cols: 80,
+                    rows: 24,
+                    pixel_width: Some(800),
+                    pixel_height: Some(480),
+                },
+                events: Vec::new(),
+            }
+        }
+
+        fn with_event(mut self, event: Event) -> Self {
+            self.events.push(event);
+            self
+        }
+
+        fn output(&self) -> String {
+            String::from_utf8_lossy(&self.output).into_owned()
+        }
+    }
+
+    impl Write for MockTerminal {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.output.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Terminal for MockTerminal {
+        fn enter_raw_mode(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn enter_cooked_mode(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn get_dimensions(&self) -> io::Result<termina::WindowSize> {
+            Ok(self.size)
+        }
+
+        fn event_reader(&self) -> EventReader {
+            unimplemented!("backend tests do not use event_reader")
+        }
+
+        fn poll<F: Fn(&Event) -> bool>(
+            &self,
+            filter: F,
+            _timeout: Option<Duration>,
+        ) -> io::Result<bool> {
+            Ok(self.events.iter().any(filter))
+        }
+
+        fn read<F: Fn(&Event) -> bool>(&self, filter: F) -> io::Result<Event> {
+            self.events
+                .iter()
+                .find(|event| filter(event))
+                .cloned()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::WouldBlock, "no matching event"))
+        }
+
+        fn set_panic_hook(
+            &mut self,
+            _f: impl Fn(&mut termina::PlatformHandle) + Send + Sync + 'static,
+        ) {
+        }
+    }
+
+    fn backend() -> TerminaBackend<MockTerminal> {
+        TerminaBackend::new(MockTerminal::new())
+    }
+
+    #[test]
+    fn writes_cursor_visibility_commands() {
+        let mut backend = backend();
+        backend.hide_cursor().unwrap();
+        backend.show_cursor().unwrap();
+
+        let hide_cursor = decreset!(ShowCursor);
+        let show_cursor = decset!(ShowCursor);
+        assert_eq!(
+            backend.terminal.output(),
+            format!("{hide_cursor}{show_cursor}")
+        );
+    }
+
+    #[test]
+    fn reads_cursor_position_reports() {
+        let event = Event::Csi(Csi::Cursor(Cursor::ActivePositionReport {
+            line: OneBased::new(5).unwrap(),
+            col: OneBased::new(7).unwrap(),
+        }));
+        let mut backend = TerminaBackend::new(MockTerminal::new().with_event(event));
+
+        assert_eq!(backend.get_cursor_position().unwrap(), Position::new(6, 4));
+        let request = Csi::Cursor(Cursor::RequestActivePositionReport);
+        assert_eq!(backend.terminal.output(), request.to_string());
+    }
+
+    #[test]
+    fn rejects_non_cursor_position_reports() {
+        let event = Event::FocusIn;
+        let mut backend = TerminaBackend::new(MockTerminal::new().with_event(event));
+
+        let error = backend.get_cursor_position().unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+    }
+
+    #[test]
+    fn sets_cursor_position() {
+        let mut backend = backend();
+        backend.set_cursor_position(Position::new(3, 4)).unwrap();
+
+        let position = Cursor::Position {
+            line: OneBased::new(5).unwrap(),
+            col: OneBased::new(4).unwrap(),
+        };
+        assert_eq!(backend.terminal.output(), Csi::Cursor(position).to_string());
+    }
+
+    #[test]
+    fn rejects_cursor_position_overflow() {
+        let mut backend = backend();
+
+        let error = backend.set_cursor_position(Position::new(u16::MAX, 0));
+        assert_eq!(error.unwrap_err().kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn clears_regions() {
+        let mut backend = backend();
+        backend.clear_region(ClearType::All).unwrap();
+        backend.clear_region(ClearType::AfterCursor).unwrap();
+        backend.clear_region(ClearType::BeforeCursor).unwrap();
+        backend.clear_region(ClearType::CurrentLine).unwrap();
+        backend.clear_region(ClearType::UntilNewLine).unwrap();
+
+        let expected = [
+            Csi::Edit(Edit::EraseInDisplay(EraseInDisplay::EraseDisplay)),
+            Csi::Edit(Edit::EraseInDisplay(EraseInDisplay::EraseToEndOfDisplay)),
+            Csi::Edit(Edit::EraseInDisplay(EraseInDisplay::EraseToStartOfDisplay)),
+            Csi::Edit(Edit::EraseInLine(EraseInLine::EraseLine)),
+            Csi::Edit(Edit::EraseInLine(EraseInLine::EraseToEndOfLine)),
+        ]
+        .into_iter()
+        .map(|command| command.to_string())
+        .collect::<String>();
+        assert_eq!(backend.terminal.output(), expected);
+    }
+
+    #[test]
+    fn reports_terminal_size() {
+        let mut backend = backend();
+
+        assert_eq!(backend.size().unwrap(), Size::new(80, 24));
+        assert_eq!(
+            backend.window_size().unwrap(),
+            WindowSize {
+                columns_rows: Size::new(80, 24),
+                pixels: Size::new(800, 480),
+            }
+        );
+    }
+
+    #[test]
+    fn appends_lines() {
+        let mut backend = backend();
+        backend.append_lines(3).unwrap();
+
+        assert_eq!(backend.terminal.output(), "\n\n\n");
+    }
+
+    #[test]
+    fn draws_cells_with_grouped_sgr_attributes() {
+        let mut backend = backend();
+        let mut cell = Cell::new("x");
+        cell.set_style(
+            Style::new()
+                .fg(Color::Red)
+                .bg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+        );
+        let content = [(2, 3, &cell)];
+
+        backend.draw(content.into_iter()).unwrap();
+
+        let output = backend.terminal.output();
+        let cursor = Csi::Cursor(cursor_position(Position::new(2, 3)).unwrap());
+        assert!(output.starts_with(&cursor.to_string()));
+        assert!(output.contains('x'));
+        assert!(output.ends_with(&Csi::Sgr(Sgr::Reset).to_string()));
+    }
+
+    #[test]
+    fn converts_ratatui_colors_to_termina_colors() {
+        assert_eq!(Color::Reset.into_termina(), ColorSpec::Reset);
+        assert_eq!(Color::Red.into_termina(), ColorSpec::RED);
+        assert_eq!(
+            Color::Indexed(42).into_termina(),
+            ColorSpec::PaletteIndex(42)
+        );
+        assert_eq!(
+            Color::Rgb(1, 2, 3).into_termina(),
+            ColorSpec::TrueColor(RgbColor::new(1, 2, 3).into())
+        );
+    }
+
+    #[test]
+    fn converts_termina_colors_to_ratatui_colors() {
+        assert_eq!(Color::from_termina(ColorSpec::Reset), Color::Reset);
+        assert_eq!(Color::from_termina(ColorSpec::PaletteIndex(1)), Color::Red);
+        assert_eq!(
+            Color::from_termina(ColorSpec::TrueColor(RgbColor::new(1, 2, 3).into())),
+            Color::Rgb(1, 2, 3)
+        );
+    }
+
+    #[test]
+    fn converts_modifier_diffs_to_sgr_modifiers() {
+        let from = Modifier::BOLD | Modifier::ITALIC | Modifier::UNDERLINED;
+        let to = Modifier::DIM | Modifier::REVERSED | Modifier::CROSSED_OUT;
+        let modifiers = ModifierDiff { from, to }.into_termina();
+
+        assert!(modifiers.contains(SgrModifiers::INTENSITY_NORMAL));
+        assert!(modifiers.contains(SgrModifiers::NO_ITALIC));
+        assert!(modifiers.contains(SgrModifiers::UNDERLINE_NONE));
+        assert!(modifiers.contains(SgrModifiers::INTENSITY_DIM));
+        assert!(modifiers.contains(SgrModifiers::REVERSE));
+        assert!(modifiers.contains(SgrModifiers::STRIKE_THROUGH));
+    }
+
+    #[test]
+    fn converts_termina_modifiers_to_ratatui_modifiers() {
+        assert_eq!(Modifier::from_termina(Intensity::Normal), Modifier::empty());
+        assert_eq!(Modifier::from_termina(Intensity::Bold), Modifier::BOLD);
+        assert_eq!(Modifier::from_termina(Underline::None), Modifier::empty());
+        assert_eq!(
+            Modifier::from_termina(Underline::Single),
+            Modifier::UNDERLINED
+        );
+        assert_eq!(Modifier::from_termina(Blink::None), Modifier::empty());
+        assert_eq!(Modifier::from_termina(Blink::Rapid), Modifier::RAPID_BLINK);
+    }
+
+    #[cfg(feature = "scrolling-regions")]
+    #[test]
+    fn scrolls_regions() {
+        let mut backend = backend();
+        backend.scroll_region_up(1..4, 2).unwrap();
+        backend.scroll_region_down(1..4, 3).unwrap();
+
+        let margins = Cursor::SetTopAndBottomMargins {
+            top: OneBased::new(2).unwrap(),
+            bottom: OneBased::new(4).unwrap(),
+        };
+        let reset = reset_top_and_bottom_margins();
+        let up = Csi::Edit(Edit::ScrollUp(2_u16.into()));
+        let down = Csi::Edit(Edit::ScrollDown(3_u16.into()));
+        let expected = format!(
+            "{}{up}{}{}{down}{}",
+            Csi::Cursor(margins.clone()),
+            Csi::Cursor(reset.clone()),
+            Csi::Cursor(margins),
+            Csi::Cursor(reset)
+        );
+        assert_eq!(backend.terminal.output(), expected);
+    }
+
+    #[cfg(feature = "scrolling-regions")]
+    #[test]
+    fn rejects_zero_ended_scroll_regions() {
+        let mut backend = backend();
+
+        let error = backend.scroll_region_up(0..0, 1).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn csi_helpers_use_one_based_coordinates() {
+        assert_eq!(
+            cursor_position(Position::new(1, 2)).unwrap(),
+            Cursor::Position {
+                line: OneBased::new(3).unwrap(),
+                col: OneBased::new(2).unwrap(),
+            }
+        );
+        assert_eq!(one_based(0).unwrap(), OneBased::new(1).unwrap());
+    }
+}

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -37,6 +37,8 @@ crossterm_0_28 = ["crossterm", "ratatui-crossterm/crossterm_0_28"]
 crossterm_0_29 = ["crossterm", "ratatui-crossterm/crossterm_0_29"]
 ## enables the [`TermionBackend`](backend::TermionBackend) backend and adds a dependency on [`termion`].
 termion = ["dep:ratatui-termion", "std"]
+## enables the [`TerminaBackend`](backend::TerminaBackend) backend and adds a dependency on [`termina`].
+termina = ["dep:ratatui-termina", "std"]
 ## enables the [`TermwizBackend`](backend::TermwizBackend) backend and adds a dependency on [`termwiz`].
 termwiz = ["dep:ratatui-termwiz", "std"]
 
@@ -50,6 +52,7 @@ serde = [
   "dep:serde",
   "ratatui-core/serde",
   "ratatui-crossterm?/serde",
+  "ratatui-termina?/serde",
   "ratatui-termion?/serde",
   "ratatui-termwiz?/serde",
   "ratatui-widgets/serde",
@@ -69,6 +72,7 @@ portable-atomic = ["ratatui-core/portable-atomic"]
 scrolling-regions = [
   "ratatui-core/scrolling-regions",
   "ratatui-crossterm?/scrolling-regions",
+  "ratatui-termina?/scrolling-regions",
   "ratatui-termion?/scrolling-regions",
   "ratatui-termwiz?/scrolling-regions",
 ]
@@ -88,11 +92,12 @@ widget-calendar = ["ratatui-widgets/calendar"]
 #! The following optional features are only available for some backends:
 
 ## Enables the backend code that sets the underline color.
-## Underline color is only supported by the Crossterm and Termwiz backends, and is not supported on
-## Windows 7.
+## Underline color is only supported by the Crossterm, Termina, and Termwiz backends, and is not
+## supported on Windows 7.
 underline-color = [
   "ratatui-core/underline-color",
   "ratatui-crossterm?/underline-color",
+  "ratatui-termina?/underline-color",
   "ratatui-termwiz?/underline-color",
 ]
 
@@ -117,6 +122,7 @@ unstable-widget-ref = []
 ## Enables getting access to backends' writers.
 unstable-backend-writer = [
   "ratatui-crossterm?/unstable-backend-writer",
+  "ratatui-termina?/unstable-backend-writer",
   "ratatui-termion?/unstable-backend-writer",
 ]
 
@@ -127,6 +133,7 @@ palette = { workspace = true, optional = true }
 ratatui-core = { workspace = true }
 ratatui-crossterm = { workspace = true, optional = true }
 ratatui-macros = { workspace = true, optional = true }
+ratatui-termina = { workspace = true, optional = true }
 ratatui-termwiz = { workspace = true, optional = true }
 ratatui-widgets = { workspace = true }
 serde = { workspace = true, optional = true }

--- a/ratatui/src/lib.rs
+++ b/ratatui/src/lib.rs
@@ -80,8 +80,8 @@
 //! - [`ratatui-core`] for widget libraries, custom integrations, and lower-level rendering
 //!   contracts
 //! - [`ratatui-widgets`] when you only need the built-in widgets crate as a dependency
-//! - [`ratatui-crossterm`], [`ratatui-termion`], or [`ratatui-termwiz`] when you need to select and
-//!   depend on a backend crate directly
+//! - [`ratatui-crossterm`], [`ratatui-termion`], [`ratatui-termina`], or [`ratatui-termwiz`] when
+//!   your application needs backend-specific APIs or a direct backend dependency
 //!
 //! # Other documentation
 //!
@@ -116,7 +116,8 @@
 //! - **[`ratatui`](crate)**: Main crate with complete functionality (recommended for apps)
 //! - **[`ratatui-core`]**: Core traits and types for widget libraries
 //! - **[`ratatui-widgets`]**: Built-in widget implementations
-//! - **Backend crates**: [`ratatui-crossterm`], [`ratatui-termion`], [`ratatui-termwiz`]
+//! - **Backend crates**: [`ratatui-crossterm`], [`ratatui-termion`], [`ratatui-termina`],
+//!   [`ratatui-termwiz`]
 //! - **[`ratatui-macros`]**: Macros for simplifying the boilerplate
 //!
 //! **For application developers**: `ratatui` remains the recommended starting point.
@@ -434,6 +435,7 @@
 //! [`ratatui-widgets`]: https://crates.io/crates/ratatui-widgets
 //! [`ratatui-crossterm`]: https://crates.io/crates/ratatui-crossterm
 //! [`ratatui-termion`]: https://crates.io/crates/ratatui-termion
+//! [`ratatui-termina`]: https://crates.io/crates/ratatui-termina
 //! [`ratatui-termwiz`]: https://crates.io/crates/ratatui-termwiz
 //! [`ratatui-macros`]: https://crates.io/crates/ratatui-macros
 //! [ARCHITECTURE.md]: https://github.com/ratatui/ratatui/blob/main/ARCHITECTURE.md
@@ -458,6 +460,7 @@
 //! [`ratatui-widgets`]: https://crates.io/crates/ratatui-widgets
 //! [`ratatui-crossterm`]: https://crates.io/crates/ratatui-crossterm
 //! [`ratatui-termion`]: https://crates.io/crates/ratatui-termion
+//! [`ratatui-termina`]: https://crates.io/crates/ratatui-termina
 //! [`ratatui-termwiz`]: https://crates.io/crates/ratatui-termwiz
 //! [`ratatui-macros`]: https://crates.io/crates/ratatui-macros
 //! [ARCHITECTURE.md]: https://github.com/ratatui/ratatui/blob/main/ARCHITECTURE.md
@@ -480,6 +483,9 @@ pub use ratatui_core::{buffer, layout};
 pub use ratatui_crossterm::crossterm;
 #[cfg(feature = "macros")]
 pub use ratatui_macros as macros;
+/// re-export the `termina` crate so that users don't have to add it as a dependency
+#[cfg(feature = "termina")]
+pub use ratatui_termina::termina;
 /// re-export the `termion` crate so that users don't have to add it as a dependency
 #[cfg(all(not(windows), feature = "termion"))]
 pub use ratatui_termion::termion;
@@ -499,6 +505,8 @@ pub mod backend {
     pub use ratatui_core::backend::{Backend, ClearType, TestBackend, WindowSize};
     #[cfg(feature = "crossterm")]
     pub use ratatui_crossterm::{CrosstermBackend, FromCrossterm, IntoCrossterm};
+    #[cfg(feature = "termina")]
+    pub use ratatui_termina::{FromTermina, IntoTermina, TerminaBackend};
     #[cfg(all(not(windows), feature = "termion"))]
     pub use ratatui_termion::{FromTermion, IntoTermion, TermionBackend};
     #[cfg(feature = "termwiz")]

--- a/ratatui/src/prelude.rs
+++ b/ratatui/src/prelude.rs
@@ -32,6 +32,8 @@ pub use ratatui_core::backend::{self, Backend};
 #[cfg(feature = "crossterm")]
 pub use ratatui_crossterm::{CrosstermBackend, FromCrossterm, IntoCrossterm};
 
+#[cfg(feature = "termina")]
+pub use crate::backend::{FromTermina, IntoTermina, TerminaBackend};
 #[cfg(all(not(windows), feature = "termion"))]
 pub use crate::backend::{FromTermion, IntoTermion, TermionBackend};
 #[cfg(feature = "termwiz")]

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -152,7 +152,12 @@ fn lint_markdown() -> Result<()> {
 /// Run tests for libs, backends, and docs
 fn test() -> Result<()> {
     test_libs()?;
-    for backend in [Backend::Crossterm, Backend::Termion, Backend::Termwiz] {
+    for backend in [
+        Backend::Crossterm,
+        Backend::Termion,
+        Backend::Termina,
+        Backend::Termwiz,
+    ] {
         TestBackend { backend }.run()?;
     }
     test_docs::test_docs()?; // run last because it's slow

--- a/xtask/src/commands/backend.rs
+++ b/xtask/src/commands/backend.rs
@@ -21,6 +21,7 @@ pub struct TestBackend {
 pub enum Backend {
     Crossterm,
     Termion,
+    Termina,
     Termwiz,
 }
 
@@ -32,6 +33,7 @@ impl Run for CheckBackend {
         let backend = match self.backend {
             Backend::Crossterm => "crossterm",
             Backend::Termion => "termion",
+            Backend::Termina => "termina",
             Backend::Termwiz => "termwiz",
         };
         run_cargo(vec![
@@ -52,6 +54,7 @@ impl Run for TestBackend {
         let backend = match self.backend {
             Backend::Crossterm => "crossterm",
             Backend::Termion => "termion",
+            Backend::Termina => "termina",
             Backend::Termwiz => "termwiz",
         };
         // This is a temporary hack to run tests both with and without layout cache.

--- a/xtask/src/commands/rdme.rs
+++ b/xtask/src/commands/rdme.rs
@@ -19,6 +19,7 @@ const PROJECTS: &[&str] = &[
     "ratatui-crossterm",
     "ratatui-macros",
     "ratatui-termion",
+    "ratatui-termina",
     "ratatui-termwiz",
     "ratatui-widgets",
 ];


### PR DESCRIPTION
## Summary

- add the `ratatui-termina` backend crate using the published `termina` crate
- expose the backend through the `termina` feature and Ratatui prelude/backend re-exports
- add a small Termina event-loop example and wire the backend into CI, xtask, README generation, and docs

Refs #1784

## Validation

- `cargo +nightly fmt`
- `cargo check -p ratatui-termina --all-features --all-targets`
- `cargo check -p ratatui --no-default-features --features termina`
- `cargo check -p xtask`
- `cargo check -p release-header`
- `cargo xtask check-backend termina`
- `cargo xtask test-backend termina`
- `cargo xtask rdme --check`
- `markdownlint-cli2 ARCHITECTURE.md ratatui-termina/README.md .github/ISSUE_TEMPLATE/bug_report.md`
