### PR TITLE
fix(buffer): treat multi-grapheme cell symbols as single-width

### DIFF
--- a/ratatui-core/src/buffer/cell.rs
+++ b/ratatui-core/src/buffer/cell.rs
@@ -1,6 +1,7 @@
 use core::num::NonZeroU16;
 
 use compact_str::CompactString;
+use unicode_segmentation::UnicodeSegmentation;
 
 use crate::buffer::cell_width::CellWidth;
 use crate::style::{Color, Modifier, Style};
@@ -309,17 +310,63 @@ impl From<char> for Cell {
 impl CellWidth for Cell {
     /// Returns [`CellDiffOption::ForcedWidth`] when set, otherwise computes the width from the
     /// cell's symbol.
+    ///
+    /// A cell holds a single grapheme cluster, so the unicode width of its symbol is the number
+    /// of columns it takes on screen. Low-level callers can store anything in a symbol though,
+    /// and image protocols store a whole escape sequence there while still occupying a single
+    /// column. Such a symbol has no meaningful unicode width, so it counts as one column.
+    /// Use [`CellDiffOption::ForcedWidth`] to declare the real width of these cells.
     fn cell_width(&self) -> u16 {
-        match self.diff_option {
-            CellDiffOption::ForcedWidth(w) => w.get(),
-            _ => self.symbol().cell_width(),
+        if let CellDiffOption::ForcedWidth(width) = self.diff_option {
+            return width.get();
+        }
+        let symbol = self.symbol();
+        let width = symbol.cell_width();
+        if width > 1 && !is_single_grapheme(symbol) {
+            1
+        } else {
+            width
         }
     }
+}
+
+/// Returns `true` if `symbol` is a single grapheme cluster.
+///
+/// Stops after the second cluster, so this stays cheap for the long escape payloads that make
+/// the check necessary in the first place.
+fn is_single_grapheme(symbol: &str) -> bool {
+    let mut graphemes = symbol.graphemes(true);
+    graphemes.next().is_some() && graphemes.next().is_none()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cell_width_of_wide_grapheme() {
+        assert_eq!(Cell::new("あ").cell_width(), 2);
+        assert_eq!(Cell::new("a").cell_width(), 1);
+    }
+
+    /// Image protocols keep a whole escape sequence in one symbol. Its unicode width says
+    /// hundreds of columns, but the cell covers one, so it must not be reported as wide.
+    #[test]
+    fn cell_width_of_escape_sequence_symbol() {
+        let payload = "\u{1b}[s".repeat(400);
+        let mut cell = Cell::EMPTY;
+        cell.set_symbol(&payload);
+        assert_eq!(cell.cell_width(), 1);
+    }
+
+    #[test]
+    fn cell_width_of_forced_width_symbol() {
+        let payload = "\u{1b}[s".repeat(400);
+        let mut cell = Cell::EMPTY;
+        cell.set_symbol(&payload);
+        cell.set_diff_option(CellDiffOption::ForcedWidth(NonZeroU16::new(24).unwrap()));
+        assert_eq!(cell.cell_width(), 24);
+    }
 
     #[test]
     #[allow(deprecated)]

--- a/ratatui-core/src/buffer/diff.rs
+++ b/ratatui-core/src/buffer/diff.rs
@@ -232,6 +232,58 @@ mod tests {
         assert!(diff.is_empty());
     }
 
+    /// Regression for <https://github.com/ratatui/ratatui/issues/2685>: an image protocol cell
+    /// keeps its whole escape sequence in one symbol, which measures hundreds of columns wide
+    /// while covering a single column. Advancing the cursor by that width dropped every later
+    /// cell in the buffer, so the frame kept whatever was on screen before.
+    #[test]
+    fn long_symbol_does_not_hide_later_cells() {
+        let area = Rect::new(0, 0, 20, 5);
+        let prev = Buffer::filled(area, Cell::new("S"));
+        let mut next = Buffer::filled(area, Cell::new("L"));
+        next[(10, 0)].set_symbol(&"\u{1b}[s".repeat(400));
+
+        let diff: Vec<_> = BufferDiff::new(&prev, &next).collect();
+        assert_eq!(diff.len(), area.area() as usize);
+    }
+
+    /// The same cell, unchanged between the two frames. It still must not hide the cells after
+    /// it, which is how the regression showed up once the image had been drawn once.
+    #[test]
+    fn unchanged_long_symbol_does_not_hide_later_cells() {
+        let area = Rect::new(0, 0, 20, 5);
+        let mut prev = Buffer::filled(area, Cell::new("S"));
+        let mut next = Buffer::filled(area, Cell::new("L"));
+        let payload = "\u{1b}[s".repeat(400);
+        prev[(10, 0)].set_symbol(&payload);
+        next[(10, 0)].set_symbol(&payload);
+
+        let diff: Vec<_> = BufferDiff::new(&prev, &next).collect();
+        assert_eq!(diff.len(), area.area() as usize - 1);
+    }
+
+    /// A real wide glyph still hides its trailing cell: writing to the column covered by the
+    /// right half of the glyph would overwrite the glyph itself.
+    #[test]
+    fn identical_wide_glyph_hides_trailing_cell_changes() {
+        use crate::style::Style;
+
+        let area = Rect::new(0, 0, 3, 1);
+        let mut prev = Buffer::empty(area);
+        prev.set_string(0, 0, "＋", Style::default());
+
+        let mut next = prev.clone();
+        // Column 1 is occupied by the right half of `＋`.
+        next[(1, 0)].set_bg(Color::Red);
+
+        let diff: Vec<_> = BufferDiff::new(&prev, &next).collect();
+
+        assert!(
+            diff.is_empty(),
+            "the hidden trailing cell of an unchanged wide glyph must not be emitted; got {diff:?}"
+        );
+    }
+
     #[test]
     fn single_cell_change() {
         let prev = Buffer::with_lines(["hello"]);


### PR DESCRIPTION
Rewritten after @orhun's review. The first version was wrong in both directions: it broke wide glyphs, and it did not actually fix the reported case. Details below.

## What is going on

A `Cell` holds a single grapheme cluster, so the unicode width of its symbol is how many columns it covers. `BufferDiff` relies on that to step over the columns a wide glyph hides.

Image protocols break the assumption. `ratatui-image` keeps a whole kitty escape sequence in one `Cell::symbol` (and marks the rest of the row `Skip`), so `cell_width()` reports hundreds of columns for a cell that covers one. The diff then advances past the rest of the buffer and the frame keeps whatever was on screen before.

Before #2416 this was harmless: `to_skip` was reassigned on every iteration, so a wide cell only ever suppressed the single cell after it. #2416 turned it into a real multi-cell advance, which is where the regression comes from.

## The fix

Report a symbol that is not a single grapheme cluster as one column wide. `CellDiffOption::ForcedWidth` still wins, so a caller that really does write wider content into one cell can say so.

Real wide glyphs are unaffected: they are one cluster, keep their unicode width, and keep hiding their trailing cells.

## On the previous version

The old approach (drop the advance on equal cells) was wrong twice over:

- It broke unchanged wide glyphs, which is the regression you caught. Your test is in as `identical_wide_glyph_hides_trailing_cell_changes`.
- It did not fix #2685. The repro in the issue draws text, then the image, so the payload cell *changed* and took the unequal branch, which still advanced by ~1300. I confirmed that on the old branch: the changed-payload case emitted 11 of 100 cells.

## Verified

- `cargo test --workspace --all-features`, `cargo clippy --workspace --all-targets --all-features`, `cargo fmt --check`
- `ratatui-core/src/buffer/diff.rs` is test-only in this diff; the behaviour change is entirely in `CellWidth for Cell`
- new tests: changed payload cell, unchanged payload cell, your wide glyph case, plus `cell_width` unit tests for a wide grapheme, an escape payload, and `ForcedWidth`

Fixes #2685
