### PR TITLE
fix(backend): account for symbol width when skipping cursor moves

### DIFF
--- a/ratatui-crossterm/src/lib.rs
+++ b/ratatui-crossterm/src/lib.rs
@@ -797,6 +797,47 @@ mod tests {
 
     use super::*;
 
+    /// Renders `content` and returns the emitted bytes as a lossy string.
+    fn draw_to_string(content: &[(u16, u16, &Cell)]) -> String {
+        let mut out = Vec::new();
+        CrosstermBackend::new(&mut out)
+            .draw(content.iter().copied())
+            .unwrap();
+        String::from_utf8_lossy(&out).into_owned()
+    }
+
+    #[test]
+    fn draw_moves_cursor_after_wide_symbol() {
+        // A double-width glyph advances the terminal cursor by two columns, so writing the
+        // very next cell requires an explicit cursor move. See issue #2651.
+        let wide = Cell::new("\u{2764}\u{FE0F}"); // ❤️ (VS16 emoji presentation)
+        let next = Cell::new("a");
+        let output = draw_to_string(&[(0, 0, &wide), (1, 0, &next)]);
+        let move_to = MoveTo(1, 0).to_string();
+        assert!(
+            output.contains(&move_to),
+            "expected `MoveTo(1, 0)` after a wide glyph, got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn draw_skips_cursor_move_for_contiguous_cells() {
+        let a = Cell::new("a");
+        let b = Cell::new("b");
+        let output = draw_to_string(&[(0, 0, &a), (1, 0, &b)]);
+        assert_eq!(output.matches(&MoveTo(0, 0).to_string()).count(), 1);
+        assert!(!output.contains(&MoveTo(1, 0).to_string()));
+    }
+
+    #[test]
+    fn draw_skips_cursor_move_after_wide_symbol_when_contiguous() {
+        // The cell right after a wide glyph's trailing column is where the cursor already is.
+        let wide = Cell::new("\u{1F600}"); // 😀
+        let next = Cell::new("a");
+        let output = draw_to_string(&[(0, 0, &wide), (2, 0, &next)]);
+        assert!(!output.contains(&MoveTo(2, 0).to_string()));
+    }
+
     #[rstest]
     #[case(CrosstermColor::Reset, Color::Reset)]
     #[case(CrosstermColor::Black, Color::Black)]

--- a/ratatui-crossterm/src/lib.rs
+++ b/ratatui-crossterm/src/lib.rs
@@ -795,6 +795,10 @@ impl crate::crossterm::Command for ScrollDownInRegion {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU16;
+
+    use ratatui_core::buffer::{Buffer, CellDiffOption};
+    use ratatui_core::layout::Rect;
     use rstest::rstest;
 
     use super::*;
@@ -829,6 +833,40 @@ mod tests {
         let output = draw_to_string(&[(0, 0, &a), (1, 0, &b)]);
         assert_eq!(output.matches(&MoveTo(0, 0).to_string()).count(), 1);
         assert!(!output.contains(&MoveTo(1, 0).to_string()));
+    }
+
+    #[test]
+    fn draw_uses_forced_width_for_cursor_tracking() {
+        // A cell with an escape sequence has an arbitrary text width; the forced width tells
+        // us how far the terminal cursor actually advances.
+        let mut forced = Cell::new("\u{1b}[?25hab");
+        forced.set_diff_option(CellDiffOption::ForcedWidth(NonZeroU16::new(2).unwrap()));
+        let next = Cell::new("c");
+        let output = draw_to_string(&[(0, 0, &forced), (2, 0, &next)]);
+        assert!(!output.contains(&MoveTo(2, 0).to_string()));
+        let output = draw_to_string(&[(0, 0, &forced), (1, 0, &next)]);
+        assert!(output.contains(&MoveTo(1, 0).to_string()));
+    }
+
+    #[test]
+    fn draw_moves_cursor_after_wide_symbol_from_buffer_diff() {
+        // End-to-end version of the report in #2651: the diff emits the trailing cell of a
+        // VS16 emoji sequence on purpose, and the backend must reposition before writing it.
+        let area = Rect::new(0, 0, 4, 1);
+        let mut prev = Buffer::empty(area);
+        prev.set_string(0, 0, "aaaa", Style::default());
+        let mut next = Buffer::empty(area);
+        next.set_string(0, 0, "\u{2764}\u{FE0F}bc", Style::default());
+
+        let updates: Vec<_> = prev.diff(&next).into_iter().collect();
+        assert_eq!(
+            updates.iter().map(|(x, _, _)| *x).collect::<Vec<_>>(),
+            [0, 1, 2, 3]
+        );
+        let output = draw_to_string(&updates);
+        assert!(output.contains(&MoveTo(1, 0).to_string()));
+        assert!(!output.contains(&MoveTo(2, 0).to_string()));
+        assert!(!output.contains(&MoveTo(3, 0).to_string()));
     }
 
     #[test]

--- a/ratatui-crossterm/src/lib.rs
+++ b/ratatui-crossterm/src/lib.rs
@@ -97,7 +97,7 @@ cfg_if::cfg_if! {
     }
 }
 use ratatui_core::backend::{Backend, ClearType, WindowSize};
-use ratatui_core::buffer::Cell;
+use ratatui_core::buffer::{Cell, CellWidth};
 use ratatui_core::layout::{Position, Size};
 use ratatui_core::style::{Color, Modifier, Style};
 
@@ -238,13 +238,15 @@ where
         #[cfg(feature = "underline-color")]
         let mut underline_color = Color::Reset;
         let mut modifier = Modifier::empty();
-        let mut last_pos: Option<Position> = None;
+        // Position and width of the last cell written, used to skip redundant cursor moves.
+        let mut last: Option<(Position, u16)> = None;
         for (x, y, cell) in content {
-            // Move the cursor if the previous location was not (x - 1, y)
-            if !matches!(last_pos, Some(p) if x == p.x + 1 && y == p.y) {
+            // Move the cursor unless it already sits at (x, y), i.e. this cell directly follows
+            // the previous one on the same row, accounting for the width of what was printed.
+            if !matches!(last, Some((p, w)) if x == p.x + w && y == p.y) {
                 queue!(self.writer, MoveTo(x, y))?;
             }
-            last_pos = Some(Position { x, y });
+            last = Some((Position { x, y }, cell.cell_width()));
             if cell.modifier != modifier {
                 let diff = ModifierDiff {
                     from: modifier,

--- a/ratatui-termina/src/lib.rs
+++ b/ratatui-termina/src/lib.rs
@@ -785,6 +785,20 @@ mod tests {
     }
 
     #[test]
+    fn skips_cursor_move_after_wide_symbol_when_contiguous() {
+        let mut backend = backend();
+        let wide = Cell::new("\u{1F600}"); // 😀
+        let next = Cell::new("a");
+        let content = [(0, 0, &wide), (2, 0, &next)];
+
+        backend.draw(content.into_iter()).unwrap();
+
+        let output = backend.terminal.output();
+        let cursor = Csi::Cursor(cursor_position(Position::new(2, 0)).unwrap());
+        assert!(!output.contains(&cursor.to_string()));
+    }
+
+    #[test]
     fn converts_ratatui_colors_to_termina_colors() {
         assert_eq!(Color::Reset.into_termina(), ColorSpec::Reset);
         assert_eq!(Color::Red.into_termina(), ColorSpec::RED);

--- a/ratatui-termina/src/lib.rs
+++ b/ratatui-termina/src/lib.rs
@@ -725,6 +725,39 @@ mod tests {
     }
 
     #[test]
+    fn draws_cursor_move_after_wide_symbol() {
+        // A double-width glyph advances the terminal cursor by two columns, so writing the
+        // very next cell requires an explicit cursor move. See issue #2651.
+        let mut backend = backend();
+        let wide = Cell::new("\u{2764}\u{FE0F}"); // ❤️ (VS16 emoji presentation)
+        let next = Cell::new("a");
+        let content = [(0, 0, &wide), (1, 0, &next)];
+
+        backend.draw(content.into_iter()).unwrap();
+
+        let output = backend.terminal.output();
+        let cursor = Csi::Cursor(cursor_position(Position::new(1, 0)).unwrap());
+        assert!(
+            output.contains(&cursor.to_string()),
+            "expected a cursor move to (1, 0) after a wide glyph, got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn skips_cursor_move_for_contiguous_cells() {
+        let mut backend = backend();
+        let a = Cell::new("a");
+        let b = Cell::new("b");
+        let content = [(0, 0, &a), (1, 0, &b)];
+
+        backend.draw(content.into_iter()).unwrap();
+
+        let output = backend.terminal.output();
+        let cursor = Csi::Cursor(cursor_position(Position::new(1, 0)).unwrap());
+        assert!(!output.contains(&cursor.to_string()));
+    }
+
+    #[test]
     fn converts_ratatui_colors_to_termina_colors() {
         assert_eq!(Color::Reset.into_termina(), ColorSpec::Reset);
         assert_eq!(Color::Red.into_termina(), ColorSpec::RED);

--- a/ratatui-termina/src/lib.rs
+++ b/ratatui-termina/src/lib.rs
@@ -27,7 +27,7 @@ use std::fmt::{self, Write as FmtWrite};
 use std::io::{self, Write};
 
 use ratatui_core::backend::{Backend, ClearType, WindowSize};
-use ratatui_core::buffer::Cell;
+use ratatui_core::buffer::{Cell, CellWidth};
 use ratatui_core::layout::{Position, Size};
 use ratatui_core::style::{Color, Modifier, Style};
 pub use termina;
@@ -146,13 +146,16 @@ where
         #[cfg(feature = "underline-color")]
         let mut underline_color = Color::Reset;
         let mut modifier = Modifier::empty();
-        let mut last_pos: Option<Position> = None;
+        // Position and width of the last cell written, used to skip redundant cursor moves.
+        let mut last: Option<(Position, u16)> = None;
         for (x, y, cell) in content {
-            if !matches!(last_pos, Some(p) if x == p.x + 1 && y == p.y) {
+            // Move the cursor unless it already sits at (x, y), i.e. this cell directly follows
+            // the previous one on the same row, accounting for the width of what was printed.
+            if !matches!(last, Some((p, w)) if x == p.x + w && y == p.y) {
                 let command = Csi::Cursor(cursor_position(Position { x, y })?);
                 write!(string, "{command}").unwrap();
             }
-            last_pos = Some(Position { x, y });
+            last = Some((Position { x, y }, cell.cell_width()));
 
             let mut attributes = SgrAttributes::default();
             if cell.fg != fg {

--- a/ratatui-termion/src/lib.rs
+++ b/ratatui-termion/src/lib.rs
@@ -611,6 +611,14 @@ mod tests {
     }
 
     #[test]
+    fn draw_skips_cursor_move_after_wide_symbol_when_contiguous() {
+        let wide = Cell::new("\u{1F600}"); // 😀
+        let next = Cell::new("a");
+        let output = draw_to_string(&[(0, 0, &wide), (2, 0, &next)]);
+        assert!(!output.contains(&termion::cursor::Goto(3, 1).to_string()));
+    }
+
+    #[test]
     fn save_and_restore_cursor_position_write_escape_sequences() {
         let mut backend = TermionBackend::new(Vec::new());
 

--- a/ratatui-termion/src/lib.rs
+++ b/ratatui-termion/src/lib.rs
@@ -566,6 +566,37 @@ impl fmt::Display for ResetRegion {
 mod tests {
     use super::*;
 
+    /// Renders `content` and returns the emitted bytes as a lossy string.
+    fn draw_to_string(content: &[(u16, u16, &Cell)]) -> String {
+        let mut out = Vec::new();
+        TermionBackend::new(&mut out)
+            .draw(content.iter().copied())
+            .unwrap();
+        String::from_utf8_lossy(&out).into_owned()
+    }
+
+    #[test]
+    fn draw_moves_cursor_after_wide_symbol() {
+        // A double-width glyph advances the terminal cursor by two columns, so writing the
+        // very next cell requires an explicit cursor move. See issue #2651.
+        let wide = Cell::new("\u{2764}\u{FE0F}"); // ❤️ (VS16 emoji presentation)
+        let next = Cell::new("a");
+        let output = draw_to_string(&[(0, 0, &wide), (1, 0, &next)]);
+        let goto = termion::cursor::Goto(2, 1).to_string();
+        assert!(
+            output.contains(&goto),
+            "expected `Goto(2, 1)` after a wide glyph, got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn draw_skips_cursor_move_for_contiguous_cells() {
+        let a = Cell::new("a");
+        let b = Cell::new("b");
+        let output = draw_to_string(&[(0, 0, &a), (1, 0, &b)]);
+        assert!(!output.contains(&termion::cursor::Goto(2, 1).to_string()));
+    }
+
     #[test]
     fn from_termion_color() {
         assert_eq!(Color::from_termion(tcolor::Reset), Color::Reset);

--- a/ratatui-termion/src/lib.rs
+++ b/ratatui-termion/src/lib.rs
@@ -41,7 +41,7 @@ use std::fmt;
 use std::io::{self, Write};
 
 use ratatui_core::backend::{Backend, ClearType, WindowSize};
-use ratatui_core::buffer::Cell;
+use ratatui_core::buffer::{Cell, CellWidth};
 use ratatui_core::layout::{Position, Size};
 use ratatui_core::style::{Color, Modifier, Style};
 pub use termion;
@@ -218,13 +218,15 @@ where
         let mut fg = Color::Reset;
         let mut bg = Color::Reset;
         let mut modifier = Modifier::empty();
-        let mut last_pos: Option<Position> = None;
+        // Position and width of the last cell written, used to skip redundant cursor moves.
+        let mut last: Option<(Position, u16)> = None;
         for (x, y, cell) in content {
-            // Move the cursor if the previous location was not (x - 1, y)
-            if !matches!(last_pos, Some(p) if x == p.x + 1 && y == p.y) {
+            // Move the cursor unless it already sits at (x, y), i.e. this cell directly follows
+            // the previous one on the same row, accounting for the width of what was printed.
+            if !matches!(last, Some((p, w)) if x == p.x + w && y == p.y) {
                 write!(string, "{}", termion::cursor::Goto(x + 1, y + 1)).unwrap();
             }
-            last_pos = Some(Position { x, y });
+            last = Some((Position { x, y }, cell.cell_width()));
             if cell.modifier != modifier {
                 write!(
                     string,


### PR DESCRIPTION
Fixes #2651

## Problem

The crossterm, termion and termina backends skip the cursor-move command when the current cell is at `(last.x + 1, last.y)`. That assumes every symbol advances the terminal cursor by exactly one column. After a double-width grapheme the cursor is two columns further along, so a write to the very next cell lands one column to the right and the rest of the row is shifted.

Normally `Buffer::diff` skips the trailing cell of a wide glyph and the coordinate check happens to force a move, which masks this. But the diff deliberately emits the trailing cell for VS16 emoji sequences (`❤️`, `🚀️`, …) as a workaround for terminals that don't clear it, and on that path no move is emitted at all — see the byte capture in the issue.

## Fix

Track `(position, width)` of the last cell written and only skip the move when `x == last.x + width`. Width comes from `CellWidth::cell_width`, which also honours `CellDiffOption::ForcedWidth`, so cells carrying escape sequences are handled the same way. Applied identically to all three backends that use this pattern.

## Testing

- New unit tests per backend: a wide glyph followed by `x + 1` now gets a cursor move; contiguous single-width cells and `x + 2` after a wide glyph still don't.
- crossterm additionally covers `ForcedWidth` and an end-to-end `Buffer::diff` → `draw` case reproducing the report (`aaaa` → `❤️bc`, trailing cell emitted at `x = 1`).
- `cargo clippy --all-features --all-targets` and `cargo test --all-features` for the three crates are clean.
