### PR TITLE
fix(gauge): correct off-by-one error in filled area condition

### DIFF
--- a/ratatui-widgets/src/gauge.rs
+++ b/ratatui-widgets/src/gauge.rs
@@ -195,7 +195,7 @@ impl Gauge<'_> {
                 // Use full block for the filled part of the gauge and spaces for the part that is
                 // covered by the label. Note that the background and foreground colors are swapped
                 // for the label part, otherwise the gauge will be inverted
-                if x < label_col || x > label_col + clamped_label_width || y != label_row {
+                if x < label_col || x >= label_col + clamped_label_width || y != label_row {
                     buf[(x, y)]
                         .set_symbol(symbols::block::FULL)
                         .set_fg(self.gauge_style.fg.unwrap_or(Color::Reset))


### PR DESCRIPTION
Fixes #2547 by changing the strict inequality to greater-than-or-equal so the gauge doesn't leave an empty cell after the label.