### PR TITLE
ci: add cargo-udeps dependency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,24 @@ jobs:
           persist-credentials: false
       - uses: bnjbvr/cargo-machete@ac30a525c0a8d163a92d727b3ff079ee3f6ecb08 # v0.9.2
 
+  # Check for unused dependencies that static source scanning cannot distinguish.
+  # This complements cargo-machete by compiling the workspace and checking rustc dep-info.
+  cargo-udeps:
+    name: Check Compiled Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: nightly
+      - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
+        with:
+          tool: cargo-udeps
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo xtask udeps
+
   # Run cargo clippy.
   #
   # We check for clippy warnings on beta, but these are not hard failures. They should often be
@@ -301,6 +319,7 @@ jobs:
       - lint-typos
       - cargo-deny
       - cargo-machete
+      - cargo-udeps
       - lint-clippy
       - lint-markdown
       - coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
   # Check for unused dependencies that static source scanning cannot distinguish.
   # This complements cargo-machete by compiling the workspace and checking rustc dep-info.
   cargo-udeps:
-    name: Check Compiled Dependencies
+    name: Check Unused Dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,7 +2834,6 @@ checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 name = "ratatui"
 version = "0.30.1"
 dependencies = [
- "color-eyre",
  "criterion",
  "crossterm 0.29.0",
  "document-features",
@@ -2923,7 +2922,6 @@ dependencies = [
  "instability",
  "ratatui",
  "ratatui-core",
- "rstest",
  "termina",
 ]
 
@@ -2934,7 +2932,6 @@ dependencies = [
  "document-features",
  "instability",
  "ratatui-core",
- "rstest",
  "termion",
 ]
 
@@ -2945,7 +2942,6 @@ dependencies = [
  "document-features",
  "ratatui",
  "ratatui-core",
- "rstest",
  "termwiz",
 ]
 

--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -21,6 +21,10 @@ rust-version.workspace = true
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.cargo-udeps.ignore]
+normal = ["critical-section"]
+development = ["critical-section"]
+
 [features]
 default = []
 

--- a/ratatui-crossterm/Cargo.toml
+++ b/ratatui-crossterm/Cargo.toml
@@ -18,6 +18,9 @@ rust-version.workspace = true
 features = ["document-features"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.cargo-udeps.ignore]
+normal = ["crossterm_0_28"]
+
 [features]
 default = ["crossterm_0_29", "underline-color"]
 

--- a/ratatui-termina/Cargo.toml
+++ b/ratatui-termina/Cargo.toml
@@ -48,7 +48,6 @@ termina.workspace = true
 [dev-dependencies]
 color-eyre.workspace = true
 ratatui = { path = "../ratatui", features = ["termina"], default-features = false }
-rstest.workspace = true
 
 [lints]
 workspace = true

--- a/ratatui-termion/Cargo.toml
+++ b/ratatui-termion/Cargo.toml
@@ -36,8 +36,5 @@ instability.workspace = true
 ratatui-core = { workspace = true }
 termion.workspace = true
 
-[dev-dependencies]
-rstest.workspace = true
-
 [lints]
 workspace = true

--- a/ratatui-termwiz/Cargo.toml
+++ b/ratatui-termwiz/Cargo.toml
@@ -19,6 +19,9 @@ all-features = true
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[package.metadata.cargo-udeps.ignore]
+development = ["ratatui"]
+
 [features]
 default = []
 
@@ -39,7 +42,6 @@ termwiz.workspace = true
 
 [dev-dependencies]
 ratatui = { path = "../ratatui", features = ["termwiz"], default-features = false }
-rstest.workspace = true
 
 [lints]
 workspace = true

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -142,7 +142,6 @@ serde = { workspace = true, optional = true }
 ratatui-termion = { workspace = true, optional = true }
 
 [dev-dependencies]
-color-eyre.workspace = true
 criterion.workspace = true
 crossterm = { workspace = true, features = ["event-stream"] }
 fakeit.workspace = true

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -13,7 +13,7 @@ use self::clippy::Clippy;
 use self::docs::Docs;
 use self::format::Format;
 use self::typos::Typos;
-use crate::{CROSSTERM_COMMON_FEATURES, ExpressionExt, Run, run_cargo};
+use crate::{CROSSTERM_COMMON_FEATURES, ExpressionExt, Run, run_cargo, run_cargo_nightly};
 
 mod backend;
 mod check;
@@ -77,6 +77,9 @@ pub enum Command {
     #[command(visible_alias = "ty")]
     Typos(Typos),
 
+    /// Check for unused dependencies with cargo-udeps
+    Udeps,
+
     /// Test backend
     #[command(visible_alias = "tb")]
     TestBackend(TestBackend),
@@ -108,6 +111,7 @@ impl Run for Command {
             Command::Docs(command) => command.run(),
             Command::Format(command) => command.run(),
             Command::Typos(command) => command.run(),
+            Command::Udeps => udeps(),
             Command::LintMarkdown => lint_markdown(),
             Command::Test => test(),
             Command::TestBackend(command) => command.run(),
@@ -147,6 +151,17 @@ fn lint() -> Result<()> {
 fn lint_markdown() -> Result<()> {
     cmd!("markdownlint-cli2", "**/*.md", "!target").run_with_trace()?;
     Ok(())
+}
+
+/// Check for unused dependencies using rustc dep-info.
+fn udeps() -> Result<()> {
+    run_cargo_nightly(vec![
+        "udeps",
+        "--workspace",
+        "--all-targets",
+        "--all-features",
+        "--locked",
+    ])
 }
 
 /// Run tests for libs, backends, and docs


### PR DESCRIPTION
Adds cargo xtask udeps and runs it from CI as a required job.

This complements cargo-machete rather than replacing it. cargo-machete is a fast static source scan, which is why it missed the package-level unused deps fixed in #2598 when the same dependency names were still referenced by example crates. cargo-udeps compiles the workspace and checks rustc dep-info, so it can catch unused dependency declarations for the package being checked.

To make the new job pass, this also removes the remaining true-positive unused dev-deps and records explicit cargo-udeps ignores for current false positives / intentional cases: ratatui-core critical-section, ratatui-crossterm's duplicate crossterm version feature shape, and ratatui-termwiz's doc-example-only ratatui dev-dependency.

I searched existing issues and PRs for udeps / cargo-udeps / "cargo udeps". I did not find prior ratatui discussion about adopting cargo-udeps; the only hits were Dependabot PR bodies for taiki-e/install-action release notes mentioning cargo-udeps version updates, for example #1971, #2095, #2194, and #2522.

Validation:
- cargo xtask udeps
- cargo xtask format --check