### PR TITLE
fix(barchart): split horizontal value text by display width

### DIFF
--- a/ratatui-widgets/src/barchart.rs
+++ b/ratatui-widgets/src/barchart.rs
@@ -1574,6 +1574,18 @@ mod tests {
         assert_eq!(buffer, Buffer::with_lines(["████████", "██中文██"]));
     }
 
+    /// Empty `text_value` skips value painting and leaves only the bar fill.
+    #[test]
+    fn horizontal_empty_text_value_skips_value_paint() {
+        let chart = BarChart::default()
+            .direction(Direction::Horizontal)
+            .bar_gap(0)
+            .data(BarGroup::default().bars(&[Bar::default().value(5).text_value("")]));
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 5, 1));
+        chart.render(buffer.area, &mut buffer);
+        assert_eq!(buffer, Buffer::with_lines(["█████"]));
+    }
+
     /// Multi-byte single-width characters must be split by display width on
     /// horizontal bars, not by UTF-8 byte length.
     ///

--- a/ratatui-widgets/src/barchart.rs
+++ b/ratatui-widgets/src/barchart.rs
@@ -1573,4 +1573,62 @@ mod tests {
         widget.render(buffer.area, &mut buffer);
         assert_eq!(buffer, Buffer::with_lines(["████████", "██中文██"]));
     }
+
+    /// Multi-byte single-width characters must be split by display width on
+    /// horizontal bars, not by UTF-8 byte length.
+    ///
+    /// `"α"` is two bytes and one cell. With `bar_length == 3` the value
+    /// `"ααααα"` must paint all five cells; the first three use `value_style`
+    /// and the rest use the bar style. Splitting on byte indices leaves a
+    /// filled-block cell in the middle and mis-styles the overflow.
+    #[test]
+    fn horizontal_multibyte_text_value_split_by_display_width() {
+        let bar = Bar::default()
+            .value(3)
+            .text_value("ααααα")
+            .value_style(Style::default().red());
+        let chart = BarChart::default()
+            .data(BarGroup::default().bars(&[bar, Bar::default().value(5)]))
+            .direction(Direction::Horizontal)
+            .bar_style(Style::default().yellow())
+            .value_style(Style::default().italic())
+            .bar_gap(0);
+
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 5, 2));
+        chart.render(buffer.area, &mut buffer);
+
+        let mut expected = Buffer::with_lines(["ααααα", "5████"]);
+        for x in 0..3 {
+            let cell = &mut expected[(x, 0)];
+            cell.set_fg(Color::Red);
+            cell.modifier.insert(Modifier::ITALIC);
+        }
+        for x in 3..5 {
+            expected[(x, 0)].set_fg(Color::Yellow);
+        }
+        expected[(0, 1)].modifier.insert(Modifier::ITALIC);
+        for x in 0..5 {
+            expected[(x, 1)].set_fg(Color::Yellow);
+        }
+        assert_eq!(buffer, expected);
+    }
+
+    /// CJK text values are multi-byte and double-width. On a full-width bar the
+    /// old byte-length split could subtract a larger byte count from
+    /// `area.width`, overflowing in debug builds.
+    #[test]
+    fn horizontal_cjk_text_value_does_not_panic_when_longer_than_bar() {
+        let chart = BarChart::default()
+            .direction(Direction::Horizontal)
+            .bar_gap(0)
+            .data(
+                BarGroup::default()
+                    .bars(&[Bar::default().value(10).text_value("一二三四五六七八九十")]),
+            );
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 1));
+        chart.render(buffer.area, &mut buffer);
+        // First five CJK glyphs fill the 10-wide area (2 cells each); the rest
+        // is truncated by the buffer width.
+        assert_eq!(buffer, Buffer::with_lines(["一二三四五"]));
+    }
 }

--- a/ratatui-widgets/src/barchart.rs
+++ b/ratatui-widgets/src/barchart.rs
@@ -1592,7 +1592,7 @@ mod tests {
     /// `"α"` is two bytes and one cell. With `bar_length == 3` the value
     /// `"ααααα"` must paint all five cells; the first three use `value_style`
     /// and the rest use the bar style. Splitting on byte indices leaves a
-    /// filled-block cell in the middle and mis-styles the overflow.
+    /// filled-block cell in the middle and styles the overflow incorrectly.
     #[test]
     fn horizontal_multibyte_text_value_split_by_display_width() {
         let bar = Bar::default()

--- a/ratatui-widgets/src/barchart/bar.rs
+++ b/ratatui-widgets/src/barchart/bar.rs
@@ -225,27 +225,24 @@ impl<'a> Bar<'a> {
             return;
         }
 
+        // `text_width > bar_length` means some character cannot fit in the bar, so the loop
+        // always breaks with `split_byte` at a `char_indices` boundary and a non-empty suffix.
         let mut used_width = 0usize;
-        let mut split_byte = None;
+        let mut split_byte = 0usize;
         for (i, ch) in text.char_indices() {
             let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
             if used_width.saturating_add(ch_width) > bar_length {
-                split_byte = Some(i);
+                split_byte = i;
                 break;
             }
             used_width = used_width.saturating_add(ch_width);
         }
 
-        // `char_indices` always yields char boundaries, so `get` cannot fail here.
-        let Some(second) = split_byte.and_then(|i| text.get(i..)) else {
-            return;
-        };
-        if second.is_empty() {
-            return;
-        }
-
         let style = bar_style.patch(self.style);
         let remaining = (area.width as usize).saturating_sub(used_width);
+        // `split_byte` comes from `char_indices`, so it is always a char boundary.
+        #[allow(clippy::string_slice)]
+        let second = &text[split_byte..];
         buf.set_stringn(
             area.x.saturating_add(used_width as u16),
             area.y,

--- a/ratatui-widgets/src/barchart/bar.rs
+++ b/ratatui-widgets/src/barchart/bar.rs
@@ -5,7 +5,7 @@ use ratatui_core::layout::Rect;
 use ratatui_core::style::{Style, Styled};
 use ratatui_core::text::Line;
 use ratatui_core::widgets::Widget;
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 /// A bar to be shown by the [`BarChart`](super::BarChart) widget.
 ///
@@ -209,32 +209,50 @@ impl<'a> Bar<'a> {
         let value = self.value.to_string();
         let text = self.text_value.as_ref().unwrap_or(&value);
 
-        if !text.is_empty() {
-            let style = default_value_style.patch(self.value_style);
-            // Since the value may be longer than the bar itself, we need to use 2 different styles
-            // while rendering. Render the first part with the default value style
-            buf.set_stringn(area.x, area.y, text, bar_length, style);
-            // render the second part with the bar_style
-            if text.len() > bar_length {
-                // Find the last character boundary at or before bar_length
-                let bar_length = text
-                    .char_indices()
-                    .take_while(|(i, _)| *i < bar_length)
-                    .last()
-                    .map_or(0, |(i, c)| i + c.len_utf8());
-
-                let (first, second) = text.split_at(bar_length);
-
-                let style = bar_style.patch(self.style);
-                buf.set_stringn(
-                    area.x + first.len() as u16,
-                    area.y,
-                    second,
-                    area.width as usize - first.len(),
-                    style,
-                );
-            }
+        if text.is_empty() {
+            return;
         }
+
+        let style = default_value_style.patch(self.value_style);
+        // Since the value may be longer than the bar itself, we need to use 2 different styles
+        // while rendering. Render the first part with the default value style
+        buf.set_stringn(area.x, area.y, text, bar_length, style);
+
+        // `bar_length` and `Buffer::set_stringn` both work in terminal cells. Split the overflow
+        // by display width (not UTF-8 byte length) so multi-byte and wide characters stay aligned.
+        let text_width = text.width();
+        if text_width <= bar_length {
+            return;
+        }
+
+        let mut used_width = 0usize;
+        let mut split_byte = None;
+        for (i, ch) in text.char_indices() {
+            let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+            if used_width.saturating_add(ch_width) > bar_length {
+                split_byte = Some(i);
+                break;
+            }
+            used_width = used_width.saturating_add(ch_width);
+        }
+
+        // `char_indices` always yields char boundaries, so `get` cannot fail here.
+        let Some(second) = split_byte.and_then(|i| text.get(i..)) else {
+            return;
+        };
+        if second.is_empty() {
+            return;
+        }
+
+        let style = bar_style.patch(self.style);
+        let remaining = (area.width as usize).saturating_sub(used_width);
+        buf.set_stringn(
+            area.x.saturating_add(used_width as u16),
+            area.y,
+            second,
+            remaining,
+            style,
+        );
     }
 
     pub(super) fn render_value(


### PR DESCRIPTION
## Summary

Horizontal `BarChart` value labels that overflow the filled bar are split and restyled using **terminal cell width** instead of UTF-8 **byte length**, so multi-byte and wide characters render without gaps or panics.

## Problem

`Bar::render_value_with_different_styles` paints the part of a value that fits inside the filled bar with `value_style`, and the overflow with `bar_style`. The first write correctly used `Buffer::set_stringn` (cell budget), but the overflow path compared `text.len()` (bytes) to `bar_length` (cells), split with `char_indices` against that mixed budget, then placed the second segment at `area.x + first.len()` with `area.width as usize - first.len()`.

### How it fails

1. **Misaligned overflow (multi-byte, single-width cells)**  
   For `text_value = "ααααα"` (each `α` is 2 bytes, 1 cell) and `bar_length = 3`, the bar should show five `α` cells: three with value style, two with bar style. The byte-based split left a filled-block cell in the middle (`ααα α`).

2. **Debug panic (wide CJK on a full bar)**  
   For a full-width bar and a long CJK `text_value`, the "first" segment's **byte** length can exceed `area.width` (cell count). `area.width as usize - first.len()` overflows in debug builds.

### Origin

- Overflow styling path introduced with horizontal bars in [#325](https://github.com/ratatui/ratatui/pull/325) ([`0dca6a689`](https://github.com/ratatui/ratatui/commit/0dca6a689), 2023-08-25).
- A later multi-byte fix in [#1934](https://github.com/ratatui/ratatui/pull/1934) ([`21e3b598`](https://github.com/ratatui/ratatui/commit/21e3b598), 2025-06-25) made the split char-boundary safe but still treated byte indices as a cell budget.
- Related recent work: [#2625](https://github.com/ratatui/ratatui/pull/2625) fixed the same class of bug (byte length vs display width) for **vertical** value label centering.

## Change

- Split and place overflow by Unicode **display width**, aligned with `Buffer::set_stringn`.
- Use saturating arithmetic for remaining width and x offset.
- Add two regression tests in `barchart.rs`.

## Testing

```
Red step (before fix):
  horizontal_multibyte_text_value_split_by_display_width  FAIL
    left:  "ααα α"   (gap at column 3)
    right: "ααααα"
  horizontal_cjk_text_value_does_not_panic_when_longer_than_bar  FAIL
    attempt to subtract with overflow at bar.rs:233

Green step (after fix):
  both tests PASS
  cargo test -p ratatui-widgets --lib barchart  →  50 passed
  cargo clippy -p ratatui-widgets --lib -- -D warnings  →  clean
```

## Related

- Same-repo: [#325](https://github.com/ratatui/ratatui/pull/325), [#1934](https://github.com/ratatui/ratatui/pull/1934), [#2625](https://github.com/ratatui/ratatui/pull/2625), [#1928](https://github.com/ratatui/ratatui/issues/1928) (related multi-byte label panic history)
- No open duplicate PR for the horizontal overflow path

## Disclosure

Prepared with AI assistance. I reviewed every line and verified the fix with red/green tests and the full `barchart` unit suite locally.