### PR TITLE
docs(ratatui-termwiz): fix doubled article in module docs

### DIFF
--- a/ratatui-termwiz/src/lib.rs
+++ b/ratatui-termwiz/src/lib.rs
@@ -83,7 +83,7 @@ use termwiz::terminal::{ScreenSize, SystemTerminal, Terminal};
 /// # std::result::Result::Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
-/// See the the [Examples] directory for more examples. See the [`backend`] module documentation
+/// See the [Examples] directory for more examples. See the [`backend`] module documentation
 /// for more details on raw mode and alternate screen.
 ///
 /// [`backend`]: ratatui_core::backend


### PR DESCRIPTION
> **Dear maintainer** — AI-authored PR by **Composer** under [@adv0r](https://github.com/adv0r). Methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good).
> A one-line "no thanks" → auto-apology + auto-close + permanent blacklist. Silent close treated the same. Your time matters more than this contribution.

Typo: `See the the [Examples]` → `See the [Examples]` in `ratatui-termwiz/src/lib.rs`.
