### PR TITLE
fix(paragraph): keep wrapped lines within bounds

### DIFF
--- a/ratatui-widgets/src/reflow.rs
+++ b/ratatui-widgets/src/reflow.rs
@@ -51,6 +51,17 @@ where
     pending_line_pool: Vec<Vec<StyledGrapheme<'a>>>,
 }
 
+fn width_overflow(max_width: u16, widths: &[u16]) -> bool {
+    let mut remaining_width = max_width;
+    for &width in widths {
+        if width > remaining_width {
+            return true;
+        }
+        remaining_width = remaining_width.saturating_sub(width);
+    }
+    false
+}
+
 impl<'a, O, I> WordWrapper<'a, O, I>
 where
     O: Iterator<Item = (I, Alignment)>,
@@ -95,22 +106,26 @@ where
             }
 
             let word_found = non_whitespace_previous && is_whitespace;
+            let line_has_no_width = line_width == 0;
             // current word would overflow after removing whitespace
-            let trimmed_overflow = pending_line.is_empty()
+            let trimmed_overflow = line_has_no_width
                 && self.trim
-                && word_width + symbol_width > self.max_line_width;
+                && width_overflow(self.max_line_width, &[word_width, symbol_width]);
             // separated whitespace would overflow on its own
-            let whitespace_overflow = pending_line.is_empty()
+            let whitespace_overflow = line_has_no_width
                 && self.trim
-                && whitespace_width + symbol_width > self.max_line_width;
+                && width_overflow(self.max_line_width, &[whitespace_width, symbol_width]);
             // current full word (including whitespace) would overflow
-            let untrimmed_overflow = pending_line.is_empty()
+            let untrimmed_overflow = line_has_no_width
                 && !self.trim
-                && word_width + whitespace_width + symbol_width > self.max_line_width;
+                && width_overflow(
+                    self.max_line_width,
+                    &[word_width, whitespace_width, symbol_width],
+                );
 
             // append finished segment to current line
             if word_found || trimmed_overflow || whitespace_overflow || untrimmed_overflow {
-                if !pending_line.is_empty() || !self.trim {
+                if !line_has_no_width || !self.trim {
                     pending_line.extend(self.pending_whitespace.drain(..));
                     line_width += whitespace_width;
                 }
@@ -125,12 +140,15 @@ where
 
             // pending line fills up limit
             let line_full = line_width >= self.max_line_width;
-            // pending word would overflow line limit
-            let pending_word_overflow = symbol_width > 0
-                && line_width + whitespace_width + word_width >= self.max_line_width;
+            // pending content and current symbol would overflow line limit
+            let pending_content_overflow = symbol_width > 0
+                && width_overflow(
+                    self.max_line_width,
+                    &[line_width, whitespace_width, word_width, symbol_width],
+                );
 
             // add finished wrapped line to remaining lines
-            if line_full || pending_word_overflow {
+            if line_full || pending_content_overflow {
                 let mut remaining_width = u16::saturating_sub(self.max_line_width, line_width);
 
                 self.wrapped_lines.push_back(mem::take(&mut pending_line));
@@ -298,7 +316,8 @@ where
                     continue;
                 }
 
-                if current_line_width + symbol.cell_width() > self.max_line_width {
+                let symbol_width = symbol.cell_width();
+                if width_overflow(self.max_line_width, &[current_line_width, symbol_width]) {
                     // Truncate line
                     break;
                 }
@@ -559,6 +578,59 @@ mod tests {
         ];
         assert_eq!(word_wrapper, wrapped);
         assert_eq!(word_wrapper_width, [width, width, width, width, 4]);
+    }
+
+    #[test]
+    fn line_composer_mixed_width_word() {
+        for trim in [false, true] {
+            let (word_wrapper, word_wrapper_width, _) =
+                run_composer(Composer::WordWrapper { trim }, "a🌞b", 2);
+            assert_eq!(word_wrapper, ["a", "🌞", "b"]);
+            assert_eq!(word_wrapper_width, [1, 2, 1]);
+        }
+    }
+
+    #[test]
+    fn line_composer_leading_combining_mark() {
+        let text = "\u{0301} 🌞日日日🌞🌞a";
+        let (untrimmed, untrimmed_widths, _) =
+            run_composer(Composer::WordWrapper { trim: false }, text, 8);
+        assert_eq!(untrimmed, ["\u{0301} 🌞日日", "日🌞🌞a"]);
+        assert_eq!(untrimmed_widths, [7, 7]);
+
+        let (trimmed, trimmed_widths, _) =
+            run_composer(Composer::WordWrapper { trim: true }, text, 8);
+        assert_eq!(trimmed, ["\u{0301}", "🌞日日日", "🌞🌞a"]);
+        assert_eq!(trimmed_widths, [0, 8, 5]);
+    }
+
+    #[test]
+    fn line_composer_max_width_untrimmed_does_not_overflow() {
+        let width = u16::MAX;
+        let mut text = "a".repeat(usize::from(width) - 1);
+        text.push_str(" b");
+
+        let (_, widths, _) = run_composer(Composer::WordWrapper { trim: false }, text, width);
+        assert_eq!(widths, [width - 1, 1]);
+    }
+
+    #[test]
+    fn line_composer_max_width_trimmed_does_not_overflow() {
+        let width = u16::MAX;
+        let mut text = "a".repeat(usize::from(width) - 1);
+        text.push_str(" b");
+
+        let (_, widths, _) = run_composer(Composer::WordWrapper { trim: true }, text, width);
+        assert_eq!(widths, [width - 1, 1]);
+    }
+
+    #[test]
+    fn line_truncator_max_width_does_not_overflow() {
+        let width = u16::MAX;
+        let text = "a".repeat(usize::from(width) + 1);
+
+        let (_, widths, _) = run_composer(Composer::LineTruncator, text, width);
+        assert_eq!(widths, [width]);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2679.

Word wrapping could emit lines wider than the paragraph when a wide grapheme did not fit the remaining cells. A leading zero-width grapheme could also make a widthless pending line appear non-empty and delay wrapping.

Use measured cell width when checking pending content and include the current grapheme in the overflow calculation. Regression tests cover mixed-width words and leading combining marks with trimmed and untrimmed wrapping.

## Testing

- cargo test -p ratatui-widgets --lib
- cargo xtask check --all
- cargo clippy --package ratatui-widgets --all-features --all-targets --tests --benches -- -D warnings
- cargo xtask format --check
- cargo xtask typos

## AI assistance

Codex was used for issue analysis and local validation.