### PR TITLE
docs(core): clarify Rect::contains half-open bounds

### DIFF
--- a/ratatui-core/src/layout/rect.rs
+++ b/ratatui-core/src/layout/rect.rs
@@ -342,7 +342,9 @@ impl Rect {
 
     /// Returns true if the given position is inside the `Rect`.
     ///
-    /// The position is considered inside the `Rect` if it is on the `Rect`'s border.
+    /// A `Rect` covers the half-open range `x..right()` by `y..bottom()`, so the top and left
+    /// edges are inside while the right and bottom edges are not. A position is contained when
+    /// `x..right()` includes its `x` and `y..bottom()` includes its `y`.
     ///
     /// # Examples
     ///
@@ -350,7 +352,10 @@ impl Rect {
     /// use ratatui_core::layout::{Position, Rect};
     ///
     /// let rect = Rect::new(1, 2, 3, 4);
+    /// // The top-left corner is inside.
     /// assert!(rect.contains(Position { x: 1, y: 2 }));
+    /// // The cell just past the right edge is not.
+    /// assert!(!rect.contains(Position { x: 4, y: 2 }));
     /// ````
     pub const fn contains(self, position: Position) -> bool {
         position.x >= self.x


### PR DESCRIPTION
## Description

`Rect::contains` documents that a position is inside "if it is on the `Rect`'s border", but a `Rect` covers the half-open range `x..right()` by `y..bottom()` — the top and left edges are inside, the right and bottom edges are not. The `outside_right` and `outside_bottom` test cases already lock in that exclusive behavior, so the "border" wording is misleading.

This updates the doc comment to describe the actual bounds and adds an example showing the excluded right edge. No behavior change.

## Testing

The doc example is a doctest; `cargo test --doc -p ratatui-core contains` passes.

---

This PR was drafted with the help of Claude Code (per the project's note on AI-assisted contributions); I've reviewed and verified the change.
