### PR TITLE
test: cover and document Paragraph/Text/Line/Span style interactions

### DIFF
--- a/ratatui-core/src/text/line.rs
+++ b/ratatui-core/src/text/line.rs
@@ -327,6 +327,9 @@ impl<'a> Line<'a> {
     /// only by the style of each [`Span`] contained in the line. For this reason, this field may
     /// not be supported by all widgets (outside of the `ratatui` crate itself).
     ///
+    /// When rendered as part of a [`Text`], this style is patched on top of the text's style. Each
+    /// [`Span`] style is then patched on top, so fields set by a span take precedence.
+    ///
     /// `style` accepts any type that is convertible to [`Style`] (e.g. [`Style`], [`Color`], or
     /// your own type that implements [`Into<Style>`]).
     ///

--- a/ratatui-core/src/text/span.rs
+++ b/ratatui-core/src/text/span.rs
@@ -199,6 +199,9 @@ impl<'a> Span<'a> {
     /// In contrast to [`Span::patch_style`], this method replaces the style of the span instead of
     /// patching it.
     ///
+    /// When rendered inside a [`Line`] or [`Text`], this style is patched on top of those styles,
+    /// so any field it sets takes precedence over them.
+    ///
     /// `style` accepts any type that is convertible to [`Style`] (e.g. [`Style`], [`Color`], or
     /// your own type that implements [`Into<Style>`]).
     ///
@@ -212,6 +215,7 @@ impl<'a> Span<'a> {
     /// ```
     ///
     /// [`Color`]: crate::style::Color
+    /// [`Text`]: crate::text::Text
     #[must_use = "method moves the value of self and returns the modified value"]
     pub fn style<S: Into<Style>>(mut self, style: S) -> Self {
         self.style = style.into();

--- a/ratatui-core/src/text/text.rs
+++ b/ratatui-core/src/text/text.rs
@@ -312,6 +312,9 @@ impl<'a> Text<'a> {
     /// only by the style of each [`Line`] contained in the line. For this reason, this field may
     /// not be supported by all widgets (outside of the `ratatui` crate itself).
     ///
+    /// When rendered, this style is the base for the text. Each [`Line`] style, and then each
+    /// [`Span`] style, is patched on top, so fields set by the more specific style take precedence.
+    ///
     /// `style` accepts any type that is convertible to [`Style`] (e.g. [`Style`], [`Color`], or
     /// your own type that implements [`Into<Style>`]).
     ///

--- a/ratatui-widgets/src/paragraph.rs
+++ b/ratatui-widgets/src/paragraph.rs
@@ -182,8 +182,9 @@ impl<'a> Paragraph<'a> {
     /// `style` accepts any type that is convertible to [`Style`] (e.g. [`Style`], [`Color`], or
     /// your own type that implements [`Into<Style>`]).
     ///
-    /// This applies to the entire widget, including the block if one is present. Any style set on
-    /// the block or text will be added to this style.
+    /// This applies to the entire widget, including the block if one is present. On the rendered
+    /// text, the [`Text`], [`Line`], and [`Span`] styles are patched on top of this style in that
+    /// order, so fields they set take precedence.
     ///
     /// # Example
     ///
@@ -195,6 +196,7 @@ impl<'a> Paragraph<'a> {
     /// ```
     ///
     /// [`Color`]: ratatui_core::style::Color
+    /// [`Span`]: ratatui_core::text::Span
     #[must_use = "method moves the value of self and returns the modified value"]
     pub fn style<S: Into<Style>>(mut self, style: S) -> Self {
         self.style = style.into();

--- a/ratatui/tests/text_style.rs
+++ b/ratatui/tests/text_style.rs
@@ -1,0 +1,99 @@
+//! Tests for how `Paragraph`, `Block`, `Text`, `Line` and `Span` styles interact.
+//!
+//! See <https://github.com/ratatui/ratatui/issues/1015>.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Style, Stylize};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Paragraph, Widget};
+
+/// Renders `paragraph` onto a buffer the size of `expected` and asserts they match.
+#[track_caller]
+fn test_case(paragraph: &Paragraph, expected: &Buffer) {
+    let mut buffer = Buffer::empty(expected.area);
+    paragraph.render(buffer.area, &mut buffer);
+    assert_eq!(buffer, *expected);
+}
+
+#[test]
+fn prerendered_background_is_kept_under_unstyled_text() {
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 1));
+    buffer.set_style(buffer.area, Style::new().on_blue());
+    Paragraph::new("hi").render(buffer.area, &mut buffer);
+
+    let mut expected = Buffer::with_lines(["hi  "]);
+    expected.set_style(expected.area, Style::new().on_blue());
+    assert_eq!(buffer, expected);
+}
+
+#[test]
+fn paragraph_style_overrides_prerendered_background_and_fills_the_area() {
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 1));
+    buffer.set_style(buffer.area, Style::new().red().on_green());
+    Paragraph::new("hi")
+        .style(Style::new().blue())
+        .render(buffer.area, &mut buffer);
+
+    // Paragraph fg overrides the prerendered fg on every cell; the prerendered bg
+    // is inherited because Paragraph::style does not set one.
+    let mut expected = Buffer::with_lines(["hi  "]);
+    expected.set_style(expected.area, Style::new().blue().on_green());
+    assert_eq!(buffer, expected);
+}
+
+#[test]
+fn text_style_overrides_paragraph_style_on_text_cells_only() {
+    let paragraph = Paragraph::new(Text::from("hi").blue()).style(Style::new().red().on_green());
+    let mut expected = Buffer::with_lines(["hi  "]);
+    expected.set_style(expected.area, Style::new().red().on_green());
+    expected.set_style(Rect::new(0, 0, 2, 1), Style::new().blue());
+    test_case(&paragraph, &expected);
+}
+
+#[test]
+fn line_style_overrides_text_style_but_inherits_it() {
+    let paragraph = Paragraph::new(Text::from(Line::from("hi").blue()).red().on_green());
+    let mut expected = Buffer::with_lines(["hi  "]);
+    expected.set_style(Rect::new(0, 0, 2, 1), Style::new().blue().on_green());
+    test_case(&paragraph, &expected);
+}
+
+#[test]
+fn span_style_overrides_line_style_but_inherits_it() {
+    let paragraph = Paragraph::new(Line::from(Span::from("hi").blue()).red().on_green());
+    let mut expected = Buffer::with_lines(["hi  "]);
+    expected.set_style(Rect::new(0, 0, 2, 1), Style::new().blue().on_green());
+    test_case(&paragraph, &expected);
+}
+
+#[test]
+fn block_style_covers_the_border_but_paragraph_style_covers_the_whole_inside() {
+    let paragraph = Paragraph::new("hi")
+        .block(Block::bordered().on_green())
+        .style(Style::new().on_blue());
+    let mut expected = Buffer::with_lines(["┌────┐", "│hi  │", "└────┘"]);
+    expected.set_style(expected.area, Style::new().on_green());
+    // the whole inner rect, blanks included, is covered by the paragraph style
+    expected.set_style(Rect::new(1, 1, 4, 1), Style::new().on_blue());
+    test_case(&paragraph, &expected);
+}
+
+#[test]
+fn all_styles_combine() {
+    let text = Text::from(Line::from(Span::from("hi").red()).underlined()).bold();
+    let paragraph = Paragraph::new(text)
+        .block(Block::bordered().on_green())
+        .style(Style::new().blue());
+
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 3));
+    buffer.set_style(buffer.area, Style::new().italic());
+    paragraph.render(buffer.area, &mut buffer);
+
+    let mut expected = Buffer::with_lines(["┌──┐", "│hi│", "└──┘"]);
+    expected.set_style(expected.area, Style::new().italic().blue().on_green());
+    let inner = Style::new().red().on_green().italic().bold().underlined();
+    expected[(1, 1)].set_style(inner);
+    expected[(2, 1)].set_style(inner);
+    assert_eq!(buffer, expected);
+}


### PR DESCRIPTION
## What

Addresses #1015, covering the integration-test and API-docs items from its solution
list (the first and third).

Adds an integration test that characterizes how styles interact when a `Paragraph`
is rendered, and clarifies the API docs on `Span::style`, `Line::style`,
`Text::style`, and `Paragraph::style` to state those interactions.

## Tests

New `ratatui/tests/text_style.rs`, asserting against the rendered `Buffer`:

- a background already rendered to the buffer is preserved under unstyled text
- `Paragraph::style` fills the whole area, and overrides a prerendered foreground
  while inheriting its background
- the precedence chain on text cells is `Span` > `Line` > `Text` > `Paragraph`,
  with each layer overriding only the fields it sets and inheriting the rest
- `Block::style` covers the border while `Paragraph::style` covers the whole inside
- all six layers combined at once

## Docs

Each `style` method now states, in fieldwise terms, that its style is patched on top
of the neighbouring layers, with fields set by later layers taking precedence (order
`Text` -> `Line` -> `Span`). `Block::style` was left unchanged; the region-dependent
Paragraph/Block precedence is deferred to the fourth solution item (see the question
below).

## Deliberately not included

- The second solution item (per-type unit-test submodules): planned as a small
  follow-up PR to keep this one focused.
- The fourth solution item (reconciling illogical overrides): no behavior is changed
  here. See the question below.

## Question for maintainers (relates to the fourth solution item)

While writing the tests I noticed `Paragraph::style` is applied to the whole area,
then applied again to the inner text area *after* the block is drawn (`render` /
`render_paragraph`). The effect is that on **border** cells `Block::style` wins, but
on **inner** cells `Paragraph::style` wins.

My tentative read is that this is defensible: the inner text area being governed by
`Paragraph::style` and the border by `Block::style` is intuitive. But since it falls
out of `Paragraph::style` being applied twice rather than by explicit design, I
wanted to flag it. The test
`block_style_covers_the_border_but_paragraph_style_covers_the_whole_inside`
characterizes the current behavior without claiming it is correct, and I did not
document it as a guarantee. If a different behavior is intended I'm happy to adjust
the test or open a follow-up.

## AI disclosure

This PR was prepared with the assistance of Claude Code. I reviewed every line,
confirmed the tests pass and the docs build cleanly, and checked the style-cascade
claims against the actual render implementation.
