### PR TITLE
fix: Clear doesn't shrink a wide glyph straddling the left edge

### DIFF
--- a/ratatui-widgets/src/clear.rs
+++ b/ratatui-widgets/src/clear.rs
@@ -1,5 +1,5 @@
 //! The [`Clear`] widget allows you to clear a certain area to allow overdrawing (e.g. for popups).
-use ratatui_core::buffer::Buffer;
+use ratatui_core::buffer::{Buffer, CellWidth};
 use ratatui_core::layout::Rect;
 use ratatui_core::widgets::Widget;
 
@@ -41,6 +41,19 @@ impl Widget for &Clear {
         if area.is_empty() {
             return;
         }
+
+        // A double-width glyph sitting just to the left of the area keeps its full visual width
+        // after the loop below resets the cells inside the area: its right half occupies
+        // `area.x`, so it spills into whatever the caller draws on top of `Clear` (e.g. a popup's
+        // left border). Shrink it to a space first, while we can still see its pre-clear width.
+        if area.x > buf.area().x {
+            for y in area.top()..area.bottom() {
+                if buf[(area.x - 1, y)].cell_width() > 1 {
+                    buf[(area.x - 1, y)].set_symbol(" ");
+                }
+            }
+        }
+
         for x in area.left()..area.right() {
             for y in area.top()..area.bottom() {
                 buf[(x, y)].reset();
@@ -53,6 +66,7 @@ impl Widget for &Clear {
 mod tests {
     use ratatui_core::buffer::Buffer;
     use ratatui_core::layout::Rect;
+    use ratatui_core::style::Style;
     use ratatui_core::widgets::Widget;
 
     use super::*;
@@ -89,6 +103,39 @@ mod tests {
         let clear = Clear;
         clear.render(Rect::new(100, 0, 100, 100), &mut buffer);
         let expected = Buffer::with_lines(["xxxxxxxxxxxxxxx"; 7]);
+        assert_eq!(buffer, expected);
+    }
+
+    /// Regression test for a double-width glyph immediately to the left of the cleared area.
+    ///
+    /// `字` occupies columns 3 and 4. Clearing `Rect::new(4, 0, 2, 1)` only resets columns 4-5,
+    /// so `字` at column 3 kept its full two-cell width and its right half spilled into column 4,
+    /// underneath whatever gets drawn on top of `Clear` (e.g. a popup's left border).
+    #[test]
+    fn render_shrinks_wide_glyph_straddling_left_edge() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 6, 1));
+        buffer.set_string(0, 0, "abc字", Style::default());
+        Clear.render(Rect::new(4, 0, 2, 1), &mut buffer);
+        let expected = Buffer::with_lines(["abc   "]);
+        assert_eq!(buffer, expected);
+    }
+
+    /// A single-width glyph at `area.x - 1` must be left untouched.
+    #[test]
+    fn render_left_edge_single_width_glyph_untouched() {
+        let mut buffer = Buffer::with_lines(["abcde "]);
+        Clear.render(Rect::new(4, 0, 2, 1), &mut buffer);
+        let expected = Buffer::with_lines(["abcd  "]);
+        assert_eq!(buffer, expected);
+    }
+
+    /// The boundary patch must not panic when the area's left edge is also the buffer's left
+    /// edge (there is no `area.x - 1` cell to look at in that case).
+    #[test]
+    fn render_area_at_buffer_left_edge_does_not_panic() {
+        let mut buffer = Buffer::with_lines(["abcd"]);
+        Clear.render(Rect::new(0, 0, 4, 1), &mut buffer);
+        let expected = Buffer::with_lines(["    "]);
         assert_eq!(buffer, expected);
     }
 }


### PR DESCRIPTION
Closes #2526.

`Clear::render` only resets the cells strictly inside its area. If there's a double-width glyph (CJK, emoji, etc) sitting right at `area.x - 1`, it keeps its full two-column visual width after the clear, since terminals draw wide glyphs at their natural width regardless of which widget "owns" each column. The right half ends up underneath whatever the caller renders next, e.g. a popup's left border or title, and you get a garbled overlap.

Fix shrinks that glyph to a single space before doing the normal reset, using the existing `CellWidth` trait to detect it. Added a regression test that reproduces the overlap (fails without the fix), plus one confirming single-width neighbours are left alone and one for the buffer-edge case so the new bounds check doesn't panic.

I looked into the right-edge half of the issue too (glyph continuation past `area.right()`), but couldn't actually reproduce it through `set_string`/`with_lines` - the continuation cell is already reset to a proper space by the buffer's own multi-width handling, so I left that out to keep this scoped to the bug I could actually trigger.