### PR TITLE
fix(examples): allow --unicode=false to disable unicode symbols

### DIFF
--- a/examples/apps/demo/src/main.rs
+++ b/examples/apps/demo/src/main.rs
@@ -38,7 +38,7 @@ struct Cli {
     tick_rate: u64,
 
     /// whether unicode symbols are used to improve the overall look of the app
-    #[arg(short, long, default_value_t = true)]
+    #[arg(short, long, default_value_t = true, action = clap::ArgAction::Set)]
     unicode: bool,
 }
 


### PR DESCRIPTION
Default bool arg acts as a flag (present = true) and rejects explicit values, so --unicode false / --unicode=false failed with unexpected argument. Use ArgAction::Set to accept explicit true/false values.