### PR TITLE
docs(layout): advertise constraint explorer

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -103,7 +103,8 @@ Shows the full range of RGB colors in an animation. [Source](./apps/colors-rgb/)
 
 ## Constraint Explorer
 
-Shows how different constraints can be used to layout widgets. [Source](./apps/constraint-explorer/).
+An interactive layout playground for experimenting with constraint types and values, spacing, and
+`Flex` modes. [Source](./apps/constraint-explorer/).
 
 ![Constraint Explorer demo][constraint-explorer.gif]
 

--- a/examples/apps/constraint-explorer/README.md
+++ b/examples/apps/constraint-explorer/README.md
@@ -1,9 +1,18 @@
 # Constraint explorer demo
 
-This interactive example shows how different constraints can be used to layout widgets.
+This interactive example helps build intuition for Ratatui's layout engine. Experiment with
+different constraint types and values, add or remove layout blocks, change the spacing between them
+(including overlap), and compare how the `Flex` modes distribute the available space.
+
+Use the arrow keys to select and edit a block, `1`–`6` to change its constraint type, `a` and `x`
+to add or remove blocks, and `+` and `-` to change spacing. Press `q` or `Esc` to quit.
+
+![Constraint Explorer demo][constraint-explorer.gif]
 
 To run this demo:
 
 ```shell
 cargo run -p constraint-explorer
 ```
+
+[constraint-explorer.gif]: https://github.com/ratatui/ratatui/blob/images/examples/constraint-explorer.gif?raw=true

--- a/examples/apps/constraint-explorer/src/main.rs
+++ b/examples/apps/constraint-explorer/src/main.rs
@@ -1,9 +1,9 @@
 use std::cmp::Ordering;
 
-/// A Ratatui example that demonstrates how different layout constraints work.
+/// A Ratatui example that demonstrates how different layout constraints and flex modes work.
 ///
-/// It also supports swapping constraints, adding and removing blocks, and changing the spacing
-/// between blocks.
+/// It compares how each flex mode distributes space and supports swapping constraints, adding
+/// and removing blocks, and changing the spacing between blocks.
 ///
 /// This example runs with the Ratatui library code in the branch that you are currently
 /// reading. See the [`latest`] branch for the code which works with the most recent Ratatui
@@ -271,7 +271,8 @@ impl App {
     }
 
     fn instructions() -> impl Widget {
-        let text = "◄ ►: select, ▲ ▼: edit, 1-6: swap, a: add, x: delete, q: quit, +/-: spacing";
+        let text =
+            "◄ ►: select, ▲ ▼: edit, 1-6: swap, a: add, x: delete, q/Esc: quit, +/-: spacing";
         Paragraph::new(text)
             .fg(Self::TEXT_COLOR)
             .centered()
@@ -328,14 +329,16 @@ impl App {
         self.render_user_constraints_legend(user_constraints, buf);
 
         let [
+            legacy,
             start,
             center,
             end,
             space_between,
             space_around,
             space_evenly,
-        ] = area.layout(&Layout::vertical([Length(7); 6]));
+        ] = area.layout(&Layout::vertical([Length(7); 7]));
 
+        self.render_layout_block(Flex::Legacy, legacy, buf);
         self.render_layout_block(Flex::Start, start, buf);
         self.render_layout_block(Flex::Center, center, buf);
         self.render_layout_block(Flex::End, end, buf);

--- a/examples/apps/constraints/README.md
+++ b/examples/apps/constraints/README.md
@@ -1,6 +1,7 @@
 # Constraints demo
 
-This example shows different types of constraints.
+This example shows different types of constraints. For an interactive comparison of constraints
+with flex modes and spacing, see the [Constraint Explorer](../constraint-explorer/) demo.
 
 To run this demo:
 

--- a/examples/apps/flex/README.md
+++ b/examples/apps/flex/README.md
@@ -1,6 +1,7 @@
 # Flex demo
 
-This interactive example shows how to use the flex layouts.
+This interactive example shows how to use flex layouts. For an interactive comparison with different
+constraint types and spacing, see the [Constraint Explorer](../constraint-explorer/) demo.
 
 To run this demo:
 

--- a/examples/vhs/constraint-explorer.tape
+++ b/examples/vhs/constraint-explorer.tape
@@ -4,11 +4,11 @@ Output "target/constraint-explorer.gif"
 Set Theme "Aardvark Blue"
 Set FontSize 18
 Set Width 1200
-Set Height 950
+Set Height 1330
 Hide
 Type "cargo run -p constraint-explorer"
 Enter
-Sleep 2s
+Wait+Screen /Constraint Explorer/
 Show
 Set TypingSpeed 2s
 Type "1"

--- a/ratatui-core/src/layout.rs
+++ b/ratatui-core/src/layout.rs
@@ -305,10 +305,10 @@
 //!
 //! - [`constraints`](https://github.com/ratatui/ratatui/blob/main/examples/apps/constraints/) -
 //!   Demonstrates different constraint types
+//! - [`constraint-explorer`](https://github.com/ratatui/ratatui/tree/main/examples/apps/constraint-explorer/)
+//!   - Interactively compares constraint types, flex modes, spacing, and overlap
 //! - [`flex`](https://github.com/ratatui/ratatui/blob/main/examples/apps/flex/) - Shows flex space
 //!   distribution
-//! - [`layout`](https://github.com/ratatui/ratatui/blob/main/examples/apps/layout/) - Basic layout
-//!   examples
 
 mod alignment;
 mod constraint;

--- a/ratatui-core/src/layout/constraint.rs
+++ b/ratatui-core/src/layout/constraint.rs
@@ -66,6 +66,11 @@ use strum::EnumIs;
 /// let constraints = Constraint::from_fills([1, 2, 1]);
 /// ```
 ///
+/// For an interactive exploration of how these constraint types combine with flex modes and
+/// spacing, see the [constraint-explorer example].
+///
+/// [constraint-explorer example]: https://github.com/ratatui/ratatui/tree/main/examples/apps/constraint-explorer/
+///
 /// For comprehensive layout documentation and examples, see the [`layout`](crate::layout) module.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, EnumIs)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/ratatui-core/src/layout/flex.rs
+++ b/ratatui-core/src/layout/flex.rs
@@ -19,6 +19,12 @@ use crate::layout::Constraint;
 /// - `Center`: Centers items within the container.
 /// - `SpaceBetween`: Adds excess space between each element.
 /// - `SpaceAround`: Adds excess space around each element.
+/// - `SpaceEvenly`: Adds equal space between and around each element.
+///
+/// For an interactive comparison of these space distribution modes with different constraint
+/// types and spacing, see the [constraint-explorer example].
+///
+/// [constraint-explorer example]: https://github.com/ratatui/ratatui/tree/main/examples/apps/constraint-explorer/
 ///
 /// For comprehensive layout documentation and examples, see the [`layout`](crate::layout) module.
 #[derive(Copy, Debug, Default, Display, EnumString, Clone, Eq, PartialEq, Hash, EnumIs)]

--- a/ratatui-core/src/layout/layout.rs
+++ b/ratatui-core/src/layout/layout.rs
@@ -187,8 +187,9 @@ impl From<i16> for Spacing {
 /// }
 /// ```
 ///
-/// See the `layout`, `flex`, and `constraints` examples in the [Examples] folder for more details
-/// about how to use layouts.
+/// See the [constraint-explorer example] for an interactive exploration of how constraints, flex
+/// modes, and spacing affect the areas produced by a layout. The `flex` and `constraints` examples
+/// in the [Examples] folder show focused examples of each feature.
 ///
 /// For comprehensive layout documentation and examples, see the [`layout`](crate::layout) module.
 ///
@@ -197,6 +198,7 @@ impl From<i16> for Spacing {
 ///
 /// [`kasuari`]: https://crates.io/crates/kasuari
 /// [Examples]: https://github.com/ratatui/ratatui/blob/main/examples/README.md
+/// [constraint-explorer example]: https://github.com/ratatui/ratatui/tree/main/examples/apps/constraint-explorer/
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Layout {

--- a/ratatui/src/lib.rs
+++ b/ratatui/src/lib.rs
@@ -297,6 +297,9 @@
 //! section of the [Ratatui Website] for more info, and check out the [Layout Recipes] for
 //! practical examples.
 //!
+//! For an interactive exploration of constraint types, flex modes, and spacing, see the
+//! [Constraint Explorer example].
+//!
 //! ```rust,no_run
 //! use ratatui::Frame;
 //! use ratatui::layout::{Constraint, Layout};
@@ -398,6 +401,7 @@
 //! [Handling Events]: https://ratatui.rs/concepts/event-handling/
 //! [Layout]: https://ratatui.rs/recipes/layout/
 //! [Layout Recipes]: https://ratatui.rs/recipes/layout/
+//! [Constraint Explorer example]: https://github.com/ratatui/ratatui/tree/main/examples/apps/constraint-explorer/
 //! [Styling Text]: https://ratatui.rs/recipes/render/style-text/
 //! [Styling Recipes]: https://ratatui.rs/recipes/render/
 //! [templates]: https://github.com/ratatui/templates/


### PR DESCRIPTION
## Summary

- Make the Constraint Explorer easier to discover from the examples index and layout-related API docs.
- Expand its README with the demo GIF, controls, and guidance on constraints, flex modes, spacing, and overlap.
- Include all seven flex modes, including `Flex::Legacy`.
- Update the VHS tape to wait for the app and use a 1330px terminal height.

## Validation

- `cargo check -p constraint-explorer`
- `cargo fmt --all -- --check`
- `markdownlint-cli2 examples/README.md examples/apps/constraints/README.md examples/apps/flex/README.md examples/apps/constraint-explorer/README.md`
- `cargo xtask readme --check`
- `env -u NO_COLOR vhs examples/vhs/constraint-explorer.tape`
