### PR TITLE
fix(widgets): require thread-safe shadow effects

### DIFF
--- a/ratatui-widgets/src/block/shadow.rs
+++ b/ratatui-widgets/src/block/shadow.rs
@@ -1,5 +1,6 @@
 use alloc::sync::Arc;
 use core::hash::{Hash, Hasher};
+use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::{fmt, ptr};
 
 use ratatui_core::buffer::Buffer;
@@ -76,8 +77,12 @@ enum Effect {
 
 /// A cell effect that modifies the cells covered by a [`Shadow`].
 ///
+/// Custom effects must keep the same auto-trait guarantees as the widgets that store them:
+/// [`Send`], [`Sync`], [`UnwindSafe`], and [`RefUnwindSafe`]. This preserves the thread-safety
+/// and panic-safety behavior of widgets that contain a [`Block`](crate::block::Block).
+///
 /// See [`Shadow::custom`] for how to create a shadow from a custom effect.
-pub trait CellEffect: fmt::Debug {
+pub trait CellEffect: fmt::Debug + Send + Sync + UnwindSafe + RefUnwindSafe {
     /// Applies the effect to the cells in `shadow_area`.
     fn apply(&self, shadow_area: Rect, base_area: Rect, buf: &mut Buffer);
 }

--- a/ratatui-widgets/tests/auto_traits.rs
+++ b/ratatui-widgets/tests/auto_traits.rs
@@ -1,11 +1,18 @@
 use core::panic::{RefUnwindSafe, UnwindSafe};
 
-use ratatui::widgets::calendar::{CalendarEventStore, Monthly};
-use ratatui::widgets::canvas::{Canvas, Context};
-use ratatui::widgets::{
-    BarChart, Block, Chart, Gauge, LineGauge, List, Paragraph, Sparkline, Table, Tabs,
-};
+use ratatui_widgets::barchart::BarChart;
+use ratatui_widgets::block::Block;
+use ratatui_widgets::calendar::{CalendarEventStore, Monthly};
+use ratatui_widgets::canvas::{Canvas, Context};
+use ratatui_widgets::chart::Chart;
+use ratatui_widgets::gauge::{Gauge, LineGauge};
+use ratatui_widgets::list::List;
+use ratatui_widgets::paragraph::Paragraph;
+use ratatui_widgets::sparkline::Sparkline;
+use ratatui_widgets::table::Table;
+use ratatui_widgets::tabs::Tabs;
 
+/// A compile-time assertion for checking that the given type implements the auto traits.
 const fn assert_auto_traits<T: Send + Sync + UnwindSafe + RefUnwindSafe>() {}
 
 #[test]

--- a/ratatui/tests/widgets_auto_traits.rs
+++ b/ratatui/tests/widgets_auto_traits.rs
@@ -1,0 +1,29 @@
+use core::panic::{RefUnwindSafe, UnwindSafe};
+
+use ratatui::widgets::calendar::{CalendarEventStore, Monthly};
+use ratatui::widgets::canvas::{Canvas, Context};
+use ratatui::widgets::{
+    BarChart, Block, Chart, Gauge, LineGauge, List, Paragraph, Sparkline, Table, Tabs,
+};
+
+const fn assert_auto_traits<T: Send + Sync + UnwindSafe + RefUnwindSafe>() {}
+
+#[test]
+fn block_backed_widgets_keep_auto_traits() {
+    // This covers the widgets that store `Block`, and therefore `Shadow`. These auto traits are
+    // part of the public API surface: downstream code can require `Paragraph<'static>: Send`, for
+    // example. Keep this test near the public `ratatui::widgets` re-exports so changes to private
+    // `Block` fields do not silently break those bounds.
+    assert_auto_traits::<Block<'static>>();
+    assert_auto_traits::<Paragraph<'static>>();
+    assert_auto_traits::<Table<'static>>();
+    assert_auto_traits::<Sparkline<'static>>();
+    assert_auto_traits::<LineGauge<'static>>();
+    assert_auto_traits::<Chart<'static>>();
+    assert_auto_traits::<BarChart<'static>>();
+    assert_auto_traits::<Canvas<'static, fn(&mut Context)>>();
+    assert_auto_traits::<List<'static>>();
+    assert_auto_traits::<Monthly<'static, CalendarEventStore>>();
+    assert_auto_traits::<Gauge<'static>>();
+    assert_auto_traits::<Tabs<'static>>();
+}


### PR DESCRIPTION
## Summary

- require custom shadow effects to preserve the auto traits expected by Block-backed widgets
- document the CellEffect auto-trait contract
- add a public widget regression test for the affected ratatui::widgets re-exports

Fixes #2583

## Testing

- cargo test -p ratatui --test widgets_auto_traits
- cargo test -p ratatui-widgets block::shadow::tests
- cargo test -p ratatui-widgets
- cargo semver-checks -p ratatui-widgets --baseline-version 0.3.0 --release-type patch
  - auto-trait removals are gone; the command still reports the unrelated GraphType::Area variant addition
