### PR TITLE
fix(layout): preserve single item constraints with SpaceBetween

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -10,6 +10,8 @@ GitHub with a [breaking change] label.
 
 This is a quick summary of the sections below:
 
+- [v0.31.0](#v0310)
+  - `Flex::SpaceBetween` with a single item now preserves fixed-size constraints
 - [v0.30.1](#v0301)
   - Adding `AsRef` impls for widgets may affect type inference in rare cases
   - MSRV is now 1.88.0
@@ -96,6 +98,18 @@ This is a quick summary of the sections below:
 - [v0.20.0](#v0200)
   - MSRV is now 1.63.0
   - `List` no longer ignores empty strings
+
+## v0.31.0 (unreleased)
+
+### `Flex::SpaceBetween` with a single item now preserves fixed-size constraints
+
+Previously, `Flex::SpaceBetween` stretched a single layout item to fill the full area, even when the
+item used a fixed-size constraint such as `Length`, `Max`, `Percentage`, or `Ratio`. A single item
+now falls back to start alignment because there is no space to distribute between items.
+
+`Min` and `Fill` constraints still grow to fill the available area. If you relied on the previous
+single-item stretching behavior with a fixed-size constraint, use `Flex::Legacy` or switch the item
+to a growing constraint such as `Fill` or `Min`.
 
 ## [v0.30.1](https://github.com/ratatui/ratatui/releases/tag/ratatui-v0.30.1)
 

--- a/examples/apps/constraint-explorer/README.md
+++ b/examples/apps/constraint-explorer/README.md
@@ -5,7 +5,8 @@ different constraint types and values, add or remove layout blocks, change the s
 (including overlap), and compare how the `Flex` modes distribute the available space.
 
 Use the arrow keys to select and edit a block, `1`–`6` to change its constraint type, `a` and `x`
-to add or remove blocks, and `+` and `-` to change spacing. Press `q` or `Esc` to quit.
+to add or remove blocks, `s` to load a single `Length` block, and `+` and `-` to change spacing.
+Press `q` or `Esc` to quit.
 
 ![Constraint Explorer demo][constraint-explorer.gif]
 

--- a/examples/apps/constraint-explorer/src/main.rs
+++ b/examples/apps/constraint-explorer/src/main.rs
@@ -119,6 +119,7 @@ impl App {
                 KeyCode::Char('-') => self.decrement_spacing(),
                 KeyCode::Char('x') => self.delete_block(),
                 KeyCode::Char('a') => self.insert_block(),
+                KeyCode::Char('s') => self.load_single_length_example(),
                 KeyCode::Char('k') | KeyCode::Up => self.increment_value(),
                 KeyCode::Char('j') | KeyCode::Down => self.decrement_value(),
                 KeyCode::Char('h') | KeyCode::Left => self.prev_block(),
@@ -193,6 +194,11 @@ impl App {
         let constraint = Constraint::Length(self.value);
         self.constraints.insert(index, constraint);
         self.selected_index = index;
+    }
+
+    fn load_single_length_example(&mut self) {
+        self.constraints = vec![Constraint::Length(self.value)];
+        self.selected_index = 0;
     }
 
     const fn increment_spacing(&mut self) {
@@ -271,8 +277,7 @@ impl App {
     }
 
     fn instructions() -> impl Widget {
-        let text =
-            "◄ ►: select, ▲ ▼: edit, 1-6: swap, a: add, x: delete, q/Esc: quit, +/-: spacing";
+        let text = "◄ ►: select, ▲ ▼: edit, 1-6: swap, a: add, s: single, x: delete, q/Esc: quit, +/-: spacing";
         Paragraph::new(text)
             .fg(Self::TEXT_COLOR)
             .centered()

--- a/ratatui-core/src/layout/flex.rs
+++ b/ratatui-core/src/layout/flex.rs
@@ -149,6 +149,9 @@ pub enum Flex {
 
     /// Adds excess space between each element.
     ///
+    /// With a single element, there is no space between elements, so the element is aligned to the
+    /// start unless its constraint grows to fill the available space.
+    ///
     /// # Examples
     ///
     /// ```plain
@@ -163,9 +166,9 @@ pub enum Flex {
     /// └──────────────────┘                                        └──────────────────┘
     ///
     /// <------------------------------------80 px------------------------------------->
-    /// ┌────────────────────────────────────80 px─────────────────────────────────────┐
-    /// │                                    Max(20)                                   │
-    /// └──────────────────────────────────────────────────────────────────────────────┘
+    /// ┌──────20 px───────┐
+    /// │      Max(20)     │
+    /// └──────────────────┘
     /// ```
     SpaceBetween,
 

--- a/ratatui-core/src/layout/layout.rs
+++ b/ratatui-core/src/layout/layout.rs
@@ -1059,7 +1059,8 @@ fn configure_flex_constraints(
 
         // All spacers excluding first and last are the same size and will grow to fill
         // any remaining space after the constraints are satisfied.
-        // The first and last spacers are zero size.
+        // The first and last spacers are zero size, except for a single segment where the last
+        // spacer grows so the segment falls back to start alignment.
         Flex::SpaceBetween => {
             for [left, right] in spacers_except_first_and_last.iter().array_combinations() {
                 solver.add_constraint(left.has_size(right.size(), SPACER_SIZE_EQ))?;
@@ -1070,7 +1071,11 @@ fn configure_flex_constraints(
             }
             if let (Some(first), Some(last)) = (spacers.first(), spacers.last()) {
                 solver.add_constraint(first.is_empty())?;
-                solver.add_constraint(last.is_empty())?;
+                if spacers.len() == 2 {
+                    solver.add_constraint(last.has_size(area, GROW))?;
+                } else {
+                    solver.add_constraint(last.is_empty())?;
+                }
             }
         }
 
@@ -2495,9 +2500,12 @@ mod tests {
         #[case::max_start(vec![Max(50)], vec![0..50], Flex::Start)]
         #[case::max_end(vec![Max(50)], vec![50..100], Flex::End)]
         #[case::max_center(vec![Max(50)], vec![25..75], Flex::Center)]
-        #[case::spacebetween_becomes_stretch1(vec![Min(1)], vec![0..100], Flex::SpaceBetween)]
-        #[case::spacebetween_becomes_stretch2(vec![Max(20)], vec![0..100], Flex::SpaceBetween)]
-        #[case::spacebetween_becomes_stretch3(vec![Length(20)], vec![0..100], Flex::SpaceBetween)]
+        #[case::spacebetween_single_min(vec![Min(1)], vec![0..100], Flex::SpaceBetween)]
+        #[case::spacebetween_single_fill(vec![Fill(1)], vec![0..100], Flex::SpaceBetween)]
+        #[case::spacebetween_single_max(vec![Max(20)], vec![0..20], Flex::SpaceBetween)]
+        #[case::spacebetween_single_length(vec![Length(20)], vec![0..20], Flex::SpaceBetween)]
+        #[case::spacebetween_single_percentage(vec![Percentage(20)], vec![0..20], Flex::SpaceBetween)]
+        #[case::spacebetween_single_ratio(vec![Ratio(1, 5)], vec![0..20], Flex::SpaceBetween)]
         #[case::length_legacy2(vec![Length(25), Length(25)], vec![0..25, 25..100], Flex::Legacy)]
         #[case::length_start2(vec![Length(25), Length(25)], vec![0..25, 25..50], Flex::Start)]
         #[case::length_center2(vec![Length(25), Length(25)], vec![25..50, 50..75], Flex::Center)]
@@ -2531,7 +2539,7 @@ mod tests {
         #[case::one_segment_start(vec![Length(50)], vec![0..50], Flex::Start)]
         #[case::one_segment_end(vec![Length(50)], vec![50..100], Flex::End)]
         #[case::one_segment_center(vec![Length(50)], vec![25..75], Flex::Center)]
-        #[case::one_segment_spacebetween(vec![Length(50)], vec![0..100], Flex::SpaceBetween)]
+        #[case::one_segment_spacebetween(vec![Length(50)], vec![0..50], Flex::SpaceBetween)]
         #[case::one_segment_spaceevenly(vec![Length(50)], vec![25..75], Flex::SpaceEvenly)]
         #[case::one_segment_spacearound(vec![Length(50)], vec![25..75], Flex::SpaceAround)]
         fn flex_constraint(


### PR DESCRIPTION
Fixes https://github.com/ratatui/ratatui/issues/2710
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
 ## Summary

  Fixes single-item `Flex::SpaceBetween` layouts so fixed-size constraints are preserved instead of stretching to the full area.

  When there is only one item, there is no space to distribute between items, so `SpaceBetween` now falls back to start alignment
  unless the item uses a growing constraint like `Min` or `Fill`.

  ## Changes

  - Preserve single-item `Length`, `Max`, `Percentage`, and `Ratio` constraints with `Flex::SpaceBetween`
  - Keep `Min` and `Fill` expanding to fill available space
  - Update `Flex::SpaceBetween` docs and breaking-changes notes
  - Add a constraint explorer shortcut (`s`) for a single `Length` item example
  
  ## AI Assistance

 I used Codex while working through the layout code and test updates. I reviewed the final code before submitting.

https://github.com/user-attachments/assets/1c0c24f1-c747-4d5b-8db8-1c172a76ca93

