### PR TITLE
build(deps): raise minimum palette to 0.7.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,7 +1070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1112,12 +1112,6 @@ dependencies = [
  "bit-set",
  "regex",
 ]
-
-[[package]]
-name = "fast-srgb8"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -2337,26 +2331,35 @@ dependencies = [
 
 [[package]]
 name = "palette"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
 dependencies = [
  "approx",
- "fast-srgb8",
  "libm",
  "palette_derive",
+ "palette_math",
 ]
 
 [[package]]
 name = "palette_derive"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
 dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -3156,7 +3159,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ kasuari = { version = "0.4.9", default-features = false }
 line-clipping = "0.3"
 lru = "0.18"
 octocrab = "0.54"
-palette = { version = "0.7.6", default-features = false, features = ["libm"] }
+palette = { version = "0.7.7", default-features = false, features = ["libm"] }
 pretty_assertions = "1"
 rand = "0.10"
 rand_chacha = "0.10"


### PR DESCRIPTION
## Description

`Check Minimal Versions` currently fails on every open PR, unrelated to the PR contents. It fails inside `palette` itself, with 34 errors:

```
error[E0433]: cannot find `meta` in `xyz`
  --> palette-0.7.6/src/xyz.rs:40:28
   | #[derive(Debug, ArrayCast, FromColorUnclamped, WithAlpha)]
   |                            ^^^^^^^^^^^^^^^^^^ could not find `meta` in `xyz`
error[E0433]: cannot find `lms` in the crate root
error: could not compile `palette` (lib) due to 34 previous errors
```

## Root cause

`cargo minimal-versions check --direct` pins *direct* dependencies to their declared minimum, but lets transitive dependencies resolve normally:

- `palette` is a direct workspace dependency declared as `0.7.6` → pinned to **0.7.6**
- `palette_derive` is transitive, and `palette` 0.7.6 requires it at `^0.7.6` → resolves to **0.7.7**

The 0.7.7 derive expands to code referencing `xyz::meta` and `crate::lms`, which only exist in the 0.7.7 lib. That pairing cannot compile, and `palette` 0.7.6 has no way to exclude the incompatible derive.

## Fix

Raise the workspace minimum to `0.7.7` so the lib and its derive stay in step.

## Reproduction

The failure reproduces without the minimal-versions tooling, by pinning the derive alone against an otherwise unchanged lockfile:

```console
$ cargo update -p palette_derive --precise 0.7.7
$ cargo check -p ratatui --all-features
error[E0433]: failed to resolve: could not find `lms` in the crate root
error[E0433]: failed to resolve: could not find `meta` in `xyz`
...
```

## Lockfile notes

Beyond the version bumps, updating the lockfile:

- drops `fast-srgb8`, whose functionality moved into the new `palette_math` crate
- deduplicates two `windows-sys 0.52.0` entries (`errno`, `rustix`) onto `0.60.2`, which was already in the graph

## Dependency review

Per CONTRIBUTING's guidance on dependency changes:

- **MSRV**: `palette` 0.7.7 declares `rust-version = "1.71.0"`, well under the workspace MSRV of 1.88.0. The 1.88.0 CI jobs are unaffected.
- **Licensing**: `palette` remains `MIT OR Apache-2.0`; the new `palette_math` is also `MIT OR Apache-2.0`. Both are on the `deny.toml` allowlist.
- This is a minimum-version bump only — no API surface changes, and no ratatui code changed.

## Testing

- `cargo minimal-versions check --direct --workspace --all-features --all-targets` — passes (previously failed)
- `cargo check --workspace --all-features --locked` — passes
- `cargo test -p ratatui --all-features` — passes
- `cargo clippy --workspace --all-features --all-targets` — clean

## Notes

A companion PR fixes the other unrelated CI failure, `Check Docs`.

I did not open an issue first, as CONTRIBUTING suggests for dependency changes — happy to do so if you'd prefer, though this is a CI-unblocking minimum bump rather than a new or upgraded dependency.

Per CONTRIBUTING's AI disclosure guidance: written with Claude Code, and reviewed by me.