### PR TITLE
fix(buffer): preserve cells by position when resizing

### DIFF
--- a/ratatui-core/src/buffer/buffer.rs
+++ b/ratatui-core/src/buffer/buffer.rs
@@ -412,15 +412,28 @@ impl Buffer {
         }
     }
 
-    /// Resize the buffer so that the mapped area matches the given area and that the buffer
-    /// length is equal to area.width * area.height
+    /// Resize the buffer so that the mapped area matches the given area and the buffer
+    /// length is equal to area.width * area.height.
+    ///
+    /// Cells that overlap between the old and new areas are preserved at the same global
+    /// coordinates. New cells are initialized as empty.
     pub fn resize(&mut self, area: Rect) {
-        let length = area.area() as usize;
-        if self.content.len() > length {
-            self.content.truncate(length);
-        } else {
-            self.content.resize(length, Cell::EMPTY);
+        if self.area == area {
+            return;
         }
+
+        let old_area = self.area;
+        let old_content =
+            core::mem::replace(&mut self.content, vec![Cell::EMPTY; area.area() as usize]);
+        let preserved_area = old_area.intersection(area);
+
+        for position in preserved_area.positions() {
+            let old_index =
+                ((position.y - old_area.y) * old_area.width + position.x - old_area.x) as usize;
+            let new_index = ((position.y - area.y) * area.width + position.x - area.x) as usize;
+            self.content[new_index] = old_content[old_index].clone();
+        }
+
         self.area = area;
     }
 
@@ -575,7 +588,7 @@ impl fmt::Debug for Buffer {
     /// * `styles`: displayed as a list of: `{ x: 1, y: 2, fg: Color::Red, bg: Color::Blue,
     ///   modifier: Modifier::BOLD }` only showing a value when there is a change in style.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_fmt(format_args!("Buffer {{\n    area: {:?}", &self.area))?;
+        f.write_fmt(format_args!("Buffer {{\n    area: {:?}", self.area))?;
 
         if self.area.is_empty() {
             return f.write_str("\n}");
@@ -841,6 +854,25 @@ mod tests {
     fn index_mut_out_of_bounds_panics(#[case] x: u16, #[case] y: u16) {
         let mut buf = Buffer::empty(Rect::new(10, 10, 10, 10));
         buf[(x, y)].set_symbol("A");
+    }
+
+    #[test]
+    fn resize_preserves_cells_by_global_position() {
+        let mut buffer = Buffer::with_lines(["abcd", "efgh", "ijkl"]);
+        let area = Rect::new(1, 1, 2, 1);
+        buffer.resize(area);
+
+        let mut expected = Buffer::with_lines(["fg"]);
+        expected.area = area;
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn resize_does_not_wrap_cells_when_width_changes() {
+        let mut buffer = Buffer::with_lines(["abc", "def"]);
+        buffer.resize(Rect::new(0, 0, 2, 3));
+
+        assert_eq!(buffer, Buffer::with_lines(["ab", "de", "  "]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Preserve `Buffer::resize` contents by global cell position instead of linear vector index
- Initialize newly exposed cells as empty when the resized area grows or moves
- Add regression coverage for positioned resize and width changes

Fixes #2556

## Test Plan

- `cargo fmt --all --check` (passes; stable rustfmt prints warnings for the repo's nightly-only rustfmt options)
- `cargo test -p ratatui-core resize_ -- --nocapture`
- `cargo test -p ratatui-core buffer::buffer::tests -- --nocapture`
- `cargo test -p ratatui-core`
- `cargo clippy -p ratatui-core --all-targets -- -D warnings`
- `git diff --check`

## AI assistance

This PR was prepared with AI assistance and the resulting changes were reviewed before submission.
