### PR TITLE
build(deps): tune minimal dependency floors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,23 @@ jobs:
         env:
           RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
 
+  # Check that dependency lower bounds are accurate.
+  minimal-versions:
+    name: Check Minimal Versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
+        with:
+          tool: cargo-minimal-versions,cargo-hack
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo minimal-versions check --direct --workspace --all-features --all-targets
+
   build-no-std:
     name: Build No-Std
     runs-on: ubuntu-latest
@@ -324,6 +341,7 @@ jobs:
       - lint-markdown
       - coverage
       - check
+      - minimal-versions
       - build-no-std
       - check-readme
       - lint-docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,22 +28,22 @@ edition = "2024"
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-anstyle = "1"
-bitflags = "2.12"
-clap = { version = "4.6", features = ["derive"] }
+anstyle = "1.0.3"
+bitflags = "2.9"
+clap = { version = "4.5", features = ["derive"] }
 color-eyre = "0.6"
 compact_str = { version = "0.9", default-features = false }
 criterion = { version = "0.8", features = ["html_reports"] }
 critical-section = "1.2"
 crossterm = "0.29"
-document-features = "0.2"
+document-features = "0.2.11"
 fakeit = "1"
 futures = "0.3"
 hashbrown = "0.17"
-indoc = "2"
-instability = "0.3"
+indoc = "2.0.5"
+instability = "0.3.7"
 itertools = { version = "0.15", default-features = false, features = ["use_alloc"] }
-kasuari = { version = "0.4", default-features = false }
+kasuari = { version = "0.4.9", default-features = false }
 line-clipping = "0.3"
 lru = "0.18"
 octocrab = "0.53"
@@ -60,21 +60,21 @@ ratatui-termion = { path = "ratatui-termion", version = "0.1.2" }
 ratatui-termwiz = { path = "ratatui-termwiz", version = "0.1.2" }
 ratatui-widgets = { path = "ratatui-widgets", version = "0.3.2", default-features = false }
 rstest = "0.26"
-serde = { version = "1", default-features = false, features = ["derive"] }
-serde_json = "1"
+serde = { version = "1.0.219", default-features = false, features = ["derive"] }
+serde_json = "1.0.142"
 strum = { version = "0.28", default-features = false, features = ["derive"] }
 termina = "0.3"
 termion = "4"
 termwiz = "0.23"
-thiserror = { version = "2", default-features = false }
-time = { version = "0.3.47", default-features = false }
-tokio = "1"
+thiserror = { version = "2.0.12", default-features = false }
+time = { version = "0.3.37", default-features = false }
+tokio = "1.35"
 tokio-stream = "0.1"
-tracing = "0.1"
+tracing = "0.1.37"
 tracing-appender = "0.2"
-tracing-subscriber = "0.3"
-trybuild = "1"
-unicode-segmentation = "1"
+tracing-subscriber = "0.3.10"
+trybuild = "1.0.19"
+unicode-segmentation = "1.9"
 unicode-truncate = { version = "2", default-features = false }
 # See <https://github.com/ratatui/ratatui/issues/1271> for information about why we pin unicode-width
 unicode-width = ">=0.2.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 clap.workspace = true
-clap-verbosity-flag = { version = "3", default-features = false, features = ["tracing"] }
+clap-verbosity-flag = { version = "3.0.1", default-features = false, features = ["tracing"] }
 color-eyre.workspace = true
 duct = "1"
 tracing.workspace = true


### PR DESCRIPTION
## Summary

- tune broad dependency requirements to minimal versions verified by cargo-minimal-versions
- add a CI minimal-versions job using taiki-e/install-action
- keep Dependabot's existing increase-if-necessary Cargo update strategy

Fixes #2626.

## Validation

- `cargo minimal-versions check --direct --workspace --all-features --all-targets`
- `actionlint -color=false .github/workflows/ci.yml`
