### PR TITLE
fix(core): save and restore cursor position

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -10,6 +10,8 @@ GitHub with a [breaking change] label.
 
 This is a quick summary of the sections below:
 
+- [v0.31.0](#v0310)
+  - `Backend` adds cursor save and restore methods
 - [v0.30.1](#v0301)
   - Adding `AsRef` impls for widgets may affect type inference in rare cases
   - MSRV is now 1.88.0
@@ -96,6 +98,20 @@ This is a quick summary of the sections below:
 - [v0.20.0](#v0200)
   - MSRV is now 1.63.0
   - `List` no longer ignores empty strings
+
+## v0.31.0
+
+### `Backend` adds cursor save and restore methods
+
+`Backend` now provides default `save_cursor_position` and `restore_cursor_position` methods.
+Existing backend implementations continue to compile because both methods have default
+implementations. However, this may cause method-call ambiguity in the unlikely case that another
+trait in scope defines a method with the same name for a backend type. Use fully qualified syntax to
+disambiguate such calls.
+
+Backends that can save the cursor without querying terminal input should override both methods and
+return `Ok(true)` from `save_cursor_position`. Other backends can use the default implementations,
+which select the cursor get-and-set fallback.
 
 ## [v0.30.1](https://github.com/ratatui/ratatui/releases/tag/ratatui-v0.30.1)
 

--- a/ratatui-core/src/backend.rs
+++ b/ratatui-core/src/backend.rs
@@ -231,6 +231,37 @@ pub trait Backend {
     /// ```
     fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> Result<(), Self::Error>;
 
+    /// Try to save the current cursor position so it can be restored with
+    /// [`restore_cursor_position`](Self::restore_cursor_position).
+    ///
+    /// Returns `true` when the position was saved. When this returns `false`, callers should use
+    /// [`get_cursor_position`](Self::get_cursor_position) and
+    /// [`set_cursor_position`](Self::set_cursor_position) to preserve the cursor instead.
+    ///
+    /// Saving and restoring the cursor position is not nestable. Backends are only required to
+    /// retain one saved position, so a later successful save may replace the position from an
+    /// earlier save.
+    ///
+    /// This must not query the terminal for the cursor position or read from its input stream.
+    /// Backends that support a terminal cursor-save command should override this method and return
+    /// `true` after writing it. The default implementation returns `false`.
+    fn save_cursor_position(&mut self) -> Result<bool, Self::Error> {
+        Ok(false)
+    }
+
+    /// Restore the cursor position previously saved by
+    /// [`save_cursor_position`](Self::save_cursor_position).
+    ///
+    /// This restores the most recently saved position. Saving and restoring the cursor position
+    /// is not nestable.
+    ///
+    /// This must not query the terminal for the cursor position or read from its input stream.
+    /// Backends whose [`save_cursor_position`](Self::save_cursor_position) implementation can
+    /// return `true` must override this method. The default implementation does nothing.
+    fn restore_cursor_position(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     /// Get the current cursor position on the terminal screen.
     ///
     /// The returned tuple contains the x and y coordinates of the cursor. The origin

--- a/ratatui-core/src/backend/test.rs
+++ b/ratatui-core/src/backend/test.rs
@@ -34,6 +34,8 @@ pub struct TestBackend {
     scrollback: Buffer,
     cursor: bool,
     pos: (u16, u16),
+    saved_pos: Option<(u16, u16)>,
+    cursor_position_queries: usize,
 }
 
 /// Returns a string representation of the given buffer for debugging purpose.
@@ -74,6 +76,8 @@ impl TestBackend {
             scrollback: Buffer::empty(Rect::new(0, 0, width, 0)),
             cursor: false,
             pos: (0, 0),
+            saved_pos: None,
+            cursor_position_queries: 0,
         }
     }
 
@@ -96,6 +100,8 @@ impl TestBackend {
             scrollback,
             cursor: false,
             pos: (0, 0),
+            saved_pos: None,
+            cursor_position_queries: 0,
         }
     }
 
@@ -115,6 +121,11 @@ impl TestBackend {
             x: self.pos.0,
             y: self.pos.1,
         }
+    }
+
+    /// Returns the number of times the cursor position has been queried.
+    pub const fn cursor_position_query_count(&self) -> usize {
+        self.cursor_position_queries
     }
 
     /// Returns a reference to the internal scrollback buffer of the `TestBackend`.
@@ -270,11 +281,24 @@ impl Backend for TestBackend {
     }
 
     fn get_cursor_position(&mut self) -> Result<Position> {
+        self.cursor_position_queries += 1;
         Ok(self.pos.into())
     }
 
     fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> Result<()> {
         self.pos = position.into().into();
+        Ok(())
+    }
+
+    fn save_cursor_position(&mut self) -> Result<bool> {
+        self.saved_pos = Some(self.pos);
+        Ok(true)
+    }
+
+    fn restore_cursor_position(&mut self) -> Result<()> {
+        if let Some(position) = self.saved_pos {
+            self.pos = position;
+        }
         Ok(())
     }
 
@@ -480,6 +504,8 @@ mod tests {
                 scrollback: Buffer::empty(Rect::new(0, 0, 10, 0)),
                 cursor: false,
                 pos: (0, 0),
+                saved_pos: None,
+                cursor_position_queries: 0,
             }
         );
     }
@@ -583,6 +609,16 @@ mod tests {
             .set_cursor_position(Position { x: 5, y: 5 })
             .unwrap();
         assert_eq!(backend.pos, (5, 5));
+    }
+
+    #[test]
+    fn save_and_restore_cursor_position() {
+        let mut backend = TestBackend::new(10, 10);
+        backend.set_cursor_position((5, 5)).unwrap();
+        assert!(backend.save_cursor_position().unwrap());
+        backend.set_cursor_position((1, 2)).unwrap();
+        backend.restore_cursor_position().unwrap();
+        backend.assert_cursor_position((5, 5));
     }
 
     #[test]

--- a/ratatui-core/src/terminal/buffers.rs
+++ b/ratatui-core/src/terminal/buffers.rs
@@ -138,6 +138,15 @@ impl<B: Backend> Terminal<B> {
     ///
     /// This preserves the backend's current cursor position.
     ///
+    /// For fixed and inline viewports, this uses [`Backend::save_cursor_position`] and
+    /// [`Backend::restore_cursor_position`], falling back to [`Backend::get_cursor_position`] and
+    /// [`Backend::set_cursor_position`] when saving is unsupported. Saving avoids a terminal cursor
+    /// position query that could compete with application input readers for the response; see
+    /// [issue #2691](https://github.com/ratatui/ratatui/issues/2691). Because terminals generally
+    /// have a single saved-cursor slot, this may overwrite the position stored by any other call to
+    /// [`Backend::save_cursor_position`]; save and restore operations that overlap this call are
+    /// not nestable.
+    ///
     /// This also resets the "previous" buffer so the next [`Terminal::flush`] redraws the full
     /// viewport.
     ///
@@ -145,10 +154,21 @@ impl<B: Backend> Terminal<B> {
     ///
     /// Implementation note: this uses [`ClearType::AfterCursor`] starting at the viewport origin.
     pub fn clear(&mut self) -> Result<(), B::Error> {
-        let original_cursor = self.backend.get_cursor_position()?;
-        self.clear_viewport()?;
-        self.backend.set_cursor_position(original_cursor)?;
-        Ok(())
+        match self.viewport {
+            // Clearing the full display preserves the cursor position by the Backend contract, so
+            // avoid saving it unnecessarily.
+            Viewport::Fullscreen => self.clear_viewport(),
+            Viewport::Inline(_) | Viewport::Fixed(_) => {
+                if self.backend.save_cursor_position()? {
+                    self.clear_viewport()?;
+                    self.backend.restore_cursor_position()
+                } else {
+                    let original_cursor = self.backend.get_cursor_position()?;
+                    self.clear_viewport()?;
+                    self.backend.set_cursor_position(original_cursor)
+                }
+            }
+        }
     }
 
     /// Clears according to the current viewport and resets the back buffer.
@@ -369,6 +389,23 @@ mod tests {
         assert_eq!(
             terminal.backend().cursor_position(),
             Position { x: 2, y: 0 }
+        );
+    }
+
+    #[test]
+    fn clear_fixed_uses_saved_cursor_without_querying() {
+        let backend = TestBackend::new(10, 3);
+        let options = TerminalOptions {
+            viewport: Viewport::Fixed(Rect::new(0, 1, 10, 2)),
+        };
+        let mut terminal = Terminal::with_options(backend, options).unwrap();
+        let query_count = terminal.backend().cursor_position_query_count();
+
+        terminal.clear().unwrap();
+
+        assert_eq!(
+            terminal.backend().cursor_position_query_count(),
+            query_count
         );
     }
 

--- a/ratatui-crossterm/src/lib.rs
+++ b/ratatui-crossterm/src/lib.rs
@@ -73,7 +73,7 @@
 
 use std::io::{self, Write};
 
-use crossterm::cursor::{Hide, MoveTo, Show};
+use crossterm::cursor::{Hide, MoveTo, RestorePosition, SavePosition, Show};
 #[cfg(feature = "underline-color")]
 use crossterm::style::SetUnderlineColor;
 use crossterm::style::{
@@ -308,6 +308,15 @@ where
     fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
         let Position { x, y } = position.into();
         execute!(self.writer, MoveTo(x, y))
+    }
+
+    fn save_cursor_position(&mut self) -> io::Result<bool> {
+        execute!(self.writer, SavePosition)?;
+        Ok(true)
+    }
+
+    fn restore_cursor_position(&mut self) -> io::Result<()> {
+        execute!(self.writer, RestorePosition)
     }
 
     fn clear(&mut self) -> io::Result<()> {
@@ -796,6 +805,16 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+
+    #[test]
+    fn save_and_restore_cursor_position_write_escape_sequences() {
+        let mut backend = CrosstermBackend::new(Vec::new());
+
+        assert!(backend.save_cursor_position().unwrap());
+        backend.restore_cursor_position().unwrap();
+
+        assert_eq!(backend.writer(), b"\x1b7\x1b8");
+    }
 
     #[rstest]
     #[case(CrosstermColor::Reset, Color::Reset)]

--- a/ratatui-termina/src/lib.rs
+++ b/ratatui-termina/src/lib.rs
@@ -225,6 +225,19 @@ where
         self.terminal.flush()
     }
 
+    fn save_cursor_position(&mut self) -> io::Result<bool> {
+        let command = Csi::Cursor(Cursor::SaveCursor);
+        write!(self.terminal, "{command}")?;
+        self.terminal.flush()?;
+        Ok(true)
+    }
+
+    fn restore_cursor_position(&mut self) -> io::Result<()> {
+        let command = Csi::Cursor(Cursor::RestoreCursor);
+        write!(self.terminal, "{command}")?;
+        self.terminal.flush()
+    }
+
     fn clear(&mut self) -> io::Result<()> {
         self.clear_region(ClearType::All)
     }
@@ -615,6 +628,17 @@ mod tests {
             backend.terminal.output(),
             format!("{hide_cursor}{show_cursor}")
         );
+    }
+
+    #[test]
+    fn saves_and_restores_cursor_position() {
+        let mut backend = backend();
+        assert!(backend.save_cursor_position().unwrap());
+        backend.restore_cursor_position().unwrap();
+
+        let save = Csi::Cursor(Cursor::SaveCursor);
+        let restore = Csi::Cursor(Cursor::RestoreCursor);
+        assert_eq!(backend.terminal.output(), format!("{save}{restore}"));
     }
 
     #[test]

--- a/ratatui-termion/src/lib.rs
+++ b/ratatui-termion/src/lib.rs
@@ -208,6 +208,17 @@ where
         self.writer.flush()
     }
 
+    fn save_cursor_position(&mut self) -> io::Result<bool> {
+        write!(self.writer, "{}", termion::cursor::Save)?;
+        self.writer.flush()?;
+        Ok(true)
+    }
+
+    fn restore_cursor_position(&mut self) -> io::Result<()> {
+        write!(self.writer, "{}", termion::cursor::Restore)?;
+        self.writer.flush()
+    }
+
     fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
@@ -565,6 +576,16 @@ impl fmt::Display for ResetRegion {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn save_and_restore_cursor_position_write_escape_sequences() {
+        let mut backend = TermionBackend::new(Vec::new());
+
+        assert!(backend.save_cursor_position().unwrap());
+        backend.restore_cursor_position().unwrap();
+
+        assert_eq!(backend.writer(), b"\x1b[s\x1b[u");
+    }
 
     #[test]
     fn from_termion_color() {

--- a/ratatui-termwiz/src/lib.rs
+++ b/ratatui-termwiz/src/lib.rs
@@ -59,6 +59,12 @@ use termwiz::terminal::{ScreenSize, SystemTerminal, Terminal};
 /// commands to the terminal. It provides methods for drawing content, manipulating the cursor, and
 /// clearing the terminal screen.
 ///
+/// Termwiz tracks the cursor position in the [`BufferedTerminal`] surface rather than emitting
+/// terminal save and restore commands. [`Backend::save_cursor_position`] therefore returns `false`,
+/// and operations such as [`Terminal::clear`](ratatui_core::terminal::Terminal::clear) use the
+/// cursor get-and-set fallback. That fallback reads and updates Termwiz's local surface state
+/// without querying terminal input.
+///
 /// Most applications should not call the methods on `TermwizBackend` directly, but will instead
 /// use the [`Terminal`] struct, which provides a more ergonomic interface.
 ///
@@ -242,6 +248,9 @@ impl Backend for TermwizBackend {
         Ok(())
     }
 
+    // Termwiz intentionally uses the default cursor save and restore methods. Its buffered surface
+    // has no corresponding Change variants, and raw escape sequences could desynchronize the
+    // tracked state. The get-and-set fallback uses the local surface state without reading input.
     fn clear(&mut self) -> io::Result<()> {
         self.buffered_terminal
             .add_change(Change::ClearScreen(termwiz::color::ColorAttribute::Default));


### PR DESCRIPTION
## Summary

- add default `Backend` methods for saving and restoring the cursor position
- use save/restore during fixed and inline viewport clears, with get/set as the fallback
- implement terminal save/restore commands for Crossterm, Termion, and Termina
- keep Termwiz on its local buffered-surface fallback
- document the single saved-cursor slot and the unlikely trait method ambiguity

## Problem

`Terminal::clear()` queried the cursor position before clearing partial viewports. Termion implements that query by requesting a terminal response and reading input, which can race an application's input reader and time out.

The new save/restore path avoids reading terminal input for the built-in backends that support terminal cursor save commands. Backends that use the default `Ok(false)` implementation retain the existing get/set fallback.

## Testing

- `cargo fmt --check`
- `cargo test -p ratatui-core -p ratatui-crossterm -p ratatui-termion -p ratatui-termina -p ratatui-termwiz`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `markdownlint-cli2 BREAKING-CHANGES.md`

Fixes #2691.
