### PR TITLE
docs(widgets): document dispatch choices

### DIFF
--- a/examples/apps/widget-ref-container/README.md
+++ b/examples/apps/widget-ref-container/README.md
@@ -1,10 +1,44 @@
 # WidgetRef Container demo
 
-This example shows how to use [`WidgetRef`](https://docs.rs/ratatui/latest/ratatui/widgets/trait.WidgetRef.html)
-to store widgets in a container.
+This example shows how to use [`WidgetRef`] to store widgets in a container.
+
+`WidgetRef` is experimental and requires the `unstable-widget-ref` feature flag. It is useful when
+you need dynamic dispatch, such as storing different widget types behind `Box<dyn WidgetRef>`.
+
+For normal application code, start with a simpler enum and `match` when the possible widgets for an
+area are known. In an app, that might look like:
+
+```rust
+match self.message {
+    Message::Greeting => frame.render_widget(&Greeting, area),
+    Message::Farewell => frame.render_widget(&Farewell, area),
+}
+```
+
+That keeps ownership and state flow explicit. Use `WidgetRef` when you specifically need a boxed
+heterogeneous widget container:
+
+```rust
+use ratatui::widgets::WidgetRef;
+
+let widget: Box<dyn WidgetRef> = match self.message {
+    Message::Greeting => Box::new(&Greeting),
+    Message::Farewell => Box::new(&Farewell),
+};
+
+widget.render_ref(area, frame.buffer_mut());
+```
+
+The reason this example uses `WidgetRef` rather than `Widget` is that
+[`Widget::render`](https://docs.rs/ratatui/latest/ratatui/widgets/trait.Widget.html#tymethod.render)
+consumes `self`, so `Box<dyn Widget>` is not the right trait object for this pattern. See the
+[`WidgetRef` tracking issue](https://github.com/ratatui/ratatui/issues/1287) for the ongoing API
+discussion.
 
 To run this demo:
 
 ```shell
 cargo run -p widget-ref-container
 ```
+
+[`WidgetRef`]: https://docs.rs/ratatui/latest/ratatui/widgets/trait.WidgetRef.html

--- a/ratatui/src/widgets.rs
+++ b/ratatui/src/widgets.rs
@@ -183,6 +183,56 @@
 //! [tracking issue](https://github.com/ratatui/ratatui/issues/1287) for ongoing discussions and
 //! design considerations.
 //!
+//! ### Choosing Between Enum Dispatch and `WidgetRef`
+//!
+//! When an application needs to render one of several widget types in the same area, prefer a
+//! simple enum and `match` when the set of possible widgets is known by the application. This keeps
+//! ownership and state explicit:
+//!
+//! ```rust
+//! # use ratatui::{Frame, layout::Rect, widgets::Paragraph};
+//! enum Panel {
+//!     Details,
+//!     Help,
+//!     Logs,
+//! }
+//!
+//! # struct App { panel: Panel }
+//! # fn render(frame: &mut Frame, app: &App, area: Rect) {
+//! match &app.panel {
+//!     Panel::Details => frame.render_widget(Paragraph::new("details"), area),
+//!     Panel::Help => frame.render_widget(Paragraph::new("help"), area),
+//!     Panel::Logs => frame.render_widget(Paragraph::new("logs"), area),
+//! }
+//! # }
+//! ```
+//!
+//! Reach for [`WidgetRef`] when you specifically need dynamic dispatch, such as a container that
+//! stores heterogeneous widgets behind `Box<dyn WidgetRef>`. Use [`WidgetRef::render_ref`] because
+//! [`Widget::render`] consumes `self` and is not object safe for `dyn Widget`:
+//!
+//! ```rust
+//! # #[cfg(feature = "unstable-widget-ref")] {
+//! # use ratatui::widgets::WidgetRef;
+//! # struct Details;
+//! # struct Help;
+//! # impl WidgetRef for Details {
+//! #     fn render_ref(&self, _: ratatui::layout::Rect, _: &mut ratatui::buffer::Buffer) {}
+//! # }
+//! # impl WidgetRef for Help {
+//! #     fn render_ref(&self, _: ratatui::layout::Rect, _: &mut ratatui::buffer::Buffer) {}
+//! # }
+//! let widgets: Vec<Box<dyn WidgetRef>> = vec![Box::new(Details), Box::new(Help)];
+//! # }
+//! ```
+//!
+//! See [Using Trait Objects for Dynamic Collections](#using-trait-objects-for-dynamic-collections)
+//! below and the [`widget-ref-container` example] for complete examples that store and render
+//! heterogeneous widgets.
+//!
+//! [`widget-ref-container` example]:
+//!     https://github.com/ratatui/ratatui/tree/main/examples/apps/widget-ref-container
+//!
 //! # Rendering Widgets
 //!
 //! Widgets are typically rendered using the [`Frame`] type, which provides methods for rendering


### PR DESCRIPTION
## Summary

- document when app code should prefer enum dispatch over `WidgetRef`
- point boxed heterogeneous widget guidance at `WidgetRef` instead of `Widget`
- expand the `widget-ref-container` README with the same decision rule and links

## Validation

- `markdownlint-cli2 examples/apps/widget-ref-container/README.md`
- `cargo test -p ratatui --doc --features unstable-widget-ref`
- `cargo doc -p ratatui --features unstable-widget-ref --no-deps`
- `cargo check -p widget-ref-container`

## Notes

This is stacked on `joshka/add-udeps-ci` so the diff only contains the widget dispatch documentation changes.
