### PR TITLE
fix(examples): filter non-press key events

### DIFF
--- a/examples/apps/inline/src/main.rs
+++ b/examples/apps/inline/src/main.rs
@@ -96,27 +96,32 @@ struct Worker {
 }
 
 fn input_handling(tx: mpsc::Sender<Event>) {
+    thread::spawn(move || handle_input_events(&tx));
+}
+
+fn handle_input_events(tx: &mpsc::Sender<Event>) -> Result<()> {
     let tick_rate = Duration::from_millis(200);
-    thread::spawn(move || {
-        let mut last_tick = Instant::now();
-        loop {
-            // poll for tick rate duration, if no events, sent tick event.
-            let timeout = tick_rate.saturating_sub(last_tick.elapsed());
-            if event::poll(timeout).unwrap() {
-                let event = event::read().unwrap();
-                if let Some(key) = event.as_key_press_event() {
-                    tx.send(Event::Input(key)).unwrap();
-                }
-                if matches!(event, event::Event::Resize(_, _)) {
-                    tx.send(Event::Resize).unwrap();
-                }
-            }
-            if last_tick.elapsed() >= tick_rate {
-                tx.send(Event::Tick).unwrap();
-                last_tick = Instant::now();
-            }
+    let mut last_tick = Instant::now();
+    loop {
+        // poll for tick rate duration, if no events, sent tick event.
+        let timeout = tick_rate.saturating_sub(last_tick.elapsed());
+        if event::poll(timeout)?
+            && let Some(event) = map_input_event(&event::read()?)
+        {
+            tx.send(event)?;
         }
-    });
+        if last_tick.elapsed() >= tick_rate {
+            tx.send(Event::Tick)?;
+            last_tick = Instant::now();
+        }
+    }
+}
+
+fn map_input_event(event: &event::Event) -> Option<Event> {
+    event
+        .as_key_press_event()
+        .map(Event::Input)
+        .or_else(|| matches!(event, event::Event::Resize(_, _)).then_some(Event::Resize))
 }
 
 #[expect(clippy::cast_precision_loss, clippy::needless_pass_by_value)]
@@ -284,5 +289,34 @@ fn render(frame: &mut Frame, downloads: &Downloads) {
                 height: 1,
             },
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+
+    use super::*;
+
+    #[test]
+    fn map_input_event_maps_key_presses_and_resize() {
+        let key_event = |kind| {
+            event::Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Char('q'),
+                KeyModifiers::NONE,
+                kind,
+            ))
+        };
+
+        assert!(matches!(
+            map_input_event(&key_event(KeyEventKind::Press)),
+            Some(Event::Input(_))
+        ));
+        assert!(map_input_event(&key_event(KeyEventKind::Repeat)).is_none());
+        assert!(map_input_event(&key_event(KeyEventKind::Release)).is_none());
+        assert!(matches!(
+            map_input_event(&event::Event::Resize(80, 24)),
+            Some(Event::Resize)
+        ));
     }
 }

--- a/examples/apps/inline/src/main.rs
+++ b/examples/apps/inline/src/main.rs
@@ -103,10 +103,12 @@ fn input_handling(tx: mpsc::Sender<Event>) {
             // poll for tick rate duration, if no events, sent tick event.
             let timeout = tick_rate.saturating_sub(last_tick.elapsed());
             if event::poll(timeout).unwrap() {
-                match event::read().unwrap() {
-                    event::Event::Key(key) => tx.send(Event::Input(key)).unwrap(),
-                    event::Event::Resize(_, _) => tx.send(Event::Resize).unwrap(),
-                    _ => {}
+                let event = event::read().unwrap();
+                if let Some(key) = event.as_key_press_event() {
+                    tx.send(Event::Input(key)).unwrap();
+                }
+                if matches!(event, event::Event::Resize(_, _)) {
+                    tx.send(Event::Resize).unwrap();
                 }
             }
             if last_tick.elapsed() >= tick_rate {

--- a/examples/apps/tracing/src/main.rs
+++ b/examples/apps/tracing/src/main.rs
@@ -50,9 +50,11 @@ fn main() -> Result<()> {
 }
 
 fn should_exit(events: &[Event]) -> bool {
-    events
-        .iter()
-        .any(|event| matches!(event, Event::Key(key) if key.code == KeyCode::Char('q')))
+    events.iter().any(|event| {
+        event
+            .as_key_press_event()
+            .is_some_and(|key| key.code == KeyCode::Char('q'))
+    })
 }
 
 /// Handle events and insert them into the events vector keeping only the last 10 events
@@ -99,4 +101,26 @@ fn init_tracing() -> Result<WorkerGuard> {
         .with_env_filter(env_filter)
         .init();
     Ok(guard)
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyEvent, KeyEventKind, KeyModifiers};
+
+    use super::*;
+
+    #[test]
+    fn should_exit_only_on_q_key_press() {
+        let q_event = |kind| {
+            Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Char('q'),
+                KeyModifiers::NONE,
+                kind,
+            ))
+        };
+
+        assert!(should_exit(&[q_event(KeyEventKind::Press)]));
+        assert!(!should_exit(&[q_event(KeyEventKind::Repeat)]));
+        assert!(!should_exit(&[q_event(KeyEventKind::Release)]));
+    }
 }

--- a/examples/apps/tracing/src/main.rs
+++ b/examples/apps/tracing/src/main.rs
@@ -50,11 +50,10 @@ fn main() -> Result<()> {
 }
 
 fn should_exit(events: &[Event]) -> bool {
-    events.iter().any(|event| {
-        event
-            .as_key_press_event()
-            .is_some_and(|key| key.code == KeyCode::Char('q'))
-    })
+    events
+        .iter()
+        .map(Event::as_key_press_event)
+        .any(|key| key.is_some_and(|key| key.code == KeyCode::Char('q')))
 }
 
 /// Handle events and insert them into the events vector keeping only the last 10 events

--- a/examples/apps/user-input/src/main.rs
+++ b/examples/apps/user-input/src/main.rs
@@ -21,7 +21,7 @@
 ///
 /// [`latest`]: https://github.com/ratatui/ratatui/tree/latest
 use color_eyre::Result;
-use crossterm::event::{self, KeyCode, KeyEventKind};
+use crossterm::event::{self, KeyCode};
 use ratatui::layout::{Constraint, Layout, Position};
 use ratatui::style::{Color, Modifier, Style, Stylize};
 use ratatui::text::{Line, Span, Text};
@@ -139,7 +139,7 @@ impl App {
                         }
                         _ => {}
                     },
-                    InputMode::Editing if key.kind == KeyEventKind::Press => match key.code {
+                    InputMode::Editing => match key.code {
                         KeyCode::Enter => self.submit_message(),
                         KeyCode::Char(to_insert) => self.enter_char(to_insert),
                         KeyCode::Backspace => self.delete_char(),
@@ -148,7 +148,6 @@ impl App {
                         KeyCode::Esc => self.input_mode = InputMode::Normal,
                         _ => {}
                     },
-                    InputMode::Editing => {}
                 }
             }
         }

--- a/examples/apps/volatility-surface/src/main.rs
+++ b/examples/apps/volatility-surface/src/main.rs
@@ -10,7 +10,7 @@ mod volatility;
 use std::time::{Duration, Instant};
 
 use color_eyre::Result;
-use crossterm::event::{self, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::event::{self, KeyCode, KeyModifiers};
 use display::{Surface3D, VolatilitySurface};
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::palette::tailwind::SLATE;
@@ -84,8 +84,7 @@ impl App {
             let timeout = tick_rate.saturating_sub(last_tick.elapsed());
             if event::poll(timeout)? {
                 // Only handle key press events, not repeat or release
-                if let event::Event::Key(key) = event::read()?
-                    && key.kind == KeyEventKind::Press
+                if let Some(key) = event::read()?.as_key_press_event()
                     && self.handle_key(key.code, key.modifiers)
                 {
                     break;


### PR DESCRIPTION
## Summary

- filter Crossterm events with `as_key_press_event()` in the remaining examples
- refactor inline input handling to propagate terminal and channel errors instead of panicking
- preserve inline resize handling and remove redundant user-input event-kind matching
- add regression tests for press, repeat, release, and resize event handling

Closes #2672

## Testing

- `RUSTFLAGS='--cfg getrandom_backend="windows_legacy"' cargo test --locked -p inline --bin inline`
- `cargo test --locked -p tracing@0.0.0 --bin tracing`
- `cargo clippy --locked -p inline -p tracing@0.0.0 -p volatility-surface -p user-input --all-targets -- -D warnings`
- `cargo xtask format --check`
- `cargo xtask typos`
- `git diff --check`

An additional `cargo test --locked --workspace --exclude ratatui-termion` attempt stopped before
project tests because the local Windows GNU toolchain's incomplete `dlltool`/assembler setup could
not compile external `getrandom`/`windows-sys` dependencies.