### PR TITLE
fix(examples): use uppercase H/L for shifted color change in table example

### DIFF
--- a/examples/apps/table/src/main.rs
+++ b/examples/apps/table/src/main.rs
@@ -173,8 +173,8 @@ impl App {
                     KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
                     KeyCode::Char('j') | KeyCode::Down => self.next_row(),
                     KeyCode::Char('k') | KeyCode::Up => self.previous_row(),
-                    KeyCode::Char('l') | KeyCode::Right if shift_pressed => self.next_color(),
-                    KeyCode::Char('h') | KeyCode::Left if shift_pressed => {
+                    KeyCode::Char('L') | KeyCode::Right if shift_pressed => self.next_color(),
+                    KeyCode::Char('H') | KeyCode::Left if shift_pressed => {
                         self.previous_color();
                     }
                     KeyCode::Char('l') | KeyCode::Right => self.next_column(),


### PR DESCRIPTION
When Shift is held, crossterm reports KeyCode::Char('L') / ('H') (uppercase), so the previous arms matching lowercase 'l' / 'h' with a shift_pressed guard never fired. This restores Shift+h/l color cycling.
