### PR TITLE
chore(clippy): fix new Rust lints

### DIFF
--- a/examples/apps/panic/src/main.rs
+++ b/examples/apps/panic/src/main.rs
@@ -51,7 +51,9 @@ fn main() -> Result<()> {
             if let Some(key) = event::read()?.as_key_press_event() {
                 match key.code {
                     KeyCode::Char('p') => panic!("intentional demo panic"),
-                    KeyCode::Char('e') => bail!("intentional demo error"),
+                    KeyCode::Char('e') => {
+                        bail!("intentional demo error");
+                    }
                     KeyCode::Char('h') => {
                         let _ = std::panic::take_hook();
                         panic_hook_state = PanicHandlerState::Disabled;

--- a/ratatui-core/src/buffer/diff.rs
+++ b/ratatui-core/src/buffer/diff.rs
@@ -222,14 +222,14 @@ mod tests {
         let rect = Rect::new(0, 0, 5, 1);
         let buf = Buffer::empty(rect);
         let diff: Vec<_> = BufferDiff::new(&buf, &buf).collect();
-        assert!(diff.is_empty());
+        assert_eq!(diff, Vec::new());
     }
 
     #[test]
     fn identical_buffers_yield_no_diffs() {
         let buf = Buffer::with_lines(["hello"]);
         let diff: Vec<_> = BufferDiff::new(&buf, &buf).collect();
-        assert!(diff.is_empty());
+        assert_eq!(diff, Vec::new());
     }
 
     #[test]

--- a/ratatui-widgets/src/barchart.rs
+++ b/ratatui-widgets/src/barchart.rs
@@ -759,8 +759,8 @@ mod tests {
 
     #[test]
     fn constructors_ignore_empty_groups() {
-        assert!(BarChart::new(Vec::<Bar>::new()).data.is_empty());
-        assert!(BarChart::horizontal(Vec::<Bar>::new()).data.is_empty());
+        assert_eq!(BarChart::new(Vec::<Bar>::new()).data, Vec::new());
+        assert_eq!(BarChart::horizontal(Vec::<Bar>::new()).data, Vec::new());
 
         let chart = BarChart::grouped([
             BarGroup::new(Vec::<Bar>::new()),


### PR DESCRIPTION
## Summary

- update empty-collection assertions for the new `clippy::assert_is_empty` lint
- move `bail!` into statement position to avoid the trailing-semicolon macro diagnostic

## Testing

- `cargo xtask clippy` with Rust 1.99.0-beta.1
- `cargo xtask clippy` with stable Rust 1.97.1
- `cargo xtask format --check`
- `cargo test --package ratatui-core --package ratatui-widgets --package panic`
