### PR TITLE
fix(terminal)!: don't clear the whole screen when an inline viewport shrinks horizontally

### DIFF
--- a/ratatui-core/src/terminal/resize.rs
+++ b/ratatui-core/src/terminal/resize.rs
@@ -38,8 +38,20 @@ impl<B: Backend> Terminal<B> {
             Viewport::Fixed(_) | Viewport::Fullscreen => (area, None),
         };
 
-        // clear screen on horizontal shrink to avoid line wrapping issues
-        if next_area.width < self.viewport_area.width {
+        // Clear the screen on horizontal shrink to avoid line wrapping issues.
+        //
+        // Inline viewports are excluded: an inline viewport only owns the rows
+        // from its origin down. The rows above it were written by
+        // `insert_before`, which keeps no copy of them, so the application can
+        // never repaint them. A full-screen erase either destroys that output
+        // or, on terminals that move erased content into scrollback (Windows
+        // Terminal, conhost), pushes a copy of the viewport into scrollback on
+        // every resize event. The `clear_viewport` call below already erases
+        // from the recomputed origin to the bottom of the screen, which covers
+        // every row the inline viewport can legitimately own.
+        if next_area.width < self.viewport_area.width
+            && !matches!(self.viewport, Viewport::Inline(_))
+        {
             next_area.y = 0;
             self.backend.clear_region(ClearType::All)?;
         }
@@ -305,11 +317,69 @@ mod tests {
         );
     }
 
-    // This tests for the case where the new width is smaller than the old
-    // width. The screen should be cleared completely to avoid rendering
-    // glitches caused by line wrap.
+    // An inline viewport does not own the rows above its origin: they were
+    // written by `insert_before`, which keeps no copy of them, so the
+    // application cannot repaint them. A horizontal shrink must not erase them.
     #[test]
-    fn resize_inline_clears_screen_on_horizontal_shrink() {
+    fn resize_inline_horizontal_shrink_keeps_rows_above_the_viewport() {
+        let mut backend = TestBackend::new(6, 4);
+        backend
+            .set_cursor_position(Position { x: 0, y: 0 })
+            .unwrap();
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(1),
+            },
+        )
+        .unwrap();
+
+        for text in ["one", "two"] {
+            terminal
+                .insert_before(1, |buf| {
+                    buf.set_string(0, 0, text, crate::style::Style::default());
+                })
+                .unwrap();
+        }
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                frame.buffer_mut().set_string(
+                    area.x,
+                    area.y,
+                    "live",
+                    crate::style::Style::default(),
+                );
+            })
+            .unwrap();
+        terminal
+            .backend()
+            .assert_buffer_lines(["one   ", "two   ", "live  ", "      "]);
+
+        // A real backend leaves the cursor just past the last painted cell;
+        // `TestBackend` only moves it on an explicit cursor command, so place it
+        // where the viewport was drawn. `resize` anchors the new origin to it.
+        terminal
+            .backend_mut()
+            .set_cursor_position(Position { x: 4, y: 2 })
+            .unwrap();
+
+        // Narrow the terminal. The backend buffer is left at its original width
+        // so the assertions below read the same columns as the ones above;
+        // `resize_inline_resets_the_buffers_on_horizontal_shrink` does the same.
+        terminal.resize(Rect::new(0, 0, 5, 4)).unwrap();
+
+        assert_eq!(terminal.viewport_area, Rect::new(0, 2, 5, 1));
+        terminal
+            .backend()
+            .assert_buffer_lines(["one   ", "two   ", "      ", "      "]);
+    }
+
+    // This tests for the case where the new width is smaller than the old
+    // width. The internal buffers are reset so the next draw repaints the
+    // viewport into a consistent area.
+    #[test]
+    fn resize_inline_resets_the_buffers_on_horizontal_shrink() {
         let mut backend = TestBackend::with_lines(["0000", "1111"]);
         backend
             .set_cursor_position(Position { x: 0, y: 0 })

--- a/ratatui-core/src/terminal/resize.rs
+++ b/ratatui-core/src/terminal/resize.rs
@@ -99,6 +99,7 @@ mod tests {
     use crate::backend::{Backend, TestBackend};
     use crate::buffer::Buffer;
     use crate::layout::{Position, Rect};
+    use crate::style::Style;
     use crate::terminal::{Terminal, TerminalOptions, Viewport};
 
     #[test]
@@ -337,19 +338,16 @@ mod tests {
         for text in ["one", "two"] {
             terminal
                 .insert_before(1, |buf| {
-                    buf.set_string(0, 0, text, crate::style::Style::default());
+                    buf.set_string(0, 0, text, Style::default());
                 })
                 .unwrap();
         }
         terminal
             .draw(|frame| {
                 let area = frame.area();
-                frame.buffer_mut().set_string(
-                    area.x,
-                    area.y,
-                    "live",
-                    crate::style::Style::default(),
-                );
+                frame
+                    .buffer_mut()
+                    .set_string(area.x, area.y, "live", Style::default());
             })
             .unwrap();
         terminal


### PR DESCRIPTION
Fixes #2666.

`Terminal::resize` clears the entire screen (`ClearType::All`) on a horizontal shrink. For fullscreen and fixed viewports that's harmless, but an inline viewport only owns the rows from its origin down. The rows above it were written by `insert_before`, which keeps no copy of them, so the application can never repaint them. The full-screen erase either destroys that output (terminals that discard erased content) or, on terminals that move erased content into scrollback (Windows Terminal, conhost), pushes a copy of the live viewport into scrollback on every resize event — that's the staircase of duplicated live rows in #2666.

The erase is also redundant for inline viewports: `resize` calls `clear_viewport()` right after, which erases from the recomputed origin to the bottom of the screen. The origin is anchored to the live cursor, and everything the viewport can legitimately own is at or below it.

This change skips the full-screen erase (and the accompanying `y = 0` reset) for `Viewport::Inline` only. Fullscreen and fixed viewports are unchanged.

Testing:

- new regression test `resize_inline_horizontal_shrink_keeps_rows_above_the_viewport` fails before the change (the rows above the viewport are wiped) and passes after; the previous shrink test is kept as `resize_inline_resets_the_buffers_on_horizontal_shrink` since the buffer-reset side of it still holds
- verified on Windows Terminal with a streaming inline app (continuous `draw` plus periodic `insert_before`) while dragging the window narrower column by column: committed rows survive and scrollback no longer accumulates one copy of the live row per resize event
- `cargo test -p ratatui-core` with default features, `--no-default-features`, `--features scrolling-regions` and `--all-features` all pass

Related: #2086 / #2355 addressed the shrink erase for applications that repaint every visible cell each frame; `insert_before` output is written once and never repainted, which is the case this covers.
