### PR TITLE
fix(barchart): center wide value labels by display width

### DIFF
--- a/ratatui-widgets/src/barchart.rs
+++ b/ratatui-widgets/src/barchart.rs
@@ -1559,4 +1559,18 @@ mod tests {
         // This should not panic, even if the buffer has zero size.
         chart.render(buffer.area, &mut buffer);
     }
+
+    #[test]
+    fn wide_value_label_centered_by_display_width() {
+        // A double-width (CJK) value label must be centered by its display width,
+        // not its byte length. "中文" is 4 columns wide, so in an 8-wide bar it
+        // gets 2 columns of padding on each side. Centering by byte length (6)
+        // would instead give only 1 column on the left.
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 8, 2));
+        let widget = BarChart::default()
+            .bar_width(8)
+            .data(BarGroup::new([Bar::new(1).text_value("中文")]));
+        widget.render(buffer.area, &mut buffer);
+        assert_eq!(buffer, Buffer::with_lines(["████████", "██中文██"]));
+    }
 }

--- a/ratatui-widgets/src/barchart/bar.rs
+++ b/ratatui-widgets/src/barchart/bar.rs
@@ -255,7 +255,7 @@ impl<'a> Bar<'a> {
             // then print the value
             if width < max_width || (width == max_width && ticks >= TICKS_PER_LINE) {
                 buf.set_string(
-                    x + (max_width.saturating_sub(value_label.len() as u16) >> 1),
+                    x + (max_width.saturating_sub(width) >> 1),
                     y,
                     value_label,
                     default_value_style.patch(self.value_style),


### PR DESCRIPTION
## Description

`Bar::render_value` measures the value label's display width with `UnicodeWidthStr::width`, but the centering offset is computed from `value_label.len()`, the UTF-8 byte length:

```rust
let width = value_label.width() as u16;
// ...
buf.set_string(
    x + (max_width.saturating_sub(value_label.len() as u16) >> 1),
    // ...
```

For a value label containing wide (CJK) or other multi-byte characters, the byte length is greater than the display width, so the padding is too small and the label is drawn left of center. The neighbouring `Bar::render_label` already centers with the display width, so the two paths disagreed for the same input.

The fix reuses the `width` value the function already computed, so `render_value` centers the same way as `render_label`.

## Before / after

Rendering a bar with value label `"中文"` (4 columns wide) in an 8-column bar:

```text
before: █中文███
after:  ██中文██
```

## Testing

Added `wide_value_label_centered_by_display_width` in `barchart.rs`. `cargo test -p ratatui-widgets` is green; the existing ASCII value-label tests are unaffected because byte length equals display width for those.

Disclosure: prepared with AI assistance. I reviewed every line and verified the fix and the test locally.
