### PR TITLE
fix: satisfy beta Clippy buffer debug lint

### DIFF
--- a/ratatui-core/src/buffer/buffer.rs
+++ b/ratatui-core/src/buffer/buffer.rs
@@ -575,7 +575,7 @@ impl fmt::Debug for Buffer {
     /// * `styles`: displayed as a list of: `{ x: 1, y: 2, fg: Color::Red, bg: Color::Blue,
     ///   modifier: Modifier::BOLD }` only showing a value when there is a change in style.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_fmt(format_args!("Buffer {{\n    area: {:?}", &self.area))?;
+        f.write_fmt(format_args!("Buffer {{\n    area: {:?}", self.area))?;
 
         if self.area.is_empty() {
             return f.write_str("\n}");


### PR DESCRIPTION
## Summary

- remove a redundant borrow in `Buffer`'s `Debug` implementation
- keep the change separate from #2561 because the beta Clippy failure is unrelated to the Termina backend diff

## Validation

- `cargo +beta clippy --package ratatui-crossterm --no-default-features --features serde,underline-color,scrolling-regions,unstable,unstable-backend-writer,crossterm_0_28 -- -D warnings`
- `cargo +nightly fmt --check`
