### PR TITLE
fix(buffer): clamp forced trailing range to the buffer length

### DIFF
--- a/ratatui-core/src/buffer/diff.rs
+++ b/ratatui-core/src/buffer/diff.rs
@@ -181,7 +181,7 @@ impl<'next> Iterator for BufferDiff<'_, 'next> {
                         // refresh the terminal regardless of whether the buffer content changed.
                         self.trailing = Some(TrailingState {
                             next_index: i + 1,
-                            end: i + previous_width,
+                            end: (i + previous_width).min(len),
                             force: true,
                         });
                     } else {
@@ -573,6 +573,33 @@ mod tests {
                 .any(|(x, y, cell)| *x == 1 && *y == 0 && cell.symbol() == "好"),
             "'好' at col 1 must be emitted; got {diff:?}"
         );
+    }
+
+    /// Regression for <https://github.com/ratatui/ratatui/issues/2695> (introduced by #2587):
+    /// the forced trailing range was not clamped to the buffer length, unlike the VS16 range
+    /// above it. With a wide glyph carrying a visible-on-blank style in the *last* cell of the
+    /// buffer, replaced by narrower content, the range extended one past the end and the
+    /// iterator panicked with an index out of bounds while being consumed (i.e. inside
+    /// `Terminal::flush`).
+    #[test]
+    fn wide_glyph_in_last_cell_does_not_overrun_buffer() {
+        let rect = Rect::new(0, 0, 3, 1);
+        let mut prev = Buffer::empty(rect);
+        // set_string refuses to place a wide glyph in the last column, so write the cell
+        // directly — the path third-party widgets and direct cell access take.
+        prev.content[2].set_symbol("你").set_bg(Color::Red);
+        let mut next = Buffer::empty(rect);
+        next.content[2].set_symbol("a");
+
+        let diff: Vec<_> = BufferDiff::new(&prev, &next).collect();
+
+        assert_eq!(
+            diff.len(),
+            1,
+            "only the replaced cell must be emitted, got {diff:?}"
+        );
+        assert_eq!((diff[0].0, diff[0].1), (2, 0));
+        assert_eq!(diff[0].2.symbol(), "a");
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://github.com/ratatui/ratatui/issues/2695

## Problem

The forced trailing range introduced in #2587 — created when a wide glyph whose style is visible on blank cells (e.g. a non-reset background) is replaced by a narrower cell — is not clamped to the buffer length:

```rust
self.trailing = Some(TrailingState {
    next_index: i + 1,
    end: i + previous_width,   // not clamped
    force: true,
});
```

The trailing loop indexes `self.next[j]` *before* it clamps `end`, so when the wide glyph occupies the last cell of the buffer, the iterator reads one past the end and panics with `index out of bounds` while being consumed — i.e. inside `Terminal::flush`, crashing the app at draw time. See the issue for a minimal repro; it reproduces on `main` and in the released ratatui-core 0.1.2 / ratatui 0.30.2.

## Solution

Clamp the range with `.min(len)`, exactly like the VS16 trailing path a few lines above already does:

```rust
let trailing_end = (i + cell_width).min(len);
```

One line changed, plus a regression test (`wide_glyph_in_last_cell_does_not_overrun_buffer`) placed next to the other trailing-range regression tests in `diff.rs`. It panics without the fix and asserts the expected single-cell diff with it.

## Out of scope

While verifying the fix we noticed that the flat-index ranges in this function are clamped at the buffer end but not at *row* ends (the pre-existing wide-glyph skip at `self.pos += cell_width - 1`, the `ForcedWidth` advance, the VS16 range, and this force range can all cross a row boundary). Those are pre-existing on `main`, independent of this panic, and behavior-affecting to change, so this PR deliberately keeps to the minimal clamp that restores symmetry with the VS16 path. Happy to file a separate issue with repros for the row-boundary cases.

## Testing

- The regression test fails on `main` with `index out of bounds: the len is 3 but the index is 3` (at `diff.rs:106`) and passes with the fix.
- `cargo test -p ratatui-core --lib`: 1440 passed, 0 failed.
- `cargo clippy -p ratatui-core --all-targets` and `cargo +nightly fmt --check`: clean.

Per the AI policy in CONTRIBUTING.md: this bug was found and the fix authored with AI assistance (Claude Code). Every line was reviewed, and the panic/fix were verified by running the tests above against `main`.
