### PR TITLE
chore: remove deprecated Cargo authors metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ default-members = [
 ]
 
 [workspace.package]
-authors = ["Florian Dehau <work@fdehau.com>", "The Ratatui Developers"]
 documentation = "https://docs.rs/ratatui/latest/ratatui/"
 repository = "https://github.com/ratatui/ratatui"
 homepage = "https://ratatui.rs"

--- a/examples/apps/async-github/Cargo.toml
+++ b/examples/apps/async-github/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "async-github"
 publish = false
-authors.workspace = true
 documentation.workspace = true
 repository.workspace = true
 homepage.workspace = true

--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -7,7 +7,6 @@ description = """
 """
 documentation = "https://docs.rs/ratatui-core"
 readme = "README.md"
-authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/ratatui-crossterm/Cargo.toml
+++ b/ratatui-crossterm/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.2"
 description = "Crossterm backend for the Ratatui Terminal UI library."
 documentation = "https://docs.rs/ratatui-crossterm"
 readme = "README.md"
-authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/ratatui-macros/Cargo.toml
+++ b/ratatui-macros/Cargo.toml
@@ -3,7 +3,6 @@ name = "ratatui-macros"
 version = "0.7.2"
 description = "Macros for Ratatui"
 edition.workspace = true
-authors = ["The Ratatui Developers"]
 license = "MIT"
 repository = "https://github.com/ratatui/ratatui"
 documentation = "https://docs.rs/ratatui-macros"

--- a/ratatui-termina/Cargo.toml
+++ b/ratatui-termina/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 description = "Termina backend for the Ratatui Terminal UI library."
 documentation = "https://docs.rs/ratatui-termina"
 readme = "README.md"
-authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/ratatui-termion/Cargo.toml
+++ b/ratatui-termion/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.2"
 description = "Termion backend for the Ratatui Terminal UI library."
 documentation = "https://docs.rs/ratatui-termion"
 readme = "README.md"
-authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/ratatui-termwiz/Cargo.toml
+++ b/ratatui-termwiz/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.2"
 description = "Termwiz backend for the Ratatui Terminal UI library."
 documentation = "https://docs.rs/ratatui-termwiz"
 readme = "README.md"
-authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/ratatui-widgets/Cargo.toml
+++ b/ratatui-widgets/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.3.2"
 description = "A collection of Ratatui widgets for building terminal user interfaces using Ratatui."
 documentation = "https://docs.rs/ratatui-widgets"
 readme = "README.md"
-authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -2,7 +2,6 @@
 name = "ratatui"
 description = "A library that's all about cooking up terminal user interfaces"
 version = "0.30.2"
-authors.workspace = true
 documentation.workspace = true
 repository.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Summary

- Remove deprecated `authors` metadata from package manifests.
- Remove `authors.workspace = true` inheritances now that the workspace no longer defines authors.

## Context

Cargo's manifest reference marks `package.authors` as deprecated. The underlying change came from [RFC 3052](https://rust-lang.github.io/rfcs/3052-optional-authors-field.html), tracked in [rust-lang/rust#83227](https://github.com/rust-lang/rust/issues/83227). The Cargo-side implementation listed there is [rust-lang/cargo#9282](https://github.com/rust-lang/cargo/pull/9282), which stopped `cargo new` from generating the field.

## Verification

- `cargo metadata --no-deps --format-version 1`
- `rg -n '^authors\\s*=|authors\\.workspace' -g 'Cargo.toml' -g '!target'`
