### PR TITLE
docs: fix broken Demo and Demo2 images in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -57,13 +57,13 @@ easily be productive in creating applications:
 This is the original demo example from the main README. It is available for each of the backends.
 [Source](./apps/demo/).
 
-![Demo](demo.gif)
+![Demo][demo.gif]
 
 ## Demo2
 
 This is the demo example from the main README and crate page. [Source](./apps/demo2/).
 
-![Demo2](demo2.gif)
+![Demo2][demo2.gif]
 
 ## Async GitHub
 
@@ -257,6 +257,8 @@ vhs/generate.bash
 [constraint-explorer.gif]: https://github.com/ratatui/ratatui/blob/images/examples/constraint-explorer.gif?raw=true
 [constraints.gif]: https://github.com/ratatui/ratatui/blob/images/examples/constraints.gif?raw=true
 [custom-widget.gif]: https://github.com/ratatui/ratatui/blob/images/examples/custom-widget.gif?raw=true
+[demo.gif]: https://github.com/ratatui/ratatui/blob/images/examples/demo.gif?raw=true
+[demo2.gif]: https://github.com/ratatui/ratatui/blob/images/examples/demo2.gif?raw=true
 [flex.gif]: https://github.com/ratatui/ratatui/blob/images/examples/flex.gif?raw=true
 [hello-world.gif]: https://github.com/ratatui/ratatui/blob/images/examples/hello-world.gif?raw=true
 [hyperlink.gif]: https://github.com/ratatui/ratatui/blob/images/examples/hyperlink.gif?raw=true


### PR DESCRIPTION
The Demo and Demo2 sections of the examples README embed their gifs with inline links to `demo.gif` and `demo2.gif`:

```markdown
![Demo](demo.gif)
![Demo2](demo2.gif)
```

Those paths do not exist on the default branch, so both images render broken on GitHub and on the crate page. The gifs actually live on the `images` branch (`examples/demo.gif` and `examples/demo2.gif`), and every other example on this page already points there with a reference-style link, for example:

```markdown
![Async GitHub demo][async-github.gif]

[async-github.gif]: https://github.com/ratatui/ratatui/blob/images/examples/async-github.gif?raw=true
```

This changes Demo and Demo2 to use the same reference-style links and adds the two matching definitions, kept in alphabetical order with the rest. No other changes.

---

AI attribution (per CONTRIBUTING.md): I used an AI assistant to help spot and verify this issue. I confirmed the fix against the repository myself, the two gifs exist on the `images` branch and the Demo/Demo2 entries were the only two on the page still using inline links, and reviewed every line of the change.
