### PR TITLE
ci: restore docs and advisory checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/ratatui-widgets/Cargo.toml
+++ b/ratatui-widgets/Cargo.toml
@@ -35,7 +35,7 @@ serde = ["dep:serde", "ratatui-core/serde"]
 ## enables all widgets.
 all-widgets = ["calendar"]
 
-## enables the [`calendar`](calendar) widget module and adds a dependency on [`time`].
+## enables the [`calendar`] widget module and adds a dependency on [`time`].
 calendar = ["dep:time"]
 
 ## Enable all unstable features.

--- a/ratatui/Cargo.toml
+++ b/ratatui/Cargo.toml
@@ -76,7 +76,7 @@ scrolling-regions = [
   "ratatui-termwiz?/scrolling-regions",
 ]
 
-## enables the [`macros`](macros) module which provides some useful macros for creating spans,
+## enables the [`macros`] module which provides some useful macros for creating spans,
 ## lines, text, and layouts
 macros = ["dep:ratatui-macros"]
 


### PR DESCRIPTION
## Evidence

- `RUSTDOCFLAGS=-Dwarnings cargo +nightly-2026-07-14 hack --all --ignore-private docs-rs` passes for all eight publishable workspace crates using the same 2026-07-14 nightly as CI. This is the command delegated to by `cargo xtask docs`.
- `cargo deny --log-level info --all-features --exclude-unpublished check advisories` reports 0 errors, 0 warnings, and 0 notes against the current RustSec advisory database.
- `cargo tree -i crossbeam-epoch --workspace --all-features` confirms the affected package is only reached through Criterion's Rayon dependency chain.

## Changes

- Remove redundant explicit targets from the `macros` and `calendar` feature-description links that `document_features` injects into crate docs. The `calendar` instance was exposed only after the earlier `macros` failure was fixed.
- Update only the `crossbeam-epoch` lockfile entry from 0.9.18 to the fixed, semver-compatible 0.9.20 release required by RUSTSEC-2026-0204. No manifest minimum changes.

These are the two unrelated failures currently affecting `main` and the checks on #2647; the published performance-engineering docs change is not included in this PR.
