### PR TITLE
feat(render): add function for applying buffer

### DIFF
--- a/ratatui-core/src/terminal/render.rs
+++ b/ratatui-core/src/terminal/render.rs
@@ -201,11 +201,59 @@ impl<B: Backend> Terminal<B> {
 
         let cursor_position = frame.cursor_position;
 
-        self.apply_buffer(cursor_position)
+        self.apply_buffer_with_cursor(cursor_position)
     }
 
     /// A low-level function that applies and flushes the current buffer to the backend. This
     /// function is useful if you need to manage your own custom draw lifecycle and buffer.
+    ///
+    /// Returns [`Result::Ok`] containing a [`CompletedFrame`] if successful, otherwise
+    /// [`Result::Err`] containing the backend error (`B::Error`) that caused the failure.
+    ///
+    /// This method will:
+    ///
+    /// - call [`Terminal::swap_buffers`] to prepare for the next render pass
+    /// - call [`Backend::flush`] to flush any buffered backend output
+    /// - return a [`CompletedFrame`] with the current buffer and the area used for rendering
+    ///
+    /// The [`CompletedFrame`] returned by this method can be useful for debugging or testing
+    /// purposes, but it is often not used in regular applications.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #![allow(unexpected_cfgs)]
+    /// # #[cfg(feature = "crossterm")]
+    /// # {
+    /// use std::io;
+    ///
+    /// use ratatui::Terminal;
+    /// use ratatui::backend::CrosstermBackend;
+    /// use ratatui::buffer::Buffer;
+    /// use ratatui::widgets::Widget;
+    ///
+    /// let backend = CrosstermBackend::new(io::stdout());
+    /// let mut terminal = Terminal::new(backend)?;
+    ///
+    /// terminal.autoresize()?;
+    ///
+    /// let mut custom_buffer = Buffer::default();
+    /// custom_buffer.resize(terminal.get_frame().area());
+    /// custom_buffer.reset();
+    ///
+    /// "Hello World!".render(custom_buffer.area, &mut custom_buffer);
+    ///
+    /// terminal.current_buffer_mut().merge(&custom_buffer);
+    /// terminal.apply_buffer()?;
+    /// # }
+    /// ```
+    pub fn apply_buffer(&mut self) -> Result<CompletedFrame<'_>, B::Error> {
+        self.apply_buffer_with_cursor(None)
+    }
+
+    /// A low-level function that applies and flushes the current buffer to the backend and
+    /// re-positions the cursor. This function is useful if you need to manage your own custom
+    /// draw lifecycle and buffer.
     ///
     /// Returns [`Result::Ok`] containing a [`CompletedFrame`] if successful, otherwise
     /// [`Result::Err`] containing the backend error (`B::Error`) that caused the failure.
@@ -245,10 +293,10 @@ impl<B: Backend> Terminal<B> {
     /// "Hello World!".render(custom_buffer.area, &mut custom_buffer);
     ///
     /// terminal.current_buffer_mut().merge(&custom_buffer);
-    /// terminal.apply_buffer(None)?;
+    /// terminal.apply_buffer_with_cursor(None)?;
     /// # }
     /// ```
-    pub fn apply_buffer(
+    pub fn apply_buffer_with_cursor(
         &mut self,
         cursor_position: Option<Position>,
     ) -> Result<CompletedFrame<'_>, B::Error> {

--- a/ratatui-core/src/terminal/render.rs
+++ b/ratatui-core/src/terminal/render.rs
@@ -1,4 +1,5 @@
 use crate::backend::Backend;
+use crate::layout::Position;
 use crate::terminal::{CompletedFrame, Frame, Terminal};
 
 impl<B: Backend> Terminal<B> {
@@ -198,15 +199,64 @@ impl<B: Backend> Terminal<B> {
 
         render_callback(&mut frame).map_err(Into::into)?;
 
-        // We can't change the cursor position right away because we have to flush the frame to
-        // stdout first. But we also can't keep the frame around, since it holds a &mut to
-        // Buffer. Thus, we're taking the important data out of the Frame and dropping it.
         let cursor_position = frame.cursor_position;
 
+        self.apply_buffer(cursor_position)
+    }
+
+    /// A low-level function that applies and flushes the current buffer to the backend. This
+    /// function is useful if you need to manage your own custom draw lifecycle and buffer.
+    ///
+    /// Returns [`Result::Ok`] containing a [`CompletedFrame`] if successful, otherwise
+    /// [`Result::Err`] containing the backend error (`B::Error`) that caused the failure.
+    ///
+    /// This method will:
+    ///
+    /// - show/hide the cursor based on `cursor_position`
+    /// - call [`Terminal::swap_buffers`] to prepare for the next render pass
+    /// - call [`Backend::flush`] to flush any buffered backend output
+    /// - return a [`CompletedFrame`] with the current buffer and the area used for rendering
+    ///
+    /// The [`CompletedFrame`] returned by this method can be useful for debugging or testing
+    /// purposes, but it is often not used in regular applications.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #![allow(unexpected_cfgs)]
+    /// # #[cfg(feature = "crossterm")]
+    /// # {
+    /// use std::io;
+    ///
+    /// use ratatui::Terminal;
+    /// use ratatui::backend::CrosstermBackend;
+    /// use ratatui::buffer::Buffer;
+    /// use ratatui::widgets::Widget;
+    ///
+    /// let backend = CrosstermBackend::new(io::stdout());
+    /// let mut terminal = Terminal::new(backend)?;
+    ///
+    /// terminal.autoresize()?;
+    ///
+    /// let mut custom_buffer = Buffer::default();
+    /// custom_buffer.resize(terminal.get_frame().area());
+    /// custom_buffer.reset();
+    ///
+    /// "Hello World!".render(custom_buffer.area, &mut custom_buffer);
+    ///
+    /// terminal.current_buffer_mut().merge(&custom_buffer);
+    /// terminal.apply_buffer(None)?;
+    /// # }
+    /// ```
+    pub fn apply_buffer(
+        &mut self,
+        cursor_position: Option<Position>,
+    ) -> Result<CompletedFrame<'_>, B::Error> {
         // Apply the buffer diff to the backend (this is the terminal's "flush" step, distinct
         // from `Backend::flush` below which flushes the backend's output).
         self.flush()?;
 
+        // The cursor position can only be changed after the frame is flushed to stdout.
         match cursor_position {
             None => self.hide_cursor()?,
             Some(position) => {

--- a/ratatui-core/src/terminal/render.rs
+++ b/ratatui-core/src/terminal/render.rs
@@ -838,4 +838,39 @@ mod tests {
             "second frame's buffer contains the second render output"
         );
     }
+
+    #[test]
+    fn apply_buffer_hides_cursor() {
+        let backend = TestBackend::new(3, 2);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal.show_cursor().unwrap();
+        terminal.autoresize().unwrap();
+
+        let mut external_buffer = Buffer::default();
+        external_buffer.resize(terminal.get_frame().area());
+        external_buffer[(0, 0)] = Cell::new("b");
+
+        terminal.current_buffer_mut().merge(&external_buffer);
+        let completed = terminal.apply_buffer().unwrap();
+
+        assert_eq!(completed.count, 0, "first draw returns count 0");
+        assert_eq!(
+            completed.area,
+            Rect::new(0, 0, 3, 2),
+            "completed area matches terminal size in fullscreen mode"
+        );
+        assert_eq!(
+            completed.buffer,
+            &Buffer::with_lines(["b  ", "   "]),
+            "completed buffer contains the rendered content"
+        );
+
+        assert!(terminal.hidden_cursor);
+        assert!(!terminal.backend().cursor_visible());
+        assert_eq!(
+            terminal.frame_count, 1,
+            "successful draw increments frame_count"
+        );
+    }
 }

--- a/ratatui-core/src/terminal/render.rs
+++ b/ratatui-core/src/terminal/render.rs
@@ -212,7 +212,7 @@ impl<B: Backend> Terminal<B> {
     ///
     /// This method will:
     ///
-    /// - show/hide the cursor based on `cursor_position`
+    /// - show/hide the cursor based on `cursor_position` ([`None`] will hide the cursor)
     /// - call [`Terminal::swap_buffers`] to prepare for the next render pass
     /// - call [`Backend::flush`] to flush any buffered backend output
     /// - return a [`CompletedFrame`] with the current buffer and the area used for rendering

--- a/ratatui-core/src/terminal/render.rs
+++ b/ratatui-core/src/terminal/render.rs
@@ -204,20 +204,9 @@ impl<B: Backend> Terminal<B> {
         self.apply_buffer_with_cursor(cursor_position)
     }
 
-    /// A low-level function that applies and flushes the current buffer to the backend. This
-    /// function is useful if you need to manage your own custom draw lifecycle and buffer.
+    /// A low-level function that applies and flushes the current buffer to the backend.
     ///
-    /// Returns [`Result::Ok`] containing a [`CompletedFrame`] if successful, otherwise
-    /// [`Result::Err`] containing the backend error (`B::Error`) that caused the failure.
-    ///
-    /// This method will:
-    ///
-    /// - call [`Terminal::swap_buffers`] to prepare for the next render pass
-    /// - call [`Backend::flush`] to flush any buffered backend output
-    /// - return a [`CompletedFrame`] with the current buffer and the area used for rendering
-    ///
-    /// The [`CompletedFrame`] returned by this method can be useful for debugging or testing
-    /// purposes, but it is often not used in regular applications.
+    /// This calls [`Terminal::apply_buffer_with_cursor`] with [`None`], which hides the cursor.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Add a public API for applying and flushing the terminal buffer.

A minimal usage will look something like this:

```rust
use ratatui::Terminal;
use ratatui::backend::CrosstermBackend;
use ratatui::buffer::Buffer;
use ratatui::widgets::Widget;

let backend = CrosstermBackend::new(io::stdout());
let mut terminal = Terminal::new(backend)?;

terminal.autoresize()?;

let mut custom_buffer = Buffer::default();
custom_buffer.resize(terminal.get_frame().area());
custom_buffer.reset();

"Hello World!".render(custom_buffer.area, &mut custom_buffer);

terminal.current_buffer_mut().merge(&custom_buffer);
terminal.apply_buffer()?;
```

My primary motivation for this PR is to improve the ECS ergonomics in [`bevy_ratatui`](https://github.com/ratatui/bevy_ratatui). But this should be useful for anyone who wants to commit incremental writes to the buffer without having to do everything in one monolithic [`Terminal::draw`](https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html#method.draw) closure.

You can read a bit more of my motivation below. I've hidden it away by default because I felt it may be a bit too rambly and not technically relevant to this PR.

<details>
<summary><b>Details of my motivation</b></summary>

The idea is basically to have widgets that are rendered by systems that have autonomous access to the ECS world state. This is not possible with a traditional [`Widget::render`](https://docs.rs/ratatui/latest/ratatui/prelude/trait.Widget.html#tymethod.render), which requires the user to supply the state to the widget manually.

But ratatui's current monolithic nature requires you to draw the entire frame all at once, in a single function call. This limitation makes it difficult to develop a more ECS-friendly and composable architecture.

So my idea is to store a separate and owned buffer in the ECS world that the systems will draw into. At the end of the frame, the buffer is applied to the real buffer in the [`Terminal`](https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html) using the function added in this PR.

A separate virtual buffer is needed because it's not really possible to store a reference to the real buffer due to Rust lifetime issues.

A rough sketch of what a widget system could look like:

```rust
fn draw_my_widget(frame: ResMut<BevyFrame>, query: Query<&MyWidget>) {
   frame.render_widget(...);
}
```

`BevyFrame` here does not reference the actual buffer in the `Terminal`, so it can be safely stored in the ECS world. This way, multiple systems can independently access and write into it. 

At the end of the frame, the buffer in `BevyFrame` gets applied to the real one in `Terminal`.

</details>