### PR TITLE
feat(table): build rows lazily for large datasets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,6 +1893,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
+name = "lazy-table"
+version = "0.0.0"
+dependencies = [
+ "color-eyre",
+ "crossterm 0.29.0",
+ "ratatui",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/README.md
+++ b/examples/README.md
@@ -152,6 +152,11 @@ Shows how to use the inlined viewport to render in a specific area of the screen
 
 Shows how to render a form with input fields. [Source](./apps/input-form/).
 
+## Lazy Table
+
+Shows how to display a table with ten million rows that are built on demand.
+[Source](./apps/lazy-table/).
+
 ## Modifiers
 
 Shows different types of modifiers. [Source](./apps/modifiers/).

--- a/examples/apps/lazy-table/Cargo.toml
+++ b/examples/apps/lazy-table/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "lazy-table"
+publish = false
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+color-eyre.workspace = true
+crossterm.workspace = true
+ratatui.workspace = true
+
+[lints]
+workspace = true

--- a/examples/apps/lazy-table/README.md
+++ b/examples/apps/lazy-table/README.md
@@ -1,0 +1,13 @@
+# Lazy table demo
+
+This example shows how to display a table with 10 million rows using lazy implementation.
+
+The status bar reports how many rows the table actually built for the last frame and how long the
+frame took, so you can watch scrolling stay flat no matter how far into the dataset you jump. Press
+`v` to switch between uniform and variable row heights.
+
+To run this demo:
+
+```shell
+cargo run -p lazy-table
+```

--- a/examples/apps/lazy-table/src/main.rs
+++ b/examples/apps/lazy-table/src/main.rs
@@ -1,0 +1,205 @@
+/// A Ratatui example that demonstrates a table with ten million rows.
+///
+/// [`Table::lazy_rows`] builds rows on demand, so only the rows that are actually on screen
+/// are ever created. The status bar shows how many rows
+/// the last frame built and how long it took to draw, which stays flat however far into the
+/// dataset you scroll. Press `v` to switch between uniform and variable row heights.
+///
+/// This example runs with the Ratatui library code in the branch that you are currently
+/// reading. See the [`latest`] branch for the code which works with the most recent Ratatui
+/// release.
+///
+/// [`latest`]: https://github.com/ratatui/ratatui/tree/latest
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::layout::{Constraint, Layout};
+use ratatui::style::palette::tailwind;
+use ratatui::style::{Modifier, Style, Stylize};
+use ratatui::text::{Line, Text};
+use ratatui::widgets::{Block, HighlightSpacing, Row, Table, TableState};
+use ratatui::{DefaultTerminal, Frame};
+
+/// Ten million rows, none of which exist until they are drawn.
+const ROW_COUNT: usize = 10_000_000;
+
+/// Every twenty-fifth row is a taller, three line row.
+const TALL_ROW_INTERVAL: usize = 25;
+
+const WIDTHS: [Constraint; 4] = [
+    Constraint::Length(10),
+    Constraint::Length(18),
+    Constraint::Length(12),
+    Constraint::Fill(1),
+];
+
+const INSTRUCTIONS: &str =
+    "(q) quit  (↑/↓) move  (PgUp/PgDn) page  (Home/End) jump  (v) toggle row heights";
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    ratatui::run(|terminal| App::new().run(terminal))
+}
+
+struct App {
+    state: TableState,
+    /// Whether rows have varying heights, or all share the same height.
+    variable_heights: bool,
+    /// How many rows the row factory built, reset before every frame.
+    rows_built: Arc<AtomicUsize>,
+    /// How long the last frame took to draw, and how many rows it built.
+    last_frame: (Duration, usize),
+    exit: bool,
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            state: TableState::new().with_selected(0),
+            variable_heights: true,
+            rows_built: Arc::new(AtomicUsize::new(0)),
+            last_frame: (Duration::ZERO, 0),
+            exit: false,
+        }
+    }
+
+    fn run(mut self, terminal: &mut DefaultTerminal) -> Result<()> {
+        while !self.exit {
+            self.rows_built.store(0, Ordering::Relaxed);
+            let started = Instant::now();
+            terminal.draw(|frame| self.render(frame))?;
+            self.last_frame = (started.elapsed(), self.rows_built.load(Ordering::Relaxed));
+
+            self.handle_events()?;
+        }
+        Ok(())
+    }
+
+    fn handle_events(&mut self) -> Result<()> {
+        if let Some(key) = event::read()?.as_key_press_event() {
+            match key.code {
+                KeyCode::Char('q') | KeyCode::Esc => self.exit = true,
+                KeyCode::Char('j') | KeyCode::Down => self.state.select_next(),
+                KeyCode::Char('k') | KeyCode::Up => self.state.select_previous(),
+                KeyCode::PageDown => self.state.scroll_down_by(20),
+                KeyCode::PageUp => self.state.scroll_up_by(20),
+                KeyCode::Home => self.state.select_first(),
+                // `select_last` selects `usize::MAX`, which the table clamps to the last row.
+                KeyCode::End => self.state.select_last(),
+                KeyCode::Char('v') => self.variable_heights = !self.variable_heights,
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn render(&mut self, frame: &mut Frame) {
+        let [header_area, table_area, footer_area] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Fill(1),
+            Constraint::Length(1),
+        ])
+        .areas(frame.area());
+
+        frame.render_widget(
+            Line::from(format!(" {ROW_COUNT} rows, built on demand ")).bold(),
+            header_area,
+        );
+        frame.render_stateful_widget(self.table(), table_area, &mut self.state);
+        frame.render_widget(self.status_line(), footer_area);
+    }
+
+    /// Build the table for this frame.
+    ///
+    /// This is cheap no matter how large `ROW_COUNT` is: the table only stores the row count and
+    /// the closures, and calls the row factory while it draws.
+    fn table(&self) -> Table<'static> {
+        let rows_built = Arc::clone(&self.rows_built);
+        let row = move |index: usize| {
+            rows_built.fetch_add(1, Ordering::Relaxed);
+            build_row(index)
+        };
+
+        let table = if self.variable_heights {
+            Table::lazy_rows(ROW_COUNT, WIDTHS, row).row_height_with(row_height)
+        } else {
+            Table::lazy_rows(ROW_COUNT, WIDTHS, row)
+        };
+
+        table
+            .header(
+                Row::new(["Id", "Name", "Value", "Notes"])
+                    .style(Style::new().bold().fg(tailwind::SLATE.c200)),
+            )
+            .block(Block::bordered().title(" Lazy table "))
+            .row_highlight_style(Style::new().add_modifier(Modifier::REVERSED))
+            .highlight_symbol(" ▶ ")
+            .highlight_spacing(HighlightSpacing::Always)
+    }
+
+    fn status_line(&self) -> Line<'static> {
+        let (elapsed, rows_built) = self.last_frame;
+        let selected = self.state.selected().unwrap_or(0);
+        let heights = if self.variable_heights {
+            "variable"
+        } else {
+            "uniform"
+        };
+        Line::from(vec![
+            format!(
+                " row {selected} | {heights} heights | {rows_built} rows built in {:.2}ms ",
+                elapsed.as_secs_f64() * 1000.0
+            )
+            .into(),
+            INSTRUCTIONS.dim(),
+        ])
+    }
+}
+
+/// The height of a row, which scrolling needs to know without building the row itself.
+const fn row_height(index: usize) -> u16 {
+    if index.is_multiple_of(TALL_ROW_INTERVAL) {
+        3
+    } else {
+        1
+    }
+}
+
+/// Build the row at `index`, deriving its content from the index alone.
+///
+/// A real application would look the row up in a database, a log file, or an in-memory dataset;
+/// the point is that this only ever runs for the rows that are on screen.
+fn build_row(index: usize) -> Row<'static> {
+    const NAMES: [&str; 8] = [
+        "Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel",
+    ];
+
+    let name = format!("{} {index}", NAMES[index % NAMES.len()]);
+    let value = format!("{:.2}", (index % 10_000) as f64 / 100.0);
+
+    if row_height(index) > 1 {
+        // A taller row: its extra lines come from a multi-line cell.
+        let notes = Text::from(vec![
+            Line::from("section marker").bold(),
+            Line::from(format!("rows {index}..{}", index + TALL_ROW_INTERVAL)),
+            Line::from("─".repeat(20)).dim(),
+        ]);
+        Row::new([
+            Text::from(index.to_string()),
+            Text::from(name),
+            Text::from(value),
+            notes,
+        ])
+        .style(Style::new().fg(tailwind::EMERALD.c400))
+    } else {
+        Row::new([
+            index.to_string(),
+            name,
+            value,
+            format!("generated on demand for row {index}"),
+        ])
+    }
+}

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -1,8 +1,12 @@
 //! The [`Table`] widget is used to display multiple rows and columns in a grid and allows selecting
 //! one or multiple cells.
 
+use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
+use core::hash::Hasher;
+use core::panic::RefUnwindSafe;
+use core::{fmt, ptr};
 
 use itertools::Itertools;
 use ratatui_core::buffer::Buffer;
@@ -21,6 +25,198 @@ mod cell;
 mod highlight_spacing;
 mod row;
 mod state;
+
+/// Supplies the height of a lazy row *without* building it.
+///
+/// Scrolling has to know the geometry of rows that are never drawn (for instance the rows between
+/// the current offset and a selection further down the table), so heights are described separately
+/// from the rows themselves. This is what keeps variable-height lazy tables correct: the scroll
+/// calculation asks for heights, not for rows.
+enum LazyRowHeights<'a> {
+    /// Every row occupies the same number of lines.
+    Uniform(u16),
+    /// Row heights are computed on demand from the row index.
+    PerRow(Arc<dyn Fn(usize) -> u16 + Send + Sync + RefUnwindSafe + 'a>),
+}
+
+impl LazyRowHeights<'_> {
+    /// The number of lines occupied by the row at `index`.
+    fn height_of(&self, index: usize) -> u16 {
+        match self {
+            Self::Uniform(height) => *height,
+            Self::PerRow(heights) => heights(index),
+        }
+    }
+}
+
+impl fmt::Debug for LazyRowHeights<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Uniform(height) => f.debug_tuple("Uniform").field(height).finish(),
+            Self::PerRow(_) => f.debug_tuple("PerRow").finish(),
+        }
+    }
+}
+
+impl Clone for LazyRowHeights<'_> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Uniform(height) => Self::Uniform(*height),
+            Self::PerRow(heights) => Self::PerRow(Arc::clone(heights)),
+        }
+    }
+}
+
+impl PartialEq for LazyRowHeights<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Uniform(left), Self::Uniform(right)) => left == right,
+            (Self::PerRow(left), Self::PerRow(right)) => Arc::ptr_eq(left, right),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for LazyRowHeights<'_> {}
+
+impl core::hash::Hash for LazyRowHeights<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Uniform(height) => {
+                "uniform".hash(state);
+                height.hash(state);
+            }
+            Self::PerRow(heights) => {
+                "per_row".hash(state);
+                ptr::hash(Arc::as_ptr(heights), state);
+            }
+        }
+    }
+}
+
+/// Stores the parameters needed to build rows on demand for a lazy table.
+struct LazyRowProvider<'a> {
+    count: usize,
+    heights: LazyRowHeights<'a>,
+    factory: Arc<dyn Fn(usize) -> Row<'a> + Send + Sync + RefUnwindSafe + 'a>,
+}
+
+impl LazyRowProvider<'_> {
+    /// The number of lines occupied by the row at `index`.
+    fn height_of(&self, index: usize) -> u16 {
+        self.heights.height_of(index)
+    }
+
+    /// Return the indexes of the visible rows, as [`Table::visible_rows`] does for eager rows.
+    ///
+    /// The algorithm is the same, and produces the same window, but it only ever consults
+    /// [`LazyRowProvider::height_of`] instead of inspecting rows, so no row outside the returned
+    /// range is ever built. In particular, when the selection sits below the window the range is
+    /// anchored *at the selection and grown upwards* rather than scrolled down one row at a time,
+    /// which keeps the work proportional to the visible area rather than to the distance scrolled.
+    ///
+    /// The one case where the two differ is a selected row taller than the whole area: growing the
+    /// window upwards keeps such a row on screen (clipped), where scrolling down one row at a time
+    /// walks past it and leaves it off screen entirely.
+    fn visible_rows(&self, state: &TableState, area: Rect) -> (usize, usize) {
+        if self.count == 0 || area.height == 0 {
+            return (0, 0);
+        }
+        let last_row = self.count - 1;
+        let selected = state.selected.map(|selected| selected.min(last_row));
+
+        let mut start = state.offset.min(last_row);
+        if let Some(selected) = selected {
+            start = start.min(selected);
+        }
+
+        // Fill the area downwards from the start with the rows that fit in it completely.
+        let mut end = start;
+        let mut height = 0_u16;
+        while end < self.count {
+            let row_height = self.height_of(end);
+            if height.saturating_add(row_height) > area.height {
+                break;
+            }
+            height += row_height;
+            end += 1;
+            if window_is_full(start, end, area) {
+                break;
+            }
+        }
+
+        // Scroll down until the selected row is visible, by anchoring the window at the selection
+        // and growing it upwards until the area is full.
+        if let Some(selected) = selected
+            && selected >= end
+        {
+            start = selected;
+            end = selected + 1;
+            height = self.height_of(selected);
+            while start > 0 && !window_is_full(start, end, area) {
+                let row_height = self.height_of(start - 1);
+                if height.saturating_add(row_height) > area.height {
+                    break;
+                }
+                height += row_height;
+                start -= 1;
+            }
+        }
+
+        // Include a partial row if there is space
+        if height < area.height && end < self.count && !window_is_full(start, end, area) {
+            end += 1;
+        }
+
+        (start, end)
+    }
+}
+
+/// Whether a window of lazy rows can be grown no further.
+///
+/// A window never holds more rows than the area has lines, plus one partial row. Rows are free to
+/// report a height of zero, so this bound is what keeps [`LazyRowProvider::visible_rows`]
+/// proportional to the area rather than to the number of rows.
+const fn window_is_full(start: usize, end: usize, area: Rect) -> bool {
+    end - start > area.height as usize
+}
+
+impl fmt::Debug for LazyRowProvider<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LazyRowProvider")
+            .field("count", &self.count)
+            .field("heights", &self.heights)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Clone for LazyRowProvider<'_> {
+    fn clone(&self) -> Self {
+        Self {
+            count: self.count,
+            heights: self.heights.clone(),
+            factory: Arc::clone(&self.factory),
+        }
+    }
+}
+
+impl PartialEq for LazyRowProvider<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.count == other.count
+            && self.heights == other.heights
+            && Arc::ptr_eq(&self.factory, &other.factory)
+    }
+}
+
+impl Eq for LazyRowProvider<'_> {}
+
+impl core::hash::Hash for LazyRowProvider<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.count.hash(state);
+        self.heights.hash(state);
+        ptr::hash(Arc::as_ptr(&self.factory), state);
+    }
+}
 
 /// A widget to display data in formatted columns.
 ///
@@ -269,6 +465,9 @@ pub struct Table<'a> {
 
     /// Controls how to distribute extra space among the columns
     flex: Flex,
+
+    /// Optional lazy row provider used instead of `rows` when set
+    lazy: Option<LazyRowProvider<'a>>,
 }
 
 impl Default for Table<'_> {
@@ -287,6 +486,7 @@ impl Default for Table<'_> {
             highlight_symbol: Text::default(),
             highlight_spacing: HighlightSpacing::default(),
             flex: Flex::Start,
+            lazy: None,
         }
     }
 }
@@ -343,6 +543,8 @@ impl<'a> Table<'a> {
     /// This method does not currently set the column widths. You will need to set them manually by
     /// calling [`Table::widths`].
     ///
+    /// Setting rows explicitly replaces the rows of a table created with [`Table::lazy_rows`].
+    ///
     /// This is a fluent setter method which must be chained or used as it consumes self
     ///
     /// # Examples
@@ -362,6 +564,7 @@ impl<'a> Table<'a> {
         T: IntoIterator<Item = Row<'a>>,
     {
         self.rows = rows.into_iter().collect();
+        self.lazy = None;
         self
     }
 
@@ -720,6 +923,128 @@ impl<'a> Table<'a> {
         self.flex = flex;
         self
     }
+
+    /// Creates a [`Table`] that builds rows lazily, calling the factory only for visible rows.
+    ///
+    /// Unlike [`Table::new`], which eagerly collects all rows into a `Vec`, this constructor stores
+    /// only the total row count and a factory closure. During rendering the factory is called
+    /// exclusively for the rows that fall within the visible viewport, so memory allocation and
+    /// processing work scale with the visible area rather than the total dataset size.
+    ///
+    /// Rows are one line tall by default. Use [`Table::row_height`] for taller rows, or
+    /// [`Table::row_height_with`] when rows have individual heights.
+    ///
+    /// The `widths` parameter works exactly like [`Table::widths`] and must be provided because
+    /// column layout cannot be inferred from rows that have not yet been built.
+    ///
+    /// # Row geometry
+    ///
+    /// The height configured on the table is authoritative: [`Row::height`], [`Row::top_margin`]
+    /// and [`Row::bottom_margin`] set on rows returned by the factory are ignored, because
+    /// scrolling has to reason about rows that are never built. Include any spacing you want in
+    /// the row height.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui::layout::Constraint;
+    /// use ratatui::widgets::{Row, Table};
+    ///
+    /// let table = Table::lazy_rows(
+    ///     10_000,
+    ///     [Constraint::Length(20), Constraint::Fill(1)],
+    ///     |index| Row::new([format!("item {index}"), format!("value {index}")]),
+    /// );
+    /// ```
+    pub fn lazy_rows<C, F>(row_count: usize, widths: C, row: F) -> Self
+    where
+        C: IntoIterator,
+        C::Item: Into<Constraint>,
+        F: Fn(usize) -> Row<'a> + Send + Sync + RefUnwindSafe + 'a,
+    {
+        let widths: Vec<Constraint> = widths.into_iter().map(Into::into).collect();
+        ensure_percentages_less_than_100(&widths);
+        Self {
+            lazy: Some(LazyRowProvider {
+                count: row_count,
+                heights: LazyRowHeights::Uniform(1),
+                factory: Arc::new(row),
+            }),
+            widths,
+            ..Default::default()
+        }
+    }
+
+    /// Set the height, in lines, of every lazily built row.
+    ///
+    /// Use [`Table::row_height_with`] when rows have individual heights.
+    ///
+    /// This is a fluent setter method which must be chained or used as it consumes self
+    ///
+    /// # Note
+    ///
+    /// This only affects rows built by [`Table::lazy_rows`]; rows set with [`Table::new`] or
+    /// [`Table::rows`] carry their own [`Row::height`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui::layout::Constraint;
+    /// use ratatui::widgets::{Row, Table};
+    ///
+    /// let table = Table::lazy_rows(10_000, [Constraint::Length(20)], |index| {
+    ///     Row::new([format!("item {index}")])
+    /// })
+    /// .row_height(2);
+    /// ```
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn row_height(mut self, height: u16) -> Self {
+        if let Some(ref mut lazy) = self.lazy {
+            lazy.heights = LazyRowHeights::Uniform(height);
+        }
+        self
+    }
+
+    /// Set the height, in lines, of each lazily built row individually.
+    ///
+    /// This is the varying-height counterpart of [`Table::row_height`].
+    ///
+    /// Scrolling needs the geometry of rows that are not on screen — for instance to work out how
+    /// far to scroll back when the selection is below the viewport — which is why heights are
+    /// supplied separately from the rows. `height` should therefore be cheap: it is called for the
+    /// rows in the viewport (and, while anchoring a selection, for a viewport's worth of rows
+    /// around it), but never allocates a [`Row`]. The row factory itself is still only called for
+    /// rows that are actually drawn.
+    ///
+    /// This is a fluent setter method which must be chained or used as it consumes self
+    ///
+    /// # Note
+    ///
+    /// This only affects rows built by [`Table::lazy_rows`]; rows set with [`Table::new`] or
+    /// [`Table::rows`] carry their own [`Row::height`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui::layout::Constraint;
+    /// use ratatui::widgets::{Row, Table};
+    ///
+    /// // Every tenth row is a double-height separator.
+    /// let table = Table::lazy_rows(10_000, [Constraint::Length(20)], |index| {
+    ///     Row::new([format!("item {index}")])
+    /// })
+    /// .row_height_with(|index| if index % 10 == 0 { 2 } else { 1 });
+    /// ```
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub fn row_height_with<H>(mut self, height: H) -> Self
+    where
+        H: Fn(usize) -> u16 + Send + Sync + RefUnwindSafe + 'a,
+    {
+        if let Some(ref mut lazy) = self.lazy {
+            lazy.heights = LazyRowHeights::PerRow(Arc::new(height));
+        }
+        self
+    }
 }
 
 impl Widget for Table<'_> {
@@ -754,11 +1079,12 @@ impl StatefulWidget for &Table<'_> {
             return;
         }
 
-        if state.selected.is_some_and(|s| s >= self.rows.len()) {
-            state.select(Some(self.rows.len().saturating_sub(1)));
+        let row_count = self.row_count();
+        if state.selected.is_some_and(|s| s >= row_count) {
+            state.select(Some(row_count.saturating_sub(1)));
         }
 
-        if self.rows.is_empty() {
+        if row_count == 0 {
             state.select(None);
         }
 
@@ -848,6 +1174,11 @@ impl Table<'_> {
         state: &mut TableState,
         columns_widths: &[Rect],
     ) {
+        if let Some(ref provider) = self.lazy {
+            self.render_lazy_rows(area, buf, selection_width, state, columns_widths, provider);
+            return;
+        }
+
         if self.rows.is_empty() {
             return;
         }
@@ -881,6 +1212,64 @@ impl Table<'_> {
             y_offset += row.height_with_margin();
         }
 
+        self.apply_highlight_styles(buf, area, selected_row_area, state, columns_widths);
+    }
+
+    /// Render visible rows from a lazy provider, calling the factory only for the visible range.
+    fn render_lazy_rows(
+        &self,
+        area: Rect,
+        buf: &mut Buffer,
+        selection_width: u16,
+        state: &mut TableState,
+        columns_widths: &[Rect],
+        provider: &LazyRowProvider,
+    ) {
+        if provider.count == 0 {
+            return;
+        }
+
+        let (start_index, end_index) = provider.visible_rows(state, area);
+        state.offset = start_index;
+
+        let mut y = area.y;
+        let mut selected_row_area = None;
+
+        for index in start_index..end_index {
+            let row = (provider.factory)(index);
+            // The provider owns the geometry: a height or margin set on the row would make what is
+            // drawn disagree with the scroll calculation, which never sees the row itself.
+            let row_height = provider.height_of(index);
+            let height = y
+                .saturating_add(row_height)
+                .min(area.bottom())
+                .saturating_sub(y);
+            let row_area = Rect { y, height, ..area };
+            buf.set_style(row_area, row.style);
+
+            let is_selected = state.selected == Some(index);
+            if selection_width > 0 && is_selected {
+                self.set_selection_style(buf, selection_width, row_area, &row);
+            }
+            self.render_row_cells(buf, columns_widths.iter().collect(), &row.cells, row_area);
+            if is_selected {
+                selected_row_area = Some(row_area);
+            }
+            y = y.saturating_add(row_height);
+        }
+
+        self.apply_highlight_styles(buf, area, selected_row_area, state, columns_widths);
+    }
+
+    /// Apply row, column, and cell highlight styles after rows have been rendered.
+    fn apply_highlight_styles(
+        &self,
+        buf: &mut Buffer,
+        area: Rect,
+        selected_row_area: Option<Rect>,
+        state: &TableState,
+        columns_widths: &[Rect],
+    ) {
         let selected_column_area = state.selected_column.and_then(|s| {
             // The selection is clamped by the column count. Since a user can manually specify an
             // incorrect number of widths, we should use panic free methods.
@@ -1064,12 +1453,27 @@ impl Table<'_> {
             .collect()
     }
 
+    /// The number of rows in the table, whether they are stored eagerly or built lazily.
+    fn row_count(&self) -> usize {
+        self.lazy
+            .as_ref()
+            .map_or_else(|| self.rows.len(), |provider| provider.count)
+    }
+
     fn column_count(&self) -> usize {
+        // Lazy rows cannot be inspected without building them, so the column count comes from the
+        // widths (which `Table::lazy_rows` requires) and from the header and footer.
+        let lazy_columns = if self.lazy.is_some() {
+            self.widths.len()
+        } else {
+            0
+        };
         self.rows
             .iter()
             .chain(self.footer.iter())
             .chain(self.header.iter())
             .map(|r| r.cells.len())
+            .chain(Some(lazy_columns))
             .max()
             .unwrap_or_default()
     }

--- a/ratatui-widgets/src/table.rs
+++ b/ratatui-widgets/src/table.rs
@@ -119,7 +119,7 @@ impl LazyRowProvider<'_> {
     /// window upwards keeps such a row on screen (clipped), where scrolling down one row at a time
     /// walks past it and leaves it off screen entirely.
     fn visible_rows(&self, state: &TableState, area: Rect) -> (usize, usize) {
-        if self.count == 0 || area.height == 0 {
+        if self.count == 0 {
             return (0, 0);
         }
         let last_row = self.count - 1;
@@ -128,6 +128,12 @@ impl LazyRowProvider<'_> {
         let mut start = state.offset.min(last_row);
         if let Some(selected) = selected {
             start = start.min(selected);
+        }
+
+        // An area with no lines shows no rows, but the offset is still where the table would
+        // resume from, so it is returned unchanged rather than reset.
+        if area.height == 0 {
+            return (start, start);
         }
 
         // Fill the area downwards from the start with the rows that fit in it completely.

--- a/ratatui/tests/widgets_table_lazy_rows.rs
+++ b/ratatui/tests/widgets_table_lazy_rows.rs
@@ -1,3 +1,4 @@
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::panic::RefUnwindSafe;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -642,6 +643,42 @@ fn lazy_table_rows_no_rows_built_for_zero_height_area() {
 }
 
 #[test]
+fn lazy_table_rows_keep_their_offset_when_the_header_fills_the_area() {
+    // The table area is not empty, but the header leaves no room for rows at all.
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).header(Row::new(["head"]));
+    let mut state = TableState::default().with_offset(42);
+
+    let buffer = render_table(table, &mut state, 12, 1);
+
+    assert_content(&buffer, ["head        "]);
+    assert!(
+        built.lock().unwrap().is_empty(),
+        "factory must not be called when no row can be shown"
+    );
+    assert_eq!(
+        state.offset(),
+        42,
+        "an area too small to show a row must not discard the offset"
+    );
+}
+
+#[test]
+fn lazy_table_rows_clamp_their_offset_when_the_header_fills_the_area() {
+    // As above, but the offset is past the end of the table, so it is clamped like it would be if
+    // there were room to draw.
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(10, [Constraint::Length(10)], rows).header(Row::new(["head"]));
+    let mut state = TableState::default().with_offset(500);
+
+    let buffer = render_table(table, &mut state, 12, 1);
+
+    assert_content(&buffer, ["head        "]);
+    assert!(built.lock().unwrap().is_empty());
+    assert_eq!(state.offset(), 9, "the offset is clamped to the last row");
+}
+
+#[test]
 fn lazy_table_rows_multiline_scroll_uses_floor_not_ceil() {
     let built = Arc::new(Mutex::new(Vec::new()));
     let rows = {
@@ -1110,6 +1147,71 @@ fn lazy_tables_are_cloneable_and_comparable() {
     let (_built, other_rows) = recording_rows();
     let other = Table::lazy_rows(100, [Constraint::Length(10)], other_rows);
     assert_ne!(table, other, "different factories are different tables");
+}
+
+#[test]
+fn lazy_tables_with_per_row_heights_are_cloneable_and_comparable() {
+    let (_built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(|_| 2);
+
+    assert_eq!(
+        table.clone(),
+        table,
+        "a clone shares the same height closure"
+    );
+    assert!(
+        !format!("{table:?}").is_empty(),
+        "a table with a height closure stays Debug"
+    );
+
+    let other_heights = table.clone().row_height_with(|_| 2);
+    assert_ne!(
+        table, other_heights,
+        "different height closures are different tables"
+    );
+
+    // Uniform and per-row heights are never equal, whatever they compute.
+    let uniform = table.clone().row_height(2);
+    assert_ne!(
+        table, uniform,
+        "a height closure never equals a uniform height"
+    );
+    assert_ne!(
+        uniform, table,
+        "a uniform height never equals a height closure"
+    );
+}
+
+#[test]
+fn lazy_tables_hash_consistently_with_equality() {
+    let (_built, rows) = recording_rows();
+    let uniform = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height(2);
+    assert_eq!(
+        hash_of(&uniform.clone()),
+        hash_of(&uniform),
+        "equal tables with a uniform height must hash equally"
+    );
+
+    // Cloning shares the row factory, so the height is the only thing left to tell these apart.
+    assert_ne!(
+        hash_of(&uniform.clone().row_height(1)),
+        hash_of(&uniform),
+        "the row height must take part in the hash"
+    );
+
+    let (_built, rows) = recording_rows();
+    let per_row = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(|_| 2);
+    assert_eq!(
+        hash_of(&per_row.clone()),
+        hash_of(&per_row),
+        "equal tables with a height closure must hash equally"
+    );
+}
+
+fn hash_of(table: &Table<'_>) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    table.hash(&mut hasher);
+    hasher.finish()
 }
 
 #[test]

--- a/ratatui/tests/widgets_table_lazy_rows.rs
+++ b/ratatui/tests/widgets_table_lazy_rows.rs
@@ -1,0 +1,1253 @@
+use std::panic::RefUnwindSafe;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Rect};
+use ratatui::style::{Color, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, HighlightSpacing, Row, Table, TableState};
+
+/// Build a lazy table through closures that are **not** known to be [`UnwindSafe`].
+///
+/// `Table<'static>: Send + Sync + UnwindSafe + RefUnwindSafe` is already covered by
+/// `ratatui-widgets/tests/auto_traits.rs`, which this must not weaken. What that test cannot see is
+/// how strictly the closures themselves are bounded: `Arc<T>: UnwindSafe` only needs
+/// `T: RefUnwindSafe`, so neither closure needs `UnwindSafe` and callers must not be asked for it.
+///
+/// The assertion lives in this where-clause, which deliberately omits `UnwindSafe`. Tightening
+/// either bound on [`Table::lazy_rows`] or [`Table::row_height_with`] turns that into a compile
+/// error here.
+///
+/// [`UnwindSafe`]: std::panic::UnwindSafe
+fn lazy_table_from_closures<H, F>(row_count: usize, height: H, row: F) -> Table<'static>
+where
+    H: Fn(usize) -> u16 + Send + Sync + RefUnwindSafe + 'static,
+    F: Fn(usize) -> Row<'static> + Send + Sync + RefUnwindSafe + 'static,
+{
+    Table::lazy_rows(row_count, [Constraint::Length(10)], row).row_height_with(height)
+}
+
+#[test]
+fn lazy_closures_do_not_require_unwind_safe() {
+    let table = lazy_table_from_closures(2, |_| 1, |index| Row::new([format!("row {index}")]));
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 2);
+
+    assert_content(&buffer, ["row 0       ", "row 1       "]);
+}
+
+fn render_table(table: Table<'_>, state: &mut TableState, width: u16, height: u16) -> Buffer {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            frame.render_stateful_widget(table, frame.area(), state);
+        })
+        .unwrap();
+    terminal.backend().buffer().clone()
+}
+
+fn assert_content<'line, Lines>(buffer: &Buffer, expected: Lines)
+where
+    Lines: IntoIterator,
+    Lines::Item: Into<Line<'line>>,
+{
+    let expected_buf = Buffer::with_lines(expected);
+    for (i, (actual, exp)) in buffer
+        .content
+        .iter()
+        .zip(expected_buf.content.iter())
+        .enumerate()
+    {
+        assert_eq!(
+            actual.symbol(),
+            exp.symbol(),
+            "cell {i} symbol mismatch: got {:?}, want {:?}",
+            actual.symbol(),
+            exp.symbol()
+        );
+    }
+}
+
+#[test]
+fn lazy_table_rows_build_only_the_visible_window() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(10_000, [Constraint::Length(10)], rows);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 18, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000          ",
+            "row 0001          ",
+            "row 0002          ",
+            "row 0003          ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_table_rows_start_from_the_state_offset() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(10_000, [Constraint::Length(10)], rows);
+    let mut state = TableState::default().with_offset(5_000);
+
+    let buffer = render_table(table, &mut state, 18, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 5000          ",
+            "row 5001          ",
+            "row 5002          ",
+            "row 5003          ",
+        ],
+    );
+    assert_eq!(state.offset(), 5_000);
+    assert_eq!(&*built.lock().unwrap(), &[5_000, 5_001, 5_002, 5_003]);
+}
+
+#[test]
+fn lazy_table_rows_jump_to_a_selected_row_without_building_preceding_rows() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(10_000, [Constraint::Length(10)], rows)
+        .highlight_spacing(HighlightSpacing::Always)
+        .highlight_symbol(">")
+        .row_highlight_style(Style::new().bg(Color::Blue));
+    let mut state = TableState::default().with_selected(5_000);
+
+    let buffer = render_table(table, &mut state, 18, 4);
+
+    assert_content(
+        &buffer,
+        [
+            " row 4997         ",
+            " row 4998         ",
+            " row 4999         ",
+            ">row 5000         ",
+        ],
+    );
+    assert_eq!(state.offset(), 4_997);
+    assert_eq!(&*built.lock().unwrap(), &[4_997, 4_998, 4_999, 5_000]);
+}
+
+#[test]
+fn lazy_table_rows_with_fewer_rows_than_viewport_builds_only_those_rows() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    // 1000 total rows but viewport holds only 4 — exactly 4 must be built
+    let table = Table::lazy_rows(1_000, [Constraint::Length(10)], rows);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000       ",
+            "row 0001       ",
+            "row 0002       ",
+            "row 0003       ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    // Only the 4 visible rows must be built; the remaining 996 must never be touched
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_table_rows_rows_exactly_fill_viewport() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("item {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(2_000, [Constraint::Length(10)], rows);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "item 0000      ",
+            "item 0001      ",
+            "item 0002      ",
+            "item 0003      ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_table_rows_with_multi_line_row_height() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    // height=2 means each row occupies 2 lines; 6-line viewport fits 3 rows
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).row_height(2);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 15, 6);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000       ",
+            "               ",
+            "row 0001       ",
+            "               ",
+            "row 0002       ",
+            "               ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+}
+
+#[test]
+fn lazy_table_rows_partial_row_at_bottom_is_included() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    // height=3, area_height=5: fits 1 full row + 1 partial row (2 lines of the second row)
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).row_height(3);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 15, 5);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000       ",
+            "               ",
+            "               ",
+            "row 0001       ",
+            "               ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    // Both row 0 and the partial row 1 must be built
+    assert_eq!(&*built.lock().unwrap(), &[0, 1]);
+}
+
+#[test]
+fn lazy_table_rows_selected_first_row() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows);
+    let mut state = TableState::default().with_selected(0);
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000       ",
+            "row 0001       ",
+            "row 0002       ",
+            "row 0003       ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_table_rows_selected_last_row_scrolls_to_show_it() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows);
+    // Select the very last row; the table must scroll to show it at the bottom
+    let mut state = TableState::default().with_selected(4_999);
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 4996       ",
+            "row 4997       ",
+            "row 4998       ",
+            "row 4999       ",
+        ],
+    );
+    assert_eq!(state.offset(), 4_996);
+    assert_eq!(&*built.lock().unwrap(), &[4_996, 4_997, 4_998, 4_999]);
+}
+
+#[test]
+fn lazy_table_rows_offset_beyond_count_is_clamped() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(1_000, [Constraint::Length(10)], rows);
+    // Offset wildly exceeds row count — clamps to last_row (999), only that row is visible
+    let mut state = TableState::default().with_offset(99_999);
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0999       ",
+            "               ",
+            "               ",
+            "               ",
+        ],
+    );
+    assert_eq!(state.offset(), 999, "offset must clamp to last row");
+    let b = built.lock().unwrap();
+    // Only the clamped row is built, not all 1000
+    assert_eq!(&*b, &[999]);
+}
+
+#[test]
+fn lazy_table_rows_selection_highlight_style_applied_to_selected_row() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows)
+        .row_highlight_style(Style::new().bg(Color::Red));
+    let mut state = TableState::default().with_selected(1);
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000       ",
+            "row 0001       ",
+            "row 0002       ",
+            "row 0003       ",
+        ],
+    );
+    // The selected row (y=1) must have the red background; others must not
+    let selected_cell = &buffer.content[15]; // row 1, col 0 (width=15)
+    assert_eq!(
+        selected_cell.style().bg,
+        Some(Color::Red),
+        "selected row must have red background"
+    );
+    let unselected_cell = &buffer.content[0]; // row 0, col 0
+    assert_ne!(
+        unselected_cell.style().bg,
+        Some(Color::Red),
+        "unselected row must not have red background"
+    );
+    // Only 4 rows built (not all 5000)
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_table_rows_highlight_symbol_rendered_for_selected_row() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows)
+        .highlight_spacing(HighlightSpacing::Always)
+        .highlight_symbol(">> ");
+    let mut state = TableState::default().with_selected(2);
+
+    let buffer = render_table(table, &mut state, 18, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "   row 0000       ",
+            "   row 0001       ",
+            ">> row 0002       ",
+            "   row 0003       ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_table_rows_with_header_does_not_affect_row_indexing() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let header = Row::new(["Header"]);
+    // 4-line viewport: 1 header + 3 data rows visible
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).header(header);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "Header         ",
+            "row 0000       ",
+            "row 0001       ",
+            "row 0002       ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    // Only 3 data rows were built despite 5000 total
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+}
+
+#[test]
+fn lazy_table_rows_with_footer_does_not_affect_row_indexing() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let footer = Row::new(["Footer"]);
+    // 4-line viewport: 3 data rows + 1 footer
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows).footer(footer);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000       ",
+            "row 0001       ",
+            "row 0002       ",
+            "Footer         ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    // Only 3 data rows were built
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+}
+
+#[test]
+fn lazy_table_rows_with_block_reduces_inner_area() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    // 6-line viewport with bordered block: inner area is 4 lines
+    let table =
+        Table::lazy_rows(5_000, [Constraint::Length(8)], rows).block(Block::bordered().title("T"));
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 15, 6);
+
+    assert_content(
+        &buffer,
+        [
+            "┌T────────────┐",
+            "│row 0000     │",
+            "│row 0001     │",
+            "│row 0002     │",
+            "│row 0003     │",
+            "└─────────────┘",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    // Only 4 rows built (inner area is 4 lines after borders)
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_table_rows_mid_list_offset_without_selection() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:05}")])
+        }
+    };
+    let table = Table::lazy_rows(10_000, [Constraint::Length(10)], rows);
+    let mut state = TableState::default().with_offset(999);
+
+    let buffer = render_table(table, &mut state, 15, 3);
+
+    assert_content(
+        &buffer,
+        ["row 00999      ", "row 01000      ", "row 01001      "],
+    );
+    assert_eq!(state.offset(), 999);
+    assert_eq!(&*built.lock().unwrap(), &[999, 1_000, 1_001]);
+}
+
+#[test]
+fn lazy_table_rows_selection_above_offset_scrolls_back() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows);
+    // Offset is at 100 but we select row 50 — must scroll back
+    let mut state = TableState::default().with_offset(100).with_selected(50);
+
+    render_table(table, &mut state, 15, 4);
+
+    assert_eq!(
+        state.offset(),
+        50,
+        "table must scroll back to show selected row"
+    );
+    let b = built.lock().unwrap();
+    assert!(b.contains(&50), "selected row must be built");
+    assert!(
+        b.iter().all(|&i| (50..54).contains(&i)),
+        "only 4 rows near selection should be built"
+    );
+}
+
+#[test]
+fn lazy_table_rows_multiple_columns_layout() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("name{index:03}"), format!("val{index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(5_000, [Constraint::Length(7), Constraint::Length(7)], rows);
+    let mut state = TableState::default().with_offset(10);
+
+    let buffer = render_table(table, &mut state, 20, 3);
+
+    assert_content(
+        &buffer,
+        [
+            "name010 val0010     ",
+            "name011 val0011     ",
+            "name012 val0012     ",
+        ],
+    );
+    assert_eq!(&*built.lock().unwrap(), &[10, 11, 12]);
+}
+
+#[test]
+fn lazy_table_rows_no_rows_built_for_zero_height_area() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index}")])
+        }
+    };
+    let table = Table::lazy_rows(5_000, [Constraint::Length(10)], rows);
+    let mut state = TableState::default();
+
+    // Render into a zero-height area — nothing should be built
+    let backend = TestBackend::new(15, 5);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| {
+            frame.render_stateful_widget(table, Rect::new(0, 0, 15, 0), &mut state);
+        })
+        .unwrap();
+
+    assert!(
+        built.lock().unwrap().is_empty(),
+        "factory must not be called for a zero-height area"
+    );
+}
+
+#[test]
+fn lazy_table_rows_multiline_scroll_uses_floor_not_ceil() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height(2);
+    let mut state = TableState::default().with_selected(99);
+
+    let buffer = render_table(table, &mut state, 15, 5);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0098       ",
+            "               ",
+            "row 0099       ",
+            "               ",
+            "               ",
+        ],
+    );
+    assert_eq!(
+        state.offset(),
+        98,
+        "offset must be 98 (floor anchor), not 97 (ceil anchor)"
+    );
+    // Exactly rows 98 and 99 built — row 97 must NOT be called
+    assert_eq!(&*built.lock().unwrap(), &[98, 99]);
+}
+
+#[test]
+fn lazy_table_rows_select_last_with_usize_max_clamps_correctly() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows);
+    // select_last() sets selected to usize::MAX — must clamp to last real row
+    let mut state = TableState::default();
+    state.select_last();
+
+    let buffer = render_table(table, &mut state, 15, 4);
+
+    assert_eq!(
+        state.selected(),
+        Some(99),
+        "usize::MAX selection must clamp to last row"
+    );
+    assert_content(
+        &buffer,
+        [
+            "row 0096       ",
+            "row 0097       ",
+            "row 0098       ",
+            "row 0099       ",
+        ],
+    );
+    // Only 4 rows near end built, not all 100
+    assert_eq!(&*built.lock().unwrap(), &[96, 97, 98, 99]);
+}
+
+#[test]
+fn lazy_table_rows_multiline_rows_with_explicit_offset() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    // row_height=2, area=6: 3 full rows visible.  offset=20 means start at row 20.
+    let table = Table::lazy_rows(500, [Constraint::Length(10)], rows).row_height(2);
+    let mut state = TableState::default().with_offset(20);
+
+    let buffer = render_table(table, &mut state, 15, 6);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0020       ",
+            "               ",
+            "row 0021       ",
+            "               ",
+            "row 0022       ",
+            "               ",
+        ],
+    );
+    assert_eq!(state.offset(), 20);
+    // Rows 20, 21, 22 built — the offset is a row index, not a line index
+    assert_eq!(&*built.lock().unwrap(), &[20, 21, 22]);
+}
+
+#[test]
+fn lazy_table_rows_multiline_with_header_and_selection_scroll() {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    let header = Row::new(["Name"]);
+    let table = Table::lazy_rows(500, [Constraint::Length(10)], rows)
+        .row_height(2)
+        .header(header);
+    let mut state = TableState::default().with_selected(200);
+
+    let buffer = render_table(table, &mut state, 15, 7);
+
+    assert_content(
+        &buffer,
+        [
+            "Name           ",
+            "row 0198       ",
+            "               ",
+            "row 0199       ",
+            "               ",
+            "row 0200       ",
+            "               ",
+        ],
+    );
+    assert_eq!(state.offset(), 198);
+    // Exactly 3 data rows built
+    assert_eq!(&*built.lock().unwrap(), &[198, 199, 200]);
+}
+
+/// A row factory that records, in order, the indexes it was called with.
+fn recording_rows() -> (
+    Arc<Mutex<Vec<usize>>>,
+    impl Fn(usize) -> Row<'static> + Send + Sync + RefUnwindSafe,
+) {
+    let built = Arc::new(Mutex::new(Vec::new()));
+    let factory = {
+        let built = Arc::clone(&built);
+        move |index: usize| {
+            built.lock().unwrap().push(index);
+            Row::new([format!("row {index:04}")])
+        }
+    };
+    (built, factory)
+}
+
+/// Rows alternate between two lines (even indexes) and one line (odd indexes).
+const fn alternating_height(index: usize) -> u16 {
+    if index.is_multiple_of(2) { 2 } else { 1 }
+}
+
+#[test]
+fn lazy_variable_rows_are_laid_out_at_their_own_heights() {
+    let (built, rows) = recording_rows();
+    let table =
+        Table::lazy_rows(5, [Constraint::Length(10)], rows).row_height_with(alternating_height);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 6);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000    ", // height 2
+            "            ",
+            "row 0001    ", // height 1
+            "row 0002    ", // height 2
+            "            ",
+            "row 0003    ", // height 1
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_variable_rows_start_from_the_state_offset() {
+    let (built, rows) = recording_rows();
+    let table =
+        Table::lazy_rows(1_000, [Constraint::Length(10)], rows).row_height_with(alternating_height);
+    let mut state = TableState::default().with_offset(10);
+
+    let buffer = render_table(table, &mut state, 12, 6);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0010    ",
+            "            ",
+            "row 0011    ",
+            "row 0012    ",
+            "            ",
+            "row 0013    ",
+        ],
+    );
+    assert_eq!(state.offset(), 10);
+    assert_eq!(&*built.lock().unwrap(), &[10, 11, 12, 13]);
+}
+
+#[test]
+fn lazy_variable_rows_anchor_a_selection_below_the_window() {
+    let (built, rows) = recording_rows();
+    // Every tenth row is three lines tall, the rest are single lines.
+    let heights = |index: usize| if index.is_multiple_of(10) { 3 } else { 1 };
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(heights);
+    let mut state = TableState::default().with_selected(99);
+
+    let buffer = render_table(table, &mut state, 12, 5);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0095    ",
+            "row 0096    ",
+            "row 0097    ",
+            "row 0098    ",
+            "row 0099    ",
+        ],
+    );
+    assert_eq!(state.offset(), 95);
+    assert_eq!(&*built.lock().unwrap(), &[95, 96, 97, 98, 99]);
+}
+
+#[test]
+fn lazy_variable_rows_scroll_back_less_for_a_tall_selected_row() {
+    let (built, rows) = recording_rows();
+    // Row 20 is three lines tall, so it leaves room for only one row above it in a 4 line area.
+    let heights = |index: usize| if index == 20 { 3 } else { 1 };
+    let table = Table::lazy_rows(50, [Constraint::Length(10)], rows).row_height_with(heights);
+    let mut state = TableState::default().with_selected(20);
+
+    let buffer = render_table(table, &mut state, 12, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0019    ",
+            "row 0020    ", // three lines tall
+            "            ",
+            "            ",
+        ],
+    );
+    assert_eq!(state.offset(), 19);
+    assert_eq!(&*built.lock().unwrap(), &[19, 20]);
+}
+
+#[test]
+fn lazy_variable_rows_partial_tall_row_at_the_bottom_is_clipped() {
+    let (built, rows) = recording_rows();
+    // Row 1 is five lines tall but only two lines of space are left for it.
+    let heights = |index: usize| if index == 1 { 5 } else { 1 };
+    let table = Table::lazy_rows(10, [Constraint::Length(10)], rows).row_height_with(heights);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 3);
+
+    assert_content(&buffer, ["row 0000    ", "row 0001    ", "            "]);
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1]);
+}
+
+#[test]
+fn lazy_variable_rows_selection_above_offset_scrolls_back() {
+    let (built, rows) = recording_rows();
+    let table =
+        Table::lazy_rows(1_000, [Constraint::Length(10)], rows).row_height_with(alternating_height);
+    let mut state = TableState::default().with_offset(100).with_selected(50);
+
+    let buffer = render_table(table, &mut state, 12, 6);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0050    ",
+            "            ",
+            "row 0051    ",
+            "row 0052    ",
+            "            ",
+            "row 0053    ",
+        ],
+    );
+    assert_eq!(state.offset(), 50);
+    assert_eq!(&*built.lock().unwrap(), &[50, 51, 52, 53]);
+}
+
+#[test]
+fn lazy_variable_rows_with_header_use_the_remaining_height() {
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows)
+        .row_height_with(alternating_height)
+        .header(Row::new(["Name"]));
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 6);
+
+    assert_content(
+        &buffer,
+        [
+            "Name        ",
+            "row 0000    ",
+            "            ",
+            "row 0001    ",
+            "row 0002    ",
+            "            ",
+        ],
+    );
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+}
+
+#[test]
+fn lazy_variable_rows_selection_highlight_covers_the_whole_row_height() {
+    let (_built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows)
+        .row_height_with(alternating_height)
+        .row_highlight_style(Style::new().bg(Color::Red));
+    // Row 2 is two lines tall and starts on the fourth line (2 + 1 lines above it).
+    let mut state = TableState::default().with_selected(2);
+
+    let buffer = render_table(table, &mut state, 12, 6);
+
+    for (line, highlighted) in [(0, false), (1, false), (2, false), (3, true), (4, true)] {
+        let cell = &buffer.content[line * 12];
+        assert_eq!(
+            cell.style().bg == Some(Color::Red),
+            highlighted,
+            "line {line} should{} be highlighted",
+            if highlighted { "" } else { " not" }
+        );
+    }
+}
+
+#[test]
+fn lazy_variable_rows_height_closure_is_not_called_for_every_row() {
+    let (built, rows) = recording_rows();
+    let height_calls = Arc::new(AtomicUsize::new(0));
+    let heights = {
+        let height_calls = Arc::clone(&height_calls);
+        move |_index: usize| {
+            height_calls.fetch_add(1, Ordering::Relaxed);
+            1
+        }
+    };
+    let table =
+        Table::lazy_rows(1_000_000, [Constraint::Length(10)], rows).row_height_with(heights);
+    let mut state = TableState::default().with_selected(999_999);
+
+    render_table(table, &mut state, 12, 4);
+
+    assert_eq!(state.offset(), 999_996);
+    assert_eq!(
+        &*built.lock().unwrap(),
+        &[999_996, 999_997, 999_998, 999_999]
+    );
+    // Scrolling a million rows down must stay proportional to the viewport, not to the distance
+    // scrolled: a handful of height lookups, and nothing like a million of them.
+    let calls = height_calls.load(Ordering::Relaxed);
+    assert!(calls <= 16, "height closure was called {calls} times");
+}
+
+#[test]
+fn lazy_variable_rows_of_zero_height_do_not_build_the_whole_table() {
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(1_000_000, [Constraint::Length(10)], rows).row_height_with(|_| 0);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 4);
+
+    assert_content(&buffer, ["            "; 4]);
+    // Zero-height rows can never fill the area, so the window is bounded by the area height
+    // instead of running through the whole dataset.
+    let built = built.lock().unwrap();
+    assert!(built.len() <= 5, "built {} rows", built.len());
+}
+
+#[test]
+fn lazy_rows_ignore_the_height_and_margins_set_by_the_factory() {
+    let (built, _rows) = recording_rows();
+    let rows = {
+        let built = Arc::clone(&built);
+        move |index: usize| {
+            built.lock().unwrap().push(index);
+            // All of these are ignored: the table's row height is authoritative, because the
+            // scroll calculation never sees the row itself.
+            Row::new([format!("row {index:04}")])
+                .height(3)
+                .top_margin(2)
+                .bottom_margin(2)
+        }
+    };
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 4);
+
+    assert_content(
+        &buffer,
+        [
+            "row 0000    ",
+            "row 0001    ",
+            "row 0002    ",
+            "row 0003    ",
+        ],
+    );
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn lazy_rows_are_replaced_by_explicitly_set_rows() {
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(1_000, [Constraint::Length(10)], rows)
+        .rows([Row::new(["first"]), Row::new(["second"])]);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 3);
+
+    assert_content(&buffer, ["first       ", "second      ", "            "]);
+    assert!(
+        built.lock().unwrap().is_empty(),
+        "the lazy factory must not be used once rows are set explicitly"
+    );
+}
+
+#[test]
+fn lazy_rows_column_count_comes_from_the_widths() {
+    let (_built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(5), Constraint::Length(5)], rows);
+    let mut state = TableState::default();
+    state.select_column(Some(9));
+
+    render_table(table, &mut state, 12, 3);
+
+    assert_eq!(
+        state.selected_column(),
+        Some(1),
+        "column selection must clamp to the number of widths"
+    );
+}
+
+#[test]
+fn lazy_rows_with_no_rows_clear_the_selection() {
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(0, [Constraint::Length(10)], rows);
+    let mut state = TableState::default().with_selected(5);
+
+    let buffer = render_table(table, &mut state, 12, 3);
+
+    assert_content(&buffer, ["            "; 3]);
+    assert_eq!(state.selected(), None);
+    assert!(built.lock().unwrap().is_empty());
+}
+
+#[test]
+fn lazy_tables_are_cloneable_and_comparable() {
+    let (_built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows);
+
+    assert_eq!(table.clone(), table, "a clone shares the same row factory");
+    assert!(!format!("{table:?}").is_empty(), "Table stays Debug");
+
+    let (_built, other_rows) = recording_rows();
+    let other = Table::lazy_rows(100, [Constraint::Length(10)], other_rows);
+    assert_ne!(table, other, "different factories are different tables");
+}
+
+#[test]
+fn lazy_rows_keep_an_oversized_selected_row_visible() {
+    // Rows are three lines tall but the area is only two lines high, so no row ever fits.
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(|_| 3);
+    let mut state = TableState::default().with_selected(0);
+
+    let buffer = render_table(table, &mut state, 12, 2);
+
+    assert_content(&buffer, ["row 0000    ", "            "]);
+    assert_eq!(state.offset(), 0);
+    assert_eq!(&*built.lock().unwrap(), &[0]);
+
+    // The same holds for a selection further down: the window anchors on it and clips it, rather
+    // than scrolling past it.
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows).row_height_with(|_| 3);
+    let mut state = TableState::default().with_selected(50);
+
+    let buffer = render_table(table, &mut state, 12, 2);
+
+    assert_content(&buffer, ["row 0050    ", "            "]);
+    assert_eq!(state.offset(), 50);
+    assert_eq!(&*built.lock().unwrap(), &[50]);
+}
+
+#[test]
+fn the_last_row_height_setting_wins() {
+    let (built, rows) = recording_rows();
+    let table = Table::lazy_rows(100, [Constraint::Length(10)], rows)
+        .row_height_with(|_| 3)
+        .row_height(1);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 3);
+
+    assert_content(&buffer, ["row 0000    ", "row 0001    ", "row 0002    "]);
+    assert_eq!(&*built.lock().unwrap(), &[0, 1, 2]);
+}
+
+#[test]
+fn row_height_is_ignored_by_eagerly_built_tables() {
+    let table = Table::new(
+        [Row::new(["first"]), Row::new(["second"])],
+        [Constraint::Length(10)],
+    )
+    .row_height(3);
+    let mut state = TableState::default();
+
+    let buffer = render_table(table, &mut state, 12, 3);
+
+    // Eager rows carry their own height, so both rows stay one line tall.
+    assert_content(&buffer, ["first       ", "second      ", "            "]);
+}
+
+/// Render the same table lazily and eagerly and assert the two are indistinguishable.
+#[track_caller]
+fn assert_matches_eager_table(
+    row_count: usize,
+    heights: fn(usize) -> u16,
+    area: (u16, u16),
+    offset: usize,
+    selected: Option<usize>,
+) {
+    let row = |index: usize| Row::new([format!("row {index:04}")]);
+    let (width, height) = area;
+
+    if let Some(selected) = selected
+        && heights(selected.min(row_count - 1)) > height
+    {
+        return;
+    }
+
+    let mut lazy_state = TableState::default().with_offset(offset);
+    lazy_state.select(selected);
+    let lazy = Table::lazy_rows(row_count, [Constraint::Length(10)], row).row_height_with(heights);
+    let lazy_buffer = render_table(lazy, &mut lazy_state, width, height);
+
+    let mut eager_state = TableState::default().with_offset(offset);
+    eager_state.select(selected);
+    let eager = Table::new(
+        (0..row_count).map(|index| row(index).height(heights(index))),
+        [Constraint::Length(10)],
+    );
+    let eager_buffer = render_table(eager, &mut eager_state, width, height);
+
+    assert_eq!(
+        lazy_buffer, eager_buffer,
+        "lazy and eager rendering diverged for {row_count} rows in {width}x{height}, \
+         offset {offset}, selected {selected:?}"
+    );
+    assert_eq!(
+        lazy_state.offset(),
+        eager_state.offset(),
+        "lazy and eager offsets diverged for {row_count} rows in {width}x{height}, \
+         offset {offset}, selected {selected:?}"
+    );
+}
+
+#[test]
+fn lazy_rows_render_like_eager_rows_of_uniform_height() {
+    for row_height in [1_u16, 2, 3] {
+        for area_height in 1_u16..=8 {
+            for offset in [0_usize, 1, 7, 40] {
+                for selected in [None, Some(0), Some(1), Some(8), Some(39)] {
+                    assert_matches_eager_table(
+                        40,
+                        match row_height {
+                            1 => |_| 1,
+                            2 => |_| 2,
+                            _ => |_| 3,
+                        },
+                        (12, area_height),
+                        offset,
+                        selected,
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn lazy_rows_render_like_eager_rows_of_varying_height() {
+    for heights in [
+        alternating_height as fn(usize) -> u16,
+        |index| if index.is_multiple_of(3) { 3 } else { 1 },
+        |index| (index % 4) as u16 + 1,
+        |index| if index == 12 { 4 } else { 1 },
+    ] {
+        for area_height in 1_u16..=8 {
+            for offset in [0_usize, 1, 7, 30] {
+                for selected in [None, Some(0), Some(2), Some(12), Some(29)] {
+                    assert_matches_eager_table(30, heights, (12, area_height), offset, selected);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes ratatui/ratatui-table#5

## What

Adds `Table::lazy_rows`, which builds rows on demand instead of collecting them into a `Vec` up front, so a table over a very large dataset costs the viewport rather than the dataset.

```rust
let table = Table::lazy_rows(10_000_000, widths, |index| Row::new([format!("item {index}")]))
    .row_height_with(|index| if index % 25 == 0 { 3 } else { 1 });
```

- `Table::lazy_rows(row_count, widths, factory)` — rows are one line tall by default.
- `Table::row_height(u16)` — uniform height override.
- `Table::row_height_with(impl Fn(usize) -> u16)` — per-row heights.

All three are additive; no existing API changes behaviour.

`examples/apps/lazy-table` renders ten million rows and reports how many rows each frame actually built and how long it took to draw:

```text
 row 7884 | variable heights | 45 rows built in 9.66ms
```

## Why heights are declared separately

The scroll pass needs the height of rows it will not draw — for instance to work out where the window starts when the selection is below the viewport. For an eager table that is free, because `visible_rows` can index `self.rows`. For a lazy table, asking a row for its height means building it, which is the cost the feature exists to avoid. Declaring heights separately keeps the whole frame proportional to the viewport, and matches how other virtualised lists work (Qt `sizeHintForRow`, UIKit `heightForRowAt`, react-window `itemSize`).

Consequence, documented on the constructor: for lazy rows the declared height is authoritative and `Row::height` / `Row::top_margin` / `Row::bottom_margin` on the returned row are ignored.

## Consistency with existing code

`LazyRowHeights` follows the same shape as `Effect` in `block/shadow.rs`: an enum with cheap built-in variants plus one `Arc<dyn …>` variant, with hand-written `PartialEq` (`Arc::ptr_eq`), `Eq` and `Hash` (`ptr::hash`) so the widget keeps its derives.

It differs in one respect: `CellEffect` requires `Send + Sync + UnwindSafe + RefUnwindSafe`, whereas the lazy closures require only `Send + Sync + RefUnwindSafe`. `Arc<T>: UnwindSafe` needs just `T: RefUnwindSafe`, so the extra bound would restrict callers without buying anything — `Table<'static>` remains `UnwindSafe`, as `ratatui-widgets/tests/auto_traits.rs` already asserts. Happy to add `UnwindSafe` for symmetry if you would rather the two APIs read the same.

## Please look closely at

1. **`LazyRowProvider::visible_rows`** mirrors `Table::visible_rows` step for step, but grows the window upward from the selection instead of scrolling down one row at a time. Two tests assert the two produce identical buffers and offsets across a matrix of row heights, area heights, offsets and selections.
2. **One deliberate divergence**: when the selected row is taller than the whole area, the eager algorithm shrinks `start` past the selection and draws the row *below* it, leaving the selected row off screen. The lazy path keeps it anchored and clips it. I left the eager behaviour alone and documented the difference — happy to open a separate fix if you agree it is a bug.
3. **`row_height` / `row_height_with` are no-ops on eager tables**, since `Table::new` rows carry their own `Row::height`. Documented on both methods and covered by a test. Open to a better name or shape here.

## Testing

- New `ratatui/tests/widgets_table_lazy_rows.rs`: laziness (asserting the exact set of rows built), offsets, selection anchoring, partial rows, headers/footers/blocks, highlight styles, zero-height rows, clone/eq/hash, and equivalence with `Table::new`.
- `cargo xtask ci` passes locally.

## AI assistance
This uses AI for comments and logic validation.
