### PR TITLE
fix(scrollbar): keep a large thumb within the track at the end

### DIFF
--- a/ratatui-widgets/src/scrollbar.rs
+++ b/ratatui-widgets/src/scrollbar.rs
@@ -1196,4 +1196,24 @@ mod tests {
             "parts must sum to the track length"
         );
     }
+
+    /// Visual regression for <https://github.com/ratatui/ratatui/issues/2582>: with an end symbol
+    /// set, a large thumb at the end must render the end symbol rather than overwriting it.
+    #[rstest]
+    #[case::large_thumb_at_end("<-----#################>", 8, 9)]
+    fn render_scrollbar_keeps_end_symbol_for_large_thumb(
+        #[case] expected: &str,
+        #[case] position: usize,
+        #[case] content_length: usize,
+    ) {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::HorizontalTop)
+            .begin_symbol(Some("<"))
+            .end_symbol(Some(">"))
+            .track_symbol(Some("-"))
+            .thumb_symbol("#");
+        let mut buffer = Buffer::empty(Rect::new(0, 0, expected.width() as u16, 1));
+        let mut state = ScrollbarState::new(content_length).position(position);
+        scrollbar.render(buffer.area, &mut buffer, &mut state);
+        assert_eq!(buffer, Buffer::with_lines([expected]));
+    }
 }

--- a/ratatui-widgets/src/scrollbar.rs
+++ b/ratatui-widgets/src/scrollbar.rs
@@ -585,11 +585,14 @@ impl Scrollbar<'_> {
         )
         .clamp(1, track_length);
 
+        // Clamp so the thumb always fits within the track (`thumb_start + thumb_length <=
+        // track_length`). Clamping to `track_length - 1` instead let a large thumb overrun the
+        // track at the end, pushing the end symbol out of the rendered area. See issue #2582.
         let thumb_start = rounding_divide(
             start_position.saturating_mul(track_length),
             max_viewport_position,
         )
-        .clamp(0, track_length.saturating_sub(1));
+        .clamp(0, track_length.saturating_sub(thumb_length));
 
         let track_end = track_length.saturating_sub(thumb_start + thumb_length);
         (thumb_start, thumb_length, track_end)
@@ -1167,5 +1170,30 @@ mod tests {
 
         let (start, thumb_len, end) = scrollbar.part_lengths(Rect::new(0, 0, 0, 1), &state);
         assert_eq!((start, thumb_len, end), (0, 0, 0));
+    }
+
+    /// Regression test for <https://github.com/ratatui/ratatui/issues/2582>.
+    ///
+    /// A thumb that is large relative to the track (content shorter than the viewport) must not
+    /// overrun the track when the position is at the end. Otherwise the rendered thumb pushes the
+    /// end symbol out of the area, leaving a thumb cell where the end arrow should be.
+    #[test]
+    fn thumb_stays_within_track_for_large_thumb_at_end() {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight);
+        // height 24 minus the two arrow heads leaves a track of 22.
+        let area = Rect::new(0, 0, 1, 24);
+        let state = ScrollbarState::new(9).position(8);
+
+        let (start, thumb_len, end) = scrollbar.part_lengths(area, &state);
+
+        assert!(
+            start + thumb_len <= 22,
+            "thumb overruns the track: start={start} + thumb_len={thumb_len} > 22"
+        );
+        assert_eq!(
+            start + thumb_len + end,
+            22,
+            "parts must sum to the track length"
+        );
     }
 }


### PR DESCRIPTION
Closes #2582.

## Problem

When the content is shorter than the viewport, the thumb is large relative to the track. With the position at the end, `part_lengths` clamped `thumb_start` to `track_length - 1` while `thumb_length` was clamped independently to `[1, track_length]`, so `thumb_start + thumb_length` could exceed `track_length`.

`bar_symbols` lays out `begin + track_start + thumb + track_end + end` and zips it against the cells of the area. When the thumb overruns the track, `track_end` saturates to `0` but the thumb still emits more cells than the track can hold, so the trailing `end` symbol is pushed past the end of the area. The last visible cell ends up being a thumb (`█`) where the end arrow (`▼`) should be.

Concretely, for the issue's repro (`VerticalRight`, `content_length = 9`, `position = 8`, height `24`): track is `22`, `thumb_length = 17`, `thumb_start = 6`, and `6 + 17 = 23 > 22`.

This is a regression from v0.30.0, where `thumb_length` was derived as `thumb_end - thumb_start` and therefore always fit within the track.

## Fix

Clamp `thumb_start` to `track_length - thumb_length` (instead of `track_length - 1`) so the thumb always fits within the track and the end symbol is preserved.

## Test

Two regression tests, both fail on `main` and pass with the fix:

- `thumb_stays_within_track_for_large_thumb_at_end` checks `part_lengths` directly with the issue's parameters — asserts `thumb_start + thumb_length <= track_length` and that the parts sum to the track length.
- `render_scrollbar_keeps_end_symbol_for_large_thumb` renders the #2582 case (both arrows, large thumb at the end) and asserts the end symbol is drawn rather than overwritten by a thumb cell.

All existing scrollbar tests still pass.
