### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,13 +2839,11 @@ dependencies = [
  "crossterm 0.29.0",
  "document-features",
  "fakeit",
- "futures",
  "indoc",
  "instability",
  "palette",
  "pretty_assertions",
  "rand 0.10.1",
- "rand_chacha 0.10.0",
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
@@ -2857,10 +2855,6 @@ dependencies = [
  "serde",
  "serde_json",
  "time",
- "tokio",
- "tracing 0.1.44",
- "tracing-appender",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -69,7 +69,6 @@ compact_str.workspace = true
 critical-section = { workspace = true, optional = true }
 document-features = { workspace = true, optional = true }
 hashbrown.workspace = true
-indoc.workspace = true
 itertools.workspace = true
 kasuari = { workspace = true, default-features = false }
 lru.workspace = true
@@ -83,6 +82,7 @@ unicode-width.workspace = true
 
 [dev-dependencies]
 critical-section = { workspace = true, features = ["std"] }
+indoc.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
 serde_json.workspace = true

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -146,18 +146,12 @@ color-eyre.workspace = true
 criterion.workspace = true
 crossterm = { workspace = true, features = ["event-stream"] }
 fakeit.workspace = true
-futures.workspace = true
 indoc.workspace = true
 pretty_assertions.workspace = true
 rand.workspace = true
-rand_chacha.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
 time = { workspace = true, features = ["local-offset"] }
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }
-tracing.workspace = true
-tracing-appender.workspace = true
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Audit removes these dependencies that are not used:

  ratatui/Cargo.toml — Removed from [dev-dependencies]:
  - futures
  - rand_chacha
  - tokio
  - tracing
  - tracing-appender
  - tracing-subscriber

  ratatui-core/Cargo.toml — Moved from [dependencies] → [dev-dependencies]:
  - indoc
