### PR TITLE
fix: satisfy beta clippy lints

### DIFF
--- a/ratatui-core/src/layout/layout.rs
+++ b/ratatui-core/src/layout/layout.rs
@@ -1386,7 +1386,7 @@ mod tests {
         use strengths::*;
         assert!(SPACER_SIZE_EQ > MAX_SIZE_LE);
         assert!(MAX_SIZE_LE > MAX_SIZE_EQ);
-        assert!(MIN_SIZE_GE == MAX_SIZE_LE);
+        assert_eq!(MIN_SIZE_GE, MAX_SIZE_LE);
         assert!(MAX_SIZE_LE > LENGTH_SIZE_EQ);
         assert!(LENGTH_SIZE_EQ > PERCENTAGE_SIZE_EQ);
         assert!(PERCENTAGE_SIZE_EQ > RATIO_SIZE_EQ);

--- a/ratatui-widgets/src/reflow.rs
+++ b/ratatui-widgets/src/reflow.rs
@@ -282,7 +282,7 @@ where
             return None;
         }
 
-        self.current_line.truncate(0);
+        self.current_line.clear();
         let mut current_line_width = 0;
 
         let mut lines_exhausted = true;


### PR DESCRIPTION
## Summary

- replace zero-length truncation with `clear()` in the reflow line truncator
- replace equality `assert!` with `assert_eq!` in layout tests
- satisfy beta Clippy lints currently reported by CI

## Test

- `cargo check -p ratatui-widgets`
- `cargo xtask clippy`
- `cargo +beta xtask clippy`