### PR TITLE
fix(xtask): deny warnings in workspace docs check

### DIFF
--- a/examples/apps/advanced-widget-impl/src/main.rs
+++ b/examples/apps/advanced-widget-impl/src/main.rs
@@ -139,6 +139,8 @@ impl Default for Timer {
 /// This approach was probably always available in Ratatui, but it wasn't widely used until `Widget`
 /// was implemented on references in [PR #903] (merged in Ratatui 0.26.0). This is because all the
 /// built-in widgets previously would consume themselves when rendered.
+///
+/// [PR #903]: https://github.com/ratatui/ratatui/pull/903
 impl Widget for &Timer {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let elapsed = self.start.elapsed().as_secs_f32();

--- a/xtask/src/commands/docs.rs
+++ b/xtask/src/commands/docs.rs
@@ -1,6 +1,9 @@
-use color_eyre::Result;
+use std::env;
 
-use crate::{Run, run_cargo_nightly};
+use color_eyre::Result;
+use duct::cmd;
+
+use crate::{ExpressionExt, Run, run_cargo_nightly};
 
 /// Check documentation for errors and warnings
 #[derive(Clone, Debug, clap::Args)]
@@ -12,6 +15,8 @@ pub struct Docs {
 
 impl Run for Docs {
     fn run(self) -> Result<()> {
+        lint_workspace_docs()?;
+
         // cargo +nightly hack --all --ignore-private docs-rs
         let mut args = vec!["hack", "--all", "--ignore-private", "docs-rs"];
         if self.open {
@@ -19,4 +24,16 @@ impl Run for Docs {
         }
         run_cargo_nightly(args)
     }
+}
+
+fn lint_workspace_docs() -> Result<()> {
+    let rustdocflags = match env::var("RUSTDOCFLAGS") {
+        Ok(flags) if !flags.is_empty() => format!("{flags} -Dwarnings"),
+        _ => "-Dwarnings".to_string(),
+    };
+
+    cmd!("cargo", "doc", "--all-features", "--no-deps")
+        .env("RUSTDOCFLAGS", rustdocflags)
+        .run_with_trace()?;
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- run a warning-deny workspace `cargo doc --all-features --no-deps` pass before the existing docs.rs check in `cargo xtask docs`
- preserve existing `RUSTDOCFLAGS` while appending `-Dwarnings`
- fix the currently broken `[PR #903]` link in the advanced widget example docs

## Why

Fixes #989.

The current docs.rs check intentionally uses `cargo hack --all --ignore-private docs-rs`, which skips private example packages. That means local docs checks can miss rustdoc warnings from those workspace members. This keeps the docs.rs path intact and adds a small preflight that catches the warning class reproduced by the issue.

This PR was prepared with AI assistance and all generated changes were reviewed.

## Tests

- `cargo doc --all-features --no-deps`
  - before patch: exited 0 while warning about the unresolved `[PR #903]` link
- `RUSTDOCFLAGS=-Dwarnings cargo doc --all-features --no-deps`
  - before patch: exited 101 on the unresolved `[PR #903]` link
  - after patch: exited 0
- `cargo xtask docs`
  - after patch: the new workspace docs phase ran first and passed
  - the existing docs.rs phase then stopped locally because this machine only has stable Cargo and that phase uses nightly-only `-Z` flags
- `cargo check -p xtask`
- `cargo test -p xtask`
- `cargo fmt --check`
- `git diff --check`

## Scope

- In scope: local docs/xtask warning coverage for workspace docs and the broken link required for the new warning-deny proof to pass.
- Non-goals: CI rewrite, docs.rs behavior changes, dependency changes, formatting sweep, or rendering/widget behavior changes.
