### PR TITLE
fix(terminal): make insert_before a no-op when the terminal has no rows

### DIFF
--- a/ratatui-core/src/terminal/inline.rs
+++ b/ratatui-core/src/terminal/inline.rs
@@ -66,6 +66,8 @@ impl<B: Backend> Terminal<B> {
     /// directly into the terminal's scrollback buffer. At the limit, if the viewport takes up the
     /// whole screen, all lines will be inserted directly into the scrollback buffer.
     ///
+    /// This is a no-op for non-inline viewports and when the terminal has no rows.
+    ///
     /// # Examples
     ///
     /// ## Insert a single line before the current viewport
@@ -111,6 +113,7 @@ impl<B: Backend> Terminal<B> {
         F: FnOnce(&mut Buffer),
     {
         match self.viewport {
+            Viewport::Inline(_) if self.last_known_area.height == 0 => Ok(()),
             #[cfg(feature = "scrolling-regions")]
             Viewport::Inline(_) => self.insert_before_scrolling_regions(height, draw_fn),
             #[cfg(not(feature = "scrolling-regions"))]

--- a/ratatui-core/src/terminal/inline.rs
+++ b/ratatui-core/src/terminal/inline.rs
@@ -484,6 +484,22 @@ mod tests {
         assert_eq!(area, Rect::new(0, 0, 10, 4));
     }
 
+    #[test]
+    fn insert_before_is_noop_when_terminal_has_no_rows() {
+        let backend = TestBackend::new(5, 0);
+        let options = TerminalOptions {
+            viewport: Viewport::Inline(3),
+        };
+        let mut terminal = Terminal::with_options(backend, options).unwrap();
+        let scrollback = terminal.backend().scrollback().clone();
+
+        terminal
+            .insert_before(2, |buf| buf.set_string(0, 0, "aaaaa", Style::default()))
+            .unwrap();
+
+        assert_eq!(terminal.backend().scrollback(), &scrollback);
+    }
+
     #[cfg(not(feature = "scrolling-regions"))]
     mod no_scrolling_regions {
         use super::*;


### PR DESCRIPTION
## Problem

`Terminal::insert_before` loops forever when the terminal has zero rows and the `scrolling-regions` feature is off (the default). The fallback implementation draws at most `screen_height` lines per iteration; with `screen_height == 0` that is zero, so `while buffer_height + viewport_height > screen_height` never terminates. With `scrolling-regions` enabled it instead writes into row 0 of a terminal that has no rows.

Zero-row terminals do occur in practice — a pty created without a window size (test harnesses, some CI/container setups) reports `0x0` — so an inline app running there spins at 100% CPU instead of just printing nothing.

Found while fuzzing the terminal API with `TestBackend`; no existing issue.

Repro:

```rust
let backend = TestBackend::new(5, 0);
let mut terminal = Terminal::with_options(backend, TerminalOptions { viewport: Viewport::Inline(3) })?;
terminal.insert_before(2, |buf| buf.set_string(0, 0, "aaaaa", Style::default()))?; // hangs
```

## Fix

Return early from `insert_before` when `last_known_area.height == 0` — there is nowhere to put the lines. Documented alongside the existing non-inline no-op.

## Testing

- New test that hangs on `main` and passes with the fix, under both feature configurations.
- `cargo test -p ratatui-core` with and without `scrolling-regions`, clippy clean.
