### PR TITLE
perf: reduce size of Cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,15 +335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,21 +528,6 @@ dependencies = [
  "crossterm 0.29.0",
  "palette",
  "ratatui",
-]
-
-[[package]]
-name = "compact_str"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "serde",
- "static_assertions",
 ]
 
 [[package]]
@@ -2867,7 +2843,6 @@ version = "0.1.2"
 dependencies = [
  "anstyle",
  "bitflags 2.13.0",
- "compact_str",
  "critical-section",
  "document-features",
  "hashbrown 0.17.1",
@@ -2880,6 +2855,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "sinstr",
  "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -3497,6 +3473,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sinstr"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d749a397a42f203d82876d791faf53953507737954df0229f364ba3f524805e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3566,12 +3551,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ ratatui-widgets = { path = "ratatui-widgets", version = "0.3.2", default-feature
 rstest = "0.26"
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 serde_json = "1.0.142"
+sinstr = "0.4.4"
 strum = { version = "0.28", default-features = false, features = ["derive"] }
 termina = "0.3"
 termion = "4"

--- a/ratatui-core/Cargo.toml
+++ b/ratatui-core/Cargo.toml
@@ -30,7 +30,6 @@ default = []
 ## enables std
 std = [
   "bitflags/std",
-  "compact_str/std",
   "itertools/use_std",
   "kasuari/std",
   "palette?/std",
@@ -63,12 +62,11 @@ scrolling-regions = []
 
 ## enables serialization and deserialization of style and color types using the [`serde`] crate.
 ## This is useful if you want to save themes to a file.
-serde = ["bitflags/serde", "compact_str/serde", "dep:serde"]
+serde = ["bitflags/serde", "dep:serde", "sinstr/serde"]
 
 [dependencies]
 anstyle = { workspace = true, optional = true }
 bitflags.workspace = true
-compact_str.workspace = true
 critical-section = { workspace = true, optional = true }
 document-features = { workspace = true, optional = true }
 hashbrown.workspace = true
@@ -77,6 +75,7 @@ kasuari = { workspace = true, default-features = false }
 lru.workspace = true
 palette = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
+sinstr.workspace = true
 strum.workspace = true
 thiserror = { workspace = true, default-features = false }
 unicode-segmentation.workspace = true

--- a/ratatui-core/src/buffer/cell.rs
+++ b/ratatui-core/src/buffer/cell.rs
@@ -1,6 +1,6 @@
 use core::num::NonZeroU16;
 
-use compact_str::CompactString;
+use sinstr::SinStr;
 
 use crate::buffer::cell_width::CellWidth;
 use crate::style::{Color, Modifier, Style};
@@ -39,11 +39,11 @@ pub struct Cell {
     ///
     /// This accepts unicode grapheme clusters which might take up more than one cell.
     ///
-    /// This is a [`CompactString`] which is a wrapper around [`String`] that uses a small inline
+    /// This is a [`SinStr`] which is a wrapper around [`String`] that uses a small inline
     /// buffer for short strings.
     ///
     /// See <https://github.com/ratatui/ratatui/pull/601> for more information.
-    symbol: Option<CompactString>,
+    symbol: Option<SinStr>,
 
     /// The foreground color of the cell.
     pub fg: Color,
@@ -89,11 +89,11 @@ impl Cell {
     ///
     /// This works at compile time and puts the symbol onto the stack. Fails to build when the
     /// symbol doesn't fit onto the stack and requires to be placed on the heap. Use
-    /// `Self::default().set_symbol()` in that case. See [`CompactString::const_new`] for more
+    /// `Self::default().set_symbol()` in that case. See [`SinStr::new_const`] for more
     /// details on this.
     pub const fn new(symbol: &'static str) -> Self {
         Self {
-            symbol: Some(CompactString::const_new(symbol)),
+            symbol: Some(SinStr::new_const(symbol)),
             ..Self::EMPTY
         }
     }
@@ -148,13 +148,13 @@ impl Cell {
             .symbol
             .as_ref()
             .map_or(symbol, |s| strategy.merge(s, symbol));
-        self.symbol = Some(CompactString::new(merged_symbol));
+        self.symbol = Some(SinStr::new(merged_symbol));
         self
     }
 
     /// Sets the symbol of the cell.
     pub fn set_symbol(&mut self, symbol: &str) -> &mut Self {
-        self.symbol = Some(CompactString::new(symbol));
+        self.symbol = Some(SinStr::new(symbol));
         self
     }
 
@@ -169,7 +169,7 @@ impl Cell {
     /// Sets the symbol of the cell to a single character.
     pub fn set_char(&mut self, ch: char) -> &mut Self {
         let mut buf = [0; 4];
-        self.symbol = Some(CompactString::new(ch.encode_utf8(&mut buf)));
+        self.symbol = Some(SinStr::new(ch.encode_utf8(&mut buf)));
         self
     }
 
@@ -328,7 +328,7 @@ mod tests {
         assert_eq!(
             cell,
             Cell {
-                symbol: Some(CompactString::const_new("あ")),
+                symbol: Some(SinStr::new("あ")),
                 fg: Color::Reset,
                 bg: Color::Reset,
                 #[cfg(feature = "underline-color")]

--- a/ratatui-core/src/buffer/diff.rs
+++ b/ratatui-core/src/buffer/diff.rs
@@ -207,10 +207,9 @@ const fn is_skip(cell: &Cell) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
     use alloc::vec::Vec;
     use core::num::NonZeroU16;
-
-    use compact_str::CompactString;
 
     use super::*;
     use crate::buffer::Buffer;
@@ -317,7 +316,7 @@ mod tests {
         let mut next = Buffer::with_lines(["xyz"]);
         next.content[1].skip = true;
 
-        let diff: CompactString = BufferDiff::new(&prev, &next)
+        let diff: String = BufferDiff::new(&prev, &next)
             .map(|(_, _, cell)| cell.symbol())
             .collect();
 
@@ -333,11 +332,11 @@ mod tests {
         next.content[0].diff_option = CellDiffOption::ForcedWidth(NonZeroU16::new(2).unwrap());
 
         // ForcedWidth wins over skip=true, so the cell is diffed with forced width
-        let diff: CompactString = BufferDiff::new(&prev, &next)
+        let diff: String = BufferDiff::new(&prev, &next)
             .map(|(_, _, cell)| cell.symbol())
             .collect();
 
-        assert_eq!(diff, "x");
+        assert_eq!(diff.as_str(), "x");
     }
 
     /// Regression test for the "uncovered trailing cell" bug.


### PR DESCRIPTION
Currently a `Cell` uses 48 bytes. This isn't significant for modern desktops but embedded targets often need to deal with a limited amount of memory.

See: https://github.com/ratatui/ratatui/issues/2397

To reduce the size of a `Cell` we make use of the `sinstr` library which is a small string optimization library aimed to heavily optimize for memory usage when many of them are stored (like in `Buffer`).

Using `sinstr` shrinks the size of a `Cell` to 32 bytes. Allowing to keep more memory available on targets with limited RAM.

This PR is different than https://github.com/ratatui/ratatui/pull/2398 which solves the issue by limiting capacity to 4 bytes.
Instead, on 32 bit targets a `SinStr` will use the same amount of memory as `EmbeddedStr` while still allowing for longer strings but with the cost of only storing 3 bytes inlined.

Because `sinstr` was designed as a more general use library rather than a workaround, it requires very little changes for `ratatui` to use it.

DISCLAIMER: I am the creator and maintainer of `sinstr`. In order to provide compatibility with `ratatui` (and other libraries) I have lowered the MSRV and added `serde` support.