### PR TITLE
build(deps): bump itertools from 0.14 to 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ version = "0.0.0"
 dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "ratatui",
 ]
 
@@ -482,7 +482,7 @@ version = "0.0.0"
 dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "ratatui",
 ]
 
@@ -566,7 +566,7 @@ version = "0.0.0"
 dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "ratatui",
  "strum",
 ]
@@ -889,7 +889,7 @@ dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
  "indoc",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "palette",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
@@ -1586,7 +1586,7 @@ version = "0.0.0"
 dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "ratatui",
 ]
 
@@ -1828,6 +1828,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,7 +2068,7 @@ version = "0.0.0"
 dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "ratatui",
 ]
 
@@ -2863,7 +2872,7 @@ dependencies = [
  "document-features",
  "hashbrown 0.17.1",
  "indoc",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "kasuari",
  "lru",
  "palette",
@@ -2952,7 +2961,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "line-clipping",
  "pretty_assertions",
  "ratatui",
@@ -3649,7 +3658,7 @@ dependencies = [
  "color-eyre",
  "crossterm 0.29.0",
  "fakeit",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "ratatui",
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ futures = "0.3"
 hashbrown = "0.17"
 indoc = "2"
 instability = "0.3"
-itertools = { version = "0.14", default-features = false, features = ["use_alloc"] }
+itertools = { version = "0.15", default-features = false, features = ["use_alloc"] }
 kasuari = { version = "0.4", default-features = false }
 line-clipping = "0.3"
 lru = "0.18"

--- a/ratatui-core/src/layout/layout.rs
+++ b/ratatui-core/src/layout/layout.rs
@@ -1124,7 +1124,10 @@ fn configure_fill_constraints(
     constraints: &[Constraint],
     flex: Flex,
 ) -> Result<(), AddConstraintError> {
-    for [(&left_constraint, &left_segment), (&right_constraint, &right_segment)] in constraints
+    for [
+        (&left_constraint, &left_segment),
+        (&right_constraint, &right_segment),
+    ] in constraints
         .iter()
         .zip(segments.iter())
         .filter(|(c, _)| c.is_fill() || (!flex.is_legacy() && c.is_min()))

--- a/ratatui-core/src/layout/layout.rs
+++ b/ratatui-core/src/layout/layout.rs
@@ -1012,7 +1012,7 @@ fn configure_flex_constraints(
         Flex::SpaceAround => {
             if spacers.len() <= 2 {
                 // If there are two or less spacers, fallback to Flex::SpaceEvenly
-                for (left, right) in spacers.iter().tuple_combinations() {
+                for [left, right] in spacers.iter().array_combinations() {
                     solver.add_constraint(left.has_size(right, SPACER_SIZE_EQ))?;
                 }
                 for spacer in spacers {
@@ -1025,7 +1025,7 @@ fn configure_flex_constraints(
                 let (last, middle) = rest.split_last().unwrap();
 
                 // All middle spacers should be equal in size
-                for (left, right) in middle.iter().tuple_combinations() {
+                for [left, right] in middle.iter().array_combinations() {
                     solver.add_constraint(left.has_size(right, SPACER_SIZE_EQ))?;
                 }
 
@@ -1046,7 +1046,7 @@ fn configure_flex_constraints(
         // All spacers are the same size and will grow to fill any remaining space after the
         // constraints are satisfied
         Flex::SpaceEvenly => {
-            for (left, right) in spacers.iter().tuple_combinations() {
+            for [left, right] in spacers.iter().array_combinations() {
                 solver.add_constraint(left.has_size(right, SPACER_SIZE_EQ))?;
             }
             for spacer in spacers {
@@ -1059,7 +1059,7 @@ fn configure_flex_constraints(
         // any remaining space after the constraints are satisfied.
         // The first and last spacers are zero size.
         Flex::SpaceBetween => {
-            for (left, right) in spacers_except_first_and_last.iter().tuple_combinations() {
+            for [left, right] in spacers_except_first_and_last.iter().array_combinations() {
                 solver.add_constraint(left.has_size(right.size(), SPACER_SIZE_EQ))?;
             }
             for spacer in spacers_except_first_and_last {
@@ -1124,11 +1124,11 @@ fn configure_fill_constraints(
     constraints: &[Constraint],
     flex: Flex,
 ) -> Result<(), AddConstraintError> {
-    for ((&left_constraint, &left_segment), (&right_constraint, &right_segment)) in constraints
+    for [(&left_constraint, &left_segment), (&right_constraint, &right_segment)] in constraints
         .iter()
         .zip(segments.iter())
         .filter(|(c, _)| c.is_fill() || (!flex.is_legacy() && c.is_min()))
-        .tuple_combinations()
+        .array_combinations()
     {
         let left_scaling_factor = match left_constraint {
             Constraint::Fill(scale) => f64::from(scale).max(1e-6),


### PR DESCRIPTION
Bumps `itertools` 0.14 → 0.15. The new release deprecates `tuple_combinations()` in favour of `array_combinations()`, which trips the `-D warnings` clippy gate, so I migrated the five call sites in the layout solver (`(left, right)` → `[left, right]`). Same combinations in the same order, so behaviour is unchanged.

This supersedes the Dependabot bump in #2619, which is red on clippy for exactly this reason.

Verified locally on stable with `cargo xtask clippy` and the `ratatui-core` layout tests (825 passed).

AI attribution (per CONTRIBUTING): the migration was done with AI assistance and reviewed line-by-line.