### PR TITLE
refactor(test): group style tests into separate modules

### DIFF
--- a/ratatui-core/src/text/line.rs
+++ b/ratatui-core/src/text/line.rs
@@ -940,12 +940,6 @@ mod tests {
     }
 
     #[test]
-    fn style() {
-        let line = Line::default().style(Style::new().red());
-        assert_eq!(line.style, Style::new().red());
-    }
-
-    #[test]
     fn alignment() {
         let line = Line::from("This is left").alignment(Alignment::Left);
         assert_eq!(Some(Alignment::Left), line.alignment);
@@ -964,35 +958,6 @@ mod tests {
 
         let empty_line = Line::default();
         assert_eq!(0, empty_line.width());
-    }
-
-    #[test]
-    fn patch_style() {
-        let raw_line = Line::styled("foobar", Color::Yellow);
-        let styled_line = Line::styled("foobar", (Color::Yellow, Modifier::ITALIC));
-
-        assert_ne!(raw_line, styled_line);
-
-        let raw_line = raw_line.patch_style(Modifier::ITALIC);
-        assert_eq!(raw_line, styled_line);
-    }
-
-    #[test]
-    fn reset_style() {
-        let line =
-            Line::styled("foobar", Style::default().yellow().on_red().italic()).reset_style();
-
-        assert_eq!(Style::reset(), line.style);
-    }
-
-    #[test]
-    fn stylize() {
-        assert_eq!(Line::default().green().style, Color::Green.into());
-        assert_eq!(
-            Line::default().on_green().style,
-            Style::new().bg(Color::Green)
-        );
-        assert_eq!(Line::default().italic().style, Modifier::ITALIC.into());
     }
 
     #[test]
@@ -1246,6 +1211,69 @@ mod tests {
             line.spans,
             vec![Span::raw("A"), Span::raw("B"), Span::raw("C")]
         );
+    }
+
+    mod style {
+        use super::*;
+
+        #[test]
+        fn style() {
+            let line = Line::default().style(Style::new().red());
+            assert_eq!(line.style, Style::new().red());
+        }
+
+        #[test]
+        fn patch_style() {
+            let raw_line = Line::styled("foobar", Color::Yellow);
+            let styled_line = Line::styled("foobar", (Color::Yellow, Modifier::ITALIC));
+
+            assert_ne!(raw_line, styled_line);
+
+            let raw_line = raw_line.patch_style(Modifier::ITALIC);
+            assert_eq!(raw_line, styled_line);
+        }
+
+        #[test]
+        fn reset_style() {
+            let line =
+                Line::styled("foobar", Style::default().yellow().on_red().italic()).reset_style();
+
+            assert_eq!(Style::reset(), line.style);
+        }
+
+        #[test]
+        fn stylize() {
+            assert_eq!(Line::default().green().style, Color::Green.into());
+            assert_eq!(
+                Line::default().on_green().style,
+                Style::new().bg(Color::Green)
+            );
+            assert_eq!(Line::default().italic().style, Modifier::ITALIC.into());
+        }
+
+        #[test]
+        fn render_span_style_overrides_line_style() {
+            let mut buf = Buffer::empty(Rect::new(0, 0, 4, 1));
+            Line::from(Span::from("hi").blue())
+                .red()
+                .on_green()
+                .render(buf.area, &mut buf);
+            let expected = Buffer::with_lines([Line::from(vec![
+                "hi".blue().on_green(),
+                "  ".red().on_green(),
+            ])]);
+            assert_eq!(buf, expected);
+        }
+
+        #[test]
+        fn render_overrides_prerendered_style() {
+            let mut buf = Buffer::empty(Rect::new(0, 0, 4, 1));
+            buf.set_style(buf.area, Style::new().red().on_green().italic());
+            Line::from("hi").blue().render(buf.area, &mut buf);
+            let mut expected = Buffer::with_lines(["hi  "]);
+            expected.set_style(expected.area, Style::new().blue().on_green().italic());
+            assert_eq!(buf, expected);
+        }
     }
 
     mod widget {

--- a/ratatui-core/src/text/span.rs
+++ b/ratatui-core/src/text/span.rs
@@ -566,12 +566,6 @@ mod tests {
     }
 
     #[test]
-    fn set_style() {
-        let span = Span::default().style(Style::new().green());
-        assert_eq!(span.style, Style::new().green());
-    }
-
-    #[test]
     fn from_ref_str_borrowed_cow() {
         let content = "test content";
         let span = Span::from(content);
@@ -610,37 +604,12 @@ mod tests {
     }
 
     #[test]
-    fn reset_style() {
-        let span = Span::styled("test content", Style::new().green()).reset_style();
-        assert_eq!(span.style, Style::reset());
-    }
-
-    #[test]
-    fn patch_style() {
-        let span = Span::styled("test content", Style::new().green().on_yellow())
-            .patch_style(Style::new().red().bold());
-        assert_eq!(span.style, Style::new().red().on_yellow().bold());
-    }
-
-    #[test]
     fn width() {
         assert_eq!(Span::raw("").width(), 0);
         assert_eq!(Span::raw("test").width(), 4);
         assert_eq!(Span::raw("test content").width(), 12);
         // Needs reconsideration: https://github.com/ratatui/ratatui/issues/1271
         assert_eq!(Span::raw("test\ncontent").width(), 12);
-    }
-
-    #[test]
-    fn stylize() {
-        let span = Span::raw("test content").green();
-        assert_eq!(span.content, Cow::Borrowed("test content"));
-        assert_eq!(span.style, Style::new().green());
-
-        let span = Span::styled("test content", Style::new().green());
-        let stylized = span.on_yellow().bold();
-        assert_eq!(stylized.content, Cow::Borrowed("test content"));
-        assert_eq!(stylized.style, Style::new().green().on_yellow().bold());
     }
 
     #[test]
@@ -682,6 +651,53 @@ mod tests {
         let span = Span::styled("Test Content", Style::new().green().italic());
         let line = span.into_right_aligned_line();
         assert_eq!(line.alignment, Some(Alignment::Right));
+    }
+
+    mod style {
+        use super::*;
+
+        #[test]
+        fn style() {
+            let span = Span::default().style(Style::new().green());
+            assert_eq!(span.style, Style::new().green());
+        }
+
+        #[test]
+        fn reset_style() {
+            let span = Span::styled("test content", Style::new().green()).reset_style();
+            assert_eq!(span.style, Style::reset());
+        }
+
+        #[test]
+        fn patch_style() {
+            let span = Span::styled("test content", Style::new().green().on_yellow())
+                .patch_style(Style::new().red().bold());
+            assert_eq!(span.style, Style::new().red().on_yellow().bold());
+        }
+
+        #[test]
+        fn stylize() {
+            let span = Span::raw("test content").green();
+            assert_eq!(span.content, Cow::Borrowed("test content"));
+            assert_eq!(span.style, Style::new().green());
+
+            let span = Span::styled("test content", Style::new().green());
+            let stylized = span.on_yellow().bold();
+            assert_eq!(stylized.content, Cow::Borrowed("test content"));
+            assert_eq!(stylized.style, Style::new().green().on_yellow().bold());
+        }
+
+        #[test]
+        fn render_overrides_prerendered_style() {
+            let mut buf = Buffer::empty(Rect::new(0, 0, 4, 1));
+            buf.set_style(buf.area, Style::new().red().on_green().italic());
+            Span::from("hi").blue().render(buf.area, &mut buf);
+            let expected = Buffer::with_lines([Line::from(vec![
+                "hi".blue().on_green().italic(),
+                "  ".red().on_green().italic(),
+            ])]);
+            assert_eq!(buf, expected);
+        }
     }
 
     mod widget {

--- a/ratatui-core/src/text/text.rs
+++ b/ratatui-core/src/text/text.rs
@@ -835,26 +835,6 @@ mod tests {
     }
 
     #[test]
-    fn patch_style() {
-        let style = Style::new().yellow().italic();
-        let style2 = Style::new().red().underlined();
-        let text = Text::styled("The first line\nThe second line", style).patch_style(style2);
-
-        let expected_style = Style::new().red().italic().underlined();
-        let expected_text = Text::styled("The first line\nThe second line", expected_style);
-
-        assert_eq!(text, expected_text);
-    }
-
-    #[test]
-    fn reset_style() {
-        let style = Style::new().yellow().italic();
-        let text = Text::styled("The first line\nThe second line", style).reset_style();
-
-        assert_eq!(text.style, Style::reset());
-    }
-
-    #[test]
     fn from_string() {
         let text = Text::from(String::from("The first line\nThe second line"));
         assert_eq!(
@@ -1159,16 +1139,6 @@ mod tests {
     }
 
     #[test]
-    fn stylize() {
-        assert_eq!(Text::default().green().style, Color::Green.into());
-        assert_eq!(
-            Text::default().on_green().style,
-            Style::new().bg(Color::Green)
-        );
-        assert_eq!(Text::default().italic().style, Modifier::ITALIC.into());
-    }
-
-    #[test]
     fn left_aligned() {
         let text = Text::from("Hello, world!").left_aligned();
         assert_eq!(text.alignment, Some(Alignment::Left));
@@ -1230,6 +1200,69 @@ mod tests {
         let mut text = Text::default();
         text.push_span(Span::raw("Hello, world!"));
         assert_eq!(text.lines, [Line::from(Span::raw("Hello, world!"))]);
+    }
+
+    mod style {
+        use super::*;
+
+        #[test]
+        fn style() {
+            let text = Text::default().style(Style::new().red());
+            assert_eq!(text.style, Style::new().red());
+        }
+
+        #[test]
+        fn patch_style() {
+            let style = Style::new().yellow().italic();
+            let style2 = Style::new().red().underlined();
+            let text = Text::styled("The first line\nThe second line", style).patch_style(style2);
+
+            let expected_style = Style::new().red().italic().underlined();
+            let expected_text = Text::styled("The first line\nThe second line", expected_style);
+
+            assert_eq!(text, expected_text);
+        }
+
+        #[test]
+        fn reset_style() {
+            let style = Style::new().yellow().italic();
+            let text = Text::styled("The first line\nThe second line", style).reset_style();
+
+            assert_eq!(text.style, Style::reset());
+        }
+
+        #[test]
+        fn stylize() {
+            assert_eq!(Text::default().green().style, Color::Green.into());
+            assert_eq!(
+                Text::default().on_green().style,
+                Style::new().bg(Color::Green)
+            );
+            assert_eq!(Text::default().italic().style, Modifier::ITALIC.into());
+        }
+
+        #[test]
+        fn render_line_style_overrides_text_style() {
+            let mut buf = Buffer::empty(Rect::new(0, 0, 4, 2));
+            Text::from(Line::from("hi").blue())
+                .red()
+                .on_green()
+                .render(buf.area, &mut buf);
+            let mut expected = Buffer::with_lines(["hi  ", "    "]);
+            expected.set_style(Rect::new(0, 0, 4, 1), Style::new().blue().on_green());
+            expected.set_style(Rect::new(0, 1, 4, 1), Style::new().red().on_green());
+            assert_eq!(buf, expected);
+        }
+
+        #[test]
+        fn render_overrides_prerendered_style() {
+            let mut buf = Buffer::empty(Rect::new(0, 0, 4, 1));
+            buf.set_style(buf.area, Style::new().red().on_green().italic());
+            Text::from("hi").blue().render(buf.area, &mut buf);
+            let mut expected = Buffer::with_lines(["hi  "]);
+            expected.set_style(expected.area, Style::new().blue().on_green().italic());
+            assert_eq!(buf, expected);
+        }
     }
 
     mod widget {

--- a/ratatui-widgets/src/paragraph.rs
+++ b/ratatui-widgets/src/paragraph.rs
@@ -666,40 +666,6 @@ mod tests {
     }
 
     #[test]
-    fn test_render_line_styled() {
-        let l0 = Line::raw("unformatted");
-        let l1 = Line::styled("bold text", Style::new().bold());
-        let l2 = Line::styled("cyan text", Style::new().cyan());
-        let l3 = Line::styled("dim text", Style::new().dim());
-        let paragraph = Paragraph::new(vec![l0, l1, l2, l3]);
-
-        let mut expected =
-            Buffer::with_lines(["unformatted", "bold text", "cyan text", "dim text"]);
-        expected.set_style(Rect::new(0, 1, 9, 1), Style::new().bold());
-        expected.set_style(Rect::new(0, 2, 9, 1), Style::new().cyan());
-        expected.set_style(Rect::new(0, 3, 8, 1), Style::new().dim());
-
-        test_case(&paragraph, &expected);
-    }
-
-    #[test]
-    fn test_render_line_spans_styled() {
-        let l0 = Line::default().spans([
-            Span::styled("bold", Style::new().bold()),
-            Span::raw(" and "),
-            Span::styled("cyan", Style::new().cyan()),
-        ]);
-        let l1 = Line::default().spans([Span::raw("unformatted")]);
-        let paragraph = Paragraph::new(vec![l0, l1]);
-
-        let mut expected = Buffer::with_lines(["bold and cyan", "unformatted"]);
-        expected.set_style(Rect::new(0, 0, 4, 1), Style::new().bold());
-        expected.set_style(Rect::new(9, 0, 4, 1), Style::new().cyan());
-
-        test_case(&paragraph, &expected);
-    }
-
-    #[test]
     fn test_render_paragraph_with_block_with_bottom_title_and_border() {
         let block = Block::new()
             .borders(Borders::BOTTOM)
@@ -936,35 +902,6 @@ mod tests {
         ] {
             test_case(&paragraph, &Buffer::empty(area));
             test_case(&paragraph.clone().scroll((2, 4)), &Buffer::empty(area));
-        }
-    }
-
-    #[test]
-    fn test_render_paragraph_with_styled_text() {
-        let text = Line::from(vec![
-            Span::styled("Hello, ", Style::default().fg(Color::Red)),
-            Span::styled("world!", Style::default().fg(Color::Blue)),
-        ]);
-
-        let mut expected_buffer = Buffer::with_lines(["Hello, world!"]);
-        expected_buffer.set_style(
-            Rect::new(0, 0, 7, 1),
-            Style::default().fg(Color::Red).bg(Color::Green),
-        );
-        expected_buffer.set_style(
-            Rect::new(7, 0, 6, 1),
-            Style::default().fg(Color::Blue).bg(Color::Green),
-        );
-
-        for paragraph in [
-            Paragraph::new(text.clone()),
-            Paragraph::new(text.clone()).wrap(Wrap { trim: false }),
-            Paragraph::new(text.clone()).wrap(Wrap { trim: true }),
-        ] {
-            test_case(
-                &paragraph.style(Style::default().bg(Color::Green)),
-                &expected_buffer,
-            );
         }
     }
 
@@ -1274,27 +1211,6 @@ mod tests {
         assert_eq!(p.alignment, Alignment::Right);
     }
 
-    /// Regression test for <https://github.com/ratatui/ratatui/issues/990>
-    ///
-    /// This test ensures that paragraphs with a block and styled text are rendered correctly.
-    /// It has been simplified from the original issue but tests the same functionality.
-    #[test]
-    fn paragraph_block_text_style() {
-        let text = Text::styled("Styled text", Color::Green);
-        let paragraph = Paragraph::new(text).block(Block::bordered());
-
-        let mut buf = Buffer::empty(Rect::new(0, 0, 20, 3));
-        paragraph.render(Rect::new(0, 0, 20, 3), &mut buf);
-
-        let mut expected = Buffer::with_lines([
-            "┌──────────────────┐",
-            "│Styled text       │",
-            "└──────────────────┘",
-        ]);
-        expected.set_style(Rect::new(1, 1, 11, 1), Style::default().fg(Color::Green));
-        assert_eq!(buf, expected);
-    }
-
     #[rstest]
     #[case::bottom(Rect::new(0, 5, 15, 1))]
     #[case::right(Rect::new(20, 0, 15, 1))]
@@ -1334,5 +1250,145 @@ mod tests {
         let paragraph = Paragraph::new("Lorem ipsum");
         // This should not panic, even if the buffer has zero size.
         paragraph.render(buffer.area, &mut buffer);
+    }
+
+    mod style {
+        use super::*;
+
+        #[test]
+        fn style() {
+            let paragraph = Paragraph::new("").style(Style::new().red());
+            assert_eq!(paragraph.style, Style::new().red());
+        }
+
+        #[test]
+        fn render_overrides_prerendered_style() {
+            let mut buf = Buffer::empty(Rect::new(0, 0, 4, 1));
+            buf.set_style(buf.area, Style::new().red().on_green().italic());
+            Paragraph::new("hi").blue().render(buf.area, &mut buf);
+            let mut expected = Buffer::with_lines(["hi  "]);
+            expected.set_style(expected.area, Style::new().blue().on_green().italic());
+            assert_eq!(buf, expected);
+        }
+
+        #[test]
+        fn render_text_style_overrides_paragraph_style() {
+            let paragraph = Paragraph::new(Text::from("hi").blue()).red().on_green();
+            let mut expected = Buffer::with_lines(["hi  "]);
+            expected.set_style(expected.area, Style::new().red().on_green());
+            expected.set_style(Rect::new(0, 0, 2, 1), Style::new().blue());
+            test_case(&paragraph, &expected);
+        }
+
+        #[test]
+        fn render_line_style_overrides_text_style() {
+            let paragraph = Paragraph::new(Text::from(Line::from("hi").blue()).red().on_green());
+            let mut expected = Buffer::with_lines(["hi  "]);
+            expected.set_style(Rect::new(0, 0, 2, 1), Style::new().blue().on_green());
+            test_case(&paragraph, &expected);
+        }
+
+        #[test]
+        fn render_span_style_overrides_line_style() {
+            let paragraph = Paragraph::new(Line::from(Span::from("hi").blue()).red().on_green());
+            let mut expected = Buffer::with_lines(["hi  "]);
+            expected.set_style(Rect::new(0, 0, 2, 1), Style::new().blue().on_green());
+            test_case(&paragraph, &expected);
+        }
+
+        #[test]
+        fn render_paragraph_style_overrides_block_style_inside_the_block() {
+            let paragraph = Paragraph::new("hi")
+                .block(Block::bordered().on_green())
+                .on_blue();
+            let mut expected = Buffer::with_lines(["┌────┐", "│hi  │", "└────┘"]);
+            expected.set_style(expected.area, Style::new().on_green());
+            expected.set_style(Rect::new(1, 1, 4, 1), Style::new().on_blue());
+            test_case(&paragraph, &expected);
+        }
+
+        #[test]
+        fn render_line_styled() {
+            let l0 = Line::raw("unformatted");
+            let l1 = Line::styled("bold text", Style::new().bold());
+            let l2 = Line::styled("cyan text", Style::new().cyan());
+            let l3 = Line::styled("dim text", Style::new().dim());
+            let paragraph = Paragraph::new(vec![l0, l1, l2, l3]);
+
+            let mut expected =
+                Buffer::with_lines(["unformatted", "bold text", "cyan text", "dim text"]);
+            expected.set_style(Rect::new(0, 1, 9, 1), Style::new().bold());
+            expected.set_style(Rect::new(0, 2, 9, 1), Style::new().cyan());
+            expected.set_style(Rect::new(0, 3, 8, 1), Style::new().dim());
+
+            test_case(&paragraph, &expected);
+        }
+
+        #[test]
+        fn render_line_spans_styled() {
+            let l0 = Line::default().spans([
+                Span::styled("bold", Style::new().bold()),
+                Span::raw(" and "),
+                Span::styled("cyan", Style::new().cyan()),
+            ]);
+            let l1 = Line::default().spans([Span::raw("unformatted")]);
+            let paragraph = Paragraph::new(vec![l0, l1]);
+
+            let mut expected = Buffer::with_lines(["bold and cyan", "unformatted"]);
+            expected.set_style(Rect::new(0, 0, 4, 1), Style::new().bold());
+            expected.set_style(Rect::new(9, 0, 4, 1), Style::new().cyan());
+
+            test_case(&paragraph, &expected);
+        }
+
+        #[test]
+        fn render_with_styled_text() {
+            let text = Line::from(vec![
+                Span::styled("Hello, ", Style::default().fg(Color::Red)),
+                Span::styled("world!", Style::default().fg(Color::Blue)),
+            ]);
+
+            let mut expected_buffer = Buffer::with_lines(["Hello, world!"]);
+            expected_buffer.set_style(
+                Rect::new(0, 0, 7, 1),
+                Style::default().fg(Color::Red).bg(Color::Green),
+            );
+            expected_buffer.set_style(
+                Rect::new(7, 0, 6, 1),
+                Style::default().fg(Color::Blue).bg(Color::Green),
+            );
+
+            for paragraph in [
+                Paragraph::new(text.clone()),
+                Paragraph::new(text.clone()).wrap(Wrap { trim: false }),
+                Paragraph::new(text.clone()).wrap(Wrap { trim: true }),
+            ] {
+                test_case(
+                    &paragraph.style(Style::default().bg(Color::Green)),
+                    &expected_buffer,
+                );
+            }
+        }
+
+        /// Regression test for <https://github.com/ratatui/ratatui/issues/990>
+        ///
+        /// This test ensures that paragraphs with a block and styled text are rendered correctly.
+        /// It has been simplified from the original issue but tests the same functionality.
+        #[test]
+        fn block_text_style() {
+            let text = Text::styled("Styled text", Color::Green);
+            let paragraph = Paragraph::new(text).block(Block::bordered());
+
+            let mut buf = Buffer::empty(Rect::new(0, 0, 20, 3));
+            paragraph.render(Rect::new(0, 0, 20, 3), &mut buf);
+
+            let mut expected = Buffer::with_lines([
+                "┌──────────────────┐",
+                "│Styled text       │",
+                "└──────────────────┘",
+            ]);
+            expected.set_style(Rect::new(1, 1, 11, 1), Style::default().fg(Color::Green));
+            assert_eq!(buf, expected);
+        }
     }
 }


### PR DESCRIPTION
Part of #1015: the second checkbox (per-type `style` test modules). Follow-up to #2693, which covered the integration test and the docs.

Groups each type's style-related unit tests into a `style` submodule of its `tests` module, and adds the missing per-type precedence tests.

**What moved (bodies unchanged):**
- `Span`: `set_style` (renamed `style` to match `Line`), `reset_style`, `patch_style`, `stylize`
- `Line`: `style`, `patch_style`, `reset_style`, `stylize`
- `Text`: `patch_style`, `reset_style`, `stylize`
- `Paragraph`: `test_render_line_styled`, `test_render_line_spans_styled`, `test_render_paragraph_with_styled_text`, `paragraph_block_text_style` (renamed to drop the `test_`/`paragraph_` prefixes now that they sit under `paragraph::tests::style`)

**What's new:** each type renders itself directly (not via `Paragraph`) and pins how its style combines with a pre-rendered buffer style and with its children's styles. Lower layer sets `red().on_green()`, upper layer sets `blue()`, expected is `blue().on_green()`, so a dropped or misordered layer fails.
- `Span`: prerendered -> span
- `Line`: prerendered -> line; line -> span
- `Text`: `style()` setter; prerendered -> text; text -> line
- `Paragraph`: `style()` setter; prerendered -> paragraph; paragraph -> text; text -> line and line -> span through the paragraph's grapheme path (which, unlike `Text::render`/`Line::render`, styles only the glyph cells); block -> paragraph inside the block

**Deliberately not pinned here:** whether `Paragraph::style` should reach the block's border cells (item 4 in the issue). The bg-only block test does not depend on it either way; `all_styles_combine` in `tests/text_style.rs` (#2693) already characterizes the current behavior, so this can change in one place if maintainers decide it should.

`Block`'s own tests are untouched for the same reason.

Claude Code helped write this PR.
