### PR TITLE
fix(canvas): ignore non-finite coordinates

### DIFF
--- a/ratatui-widgets/src/canvas.rs
+++ b/ratatui-widgets/src/canvas.rs
@@ -420,7 +420,7 @@ impl Painter<'_, '_> {
     /// `(x, y)` coordinates to the location of a point on the grid.
     ///
     /// Points are rounded to the nearest grid cell (with points exactly in the center of a cell
-    /// rounding up).
+    /// rounding up). Points outside the bounds or with non-finite coordinates return `None`.
     ///
     /// # Examples
     ///
@@ -449,7 +449,7 @@ impl Painter<'_, '_> {
     pub fn get_point(&self, x: f64, y: f64) -> Option<(usize, usize)> {
         let [left, right] = self.context.x_bounds;
         let [bottom, top] = self.context.y_bounds;
-        if x < left || x > right || y < bottom || y > top {
+        if !x.is_finite() || !y.is_finite() || x < left || x > right || y < bottom || y > top {
             return None;
         }
         let width = right - left;

--- a/ratatui-widgets/src/canvas.rs
+++ b/ratatui-widgets/src/canvas.rs
@@ -1218,4 +1218,15 @@ mod tests {
         // This should not panic, even if the buffer has zero size.
         canvas.render(buffer.area, &mut buffer);
     }
+
+    #[rstest]
+    #[case::nan_x(f64::NAN, 5.0)]
+    #[case::nan_y(5.0, f64::NAN)]
+    #[case::inf_x(f64::INFINITY, 5.0)]
+    #[case::neg_inf_y(5.0, f64::NEG_INFINITY)]
+    fn get_point_rejects_non_finite_coordinates(#[case] x: f64, #[case] y: f64) {
+        let mut ctx = Context::new(2, 2, [0.0, 10.0], [0.0, 10.0], Marker::Dot);
+        let painter = Painter::from(&mut ctx);
+        assert_eq!(painter.get_point(x, y), None);
+    }
 }

--- a/ratatui-widgets/src/canvas/line.rs
+++ b/ratatui-widgets/src/canvas/line.rs
@@ -46,6 +46,12 @@ impl Line {
 impl Shape for Line {
     #[expect(clippy::similar_names)]
     fn draw(&self, painter: &mut Painter) {
+        if [self.x1, self.y1, self.x2, self.y2]
+            .iter()
+            .any(|coordinate| !coordinate.is_finite())
+        {
+            return;
+        }
         let (x_bounds, y_bounds) = painter.bounds();
         let Some((world_x1, world_y1, world_x2, world_y2)) =
             clip_line(x_bounds, y_bounds, self.x1, self.y1, self.x2, self.y2)

--- a/ratatui-widgets/src/canvas/line.rs
+++ b/ratatui-widgets/src/canvas/line.rs
@@ -600,4 +600,21 @@ mod tests {
         }
         assert_eq!(buffer, expected);
     }
+
+    #[rstest]
+    #[case::nan_x(f64::NAN, 5.0)]
+    #[case::nan_y(5.0, f64::NAN)]
+    #[case::inf_x(f64::INFINITY, 5.0)]
+    #[case::neg_inf_y(5.0, f64::NEG_INFINITY)]
+    fn non_finite_endpoint_draws_nothing(#[case] x2: f64, #[case] y2: f64) {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 10));
+        let canvas = Canvas::default()
+            .marker(Marker::Dot)
+            .x_bounds([0.0, 10.0])
+            .y_bounds([10.0, 0.0])
+            .paint(|context| context.draw(&Line::new(0.0, 0.0, x2, y2, Color::Red)));
+        canvas.render(buffer.area, &mut buffer);
+
+        assert_eq!(buffer, Buffer::with_lines(["          "; 10]));
+    }
 }

--- a/ratatui-widgets/src/chart.rs
+++ b/ratatui-widgets/src/chart.rs
@@ -1596,6 +1596,19 @@ mod tests {
     }
 
     #[rstest]
+    #[case::line(GraphType::Line)]
+    #[case::bar(GraphType::Bar)]
+    fn nan_data_point_with_reversed_bounds(#[case] graph_type: GraphType) {
+        let data = [(0.0, 0.0), (1.0, f64::NAN)];
+        let chart = Chart::new(vec![Dataset::default().data(&data).graph_type(graph_type)])
+            .x_axis(Axis::default().bounds([0.0, 1.0]))
+            .y_axis(Axis::default().bounds([1.0, 0.0]));
+        let area = Rect::new(0, 0, 3, 3);
+        let mut buffer = Buffer::empty(area);
+        chart.render(area, &mut buffer);
+    }
+
+    #[rstest]
     #[case::dot(symbols::Marker::Dot, '•')]
     #[case::dot(symbols::Marker::Braille, '⢣')]
     fn overlapping_lines(#[case] marker: symbols::Marker, #[case] symbol: char) {


### PR DESCRIPTION
## Problem

Two related issues with NaN / infinite coordinates in the canvas, found by fuzzing widget rendering with non-finite inputs (no existing issue):

1. **Hang.** `Chart` (and `canvas::Line` directly) loops forever when a line endpoint is `NaN` and the axis bounds are reversed, e.g. `Dataset::data(&[(0.0, 0.0), (1.0, f64::NAN)])` with `y_axis(Axis::default().bounds([1.0, 0.0]))`. Both `GraphType::Line` and `GraphType::Bar` are affected. The Cohen-Sutherland clipper never converges: the NaN endpoint gets region 0 (every comparison is false), the finite endpoint is clipped to an intersection with a NaN coordinate, and that point then alternates between the top/bottom regions on every iteration.
2. **Stray dots.** `Painter::get_point` lets NaN through its bounds check (all comparisons false) and `NaN.round() as usize` is `0`, so `Points` / scatter charts / any shape with a NaN coordinate paint a dot on the grid edge.

## Fix

- `Line::draw` returns early when any coordinate is non-finite, keeping NaN/inf out of the clipper.
- `Painter::get_point` returns `None` for non-finite coordinates (doc updated).

## Testing

- `canvas::line` test that would hang before the fix (NaN/inf endpoints with reversed y bounds) and asserts nothing is drawn.
- `chart` test rendering a NaN data point with reversed bounds for `Line` and `Bar` graph types.
- `canvas` test asserting `get_point` rejects NaN/inf.
- `cargo test -p ratatui-widgets --all-features` and clippy are clean.
