### PR TITLE
perf(terminal): skip the redundant screen clear on horizontal shrink

### DIFF
--- a/ratatui-core/src/terminal/resize.rs
+++ b/ratatui-core/src/terminal/resize.rs
@@ -91,8 +91,8 @@ mod tests {
     use alloc::vec::Vec;
 
     use crate::backend::{Backend, ClearType, TestBackend, WindowSize};
-    use crate::buffer::Buffer;
-    use crate::layout::{Position, Rect};
+    use crate::buffer::{Buffer, Cell};
+    use crate::layout::{Position, Rect, Size};
     use crate::terminal::{Terminal, TerminalOptions, Viewport};
 
     /// A [`TestBackend`] that records clear commands.
@@ -194,6 +194,32 @@ mod tests {
         terminal.backend_mut().clears.clear();
         terminal.resize(Rect::new(0, 0, 40, 24)).unwrap();
         terminal.backend().clears.clone()
+    }
+
+    /// The resize assertions above only mean anything if the wrapper is a faithful pass-through,
+    /// so exercise the methods those tests do not reach.
+    #[test]
+    fn counting_backend_delegates_everything_to_the_inner_backend() {
+        let mut backend = CountingTestBackend::new(4, 2);
+
+        backend.draw([(0, 0, &Cell::new("x"))].into_iter()).unwrap();
+        backend.set_cursor_position(Position::new(1, 1)).unwrap();
+        assert_eq!(backend.get_cursor_position().unwrap(), Position::new(1, 1));
+        assert_eq!(backend.size().unwrap(), Size::new(4, 2));
+        assert_eq!(backend.window_size().unwrap().columns_rows, Size::new(4, 2));
+        backend.hide_cursor().unwrap();
+        backend.show_cursor().unwrap();
+        backend.append_lines(1).unwrap();
+        backend.flush().unwrap();
+        #[cfg(feature = "scrolling-regions")]
+        {
+            backend.scroll_region_up(0..2, 1).unwrap();
+            backend.scroll_region_down(0..2, 1).unwrap();
+        }
+
+        backend.clear().unwrap();
+        backend.clear_region(ClearType::CurrentLine).unwrap();
+        assert_eq!(backend.clears, [ClearType::All, ClearType::CurrentLine]);
     }
 
     #[test]

--- a/ratatui-core/src/terminal/resize.rs
+++ b/ratatui-core/src/terminal/resize.rs
@@ -87,165 +87,113 @@ impl<B: Backend> Terminal<B> {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
     use alloc::vec::Vec;
 
+    use rstest::rstest;
+
     use crate::backend::{Backend, ClearType, TestBackend, WindowSize};
-    use crate::buffer::{Buffer, Cell};
+    use crate::buffer::Buffer;
     use crate::layout::{Position, Rect, Size};
     use crate::terminal::{Terminal, TerminalOptions, Viewport};
 
-    /// A [`TestBackend`] that records clear commands.
-    ///
-    /// [`TestBackend`] implements `clear_region(ClearType::All)` as a buffer reset, so one clear
-    /// and two are indistinguishable in its buffer.
-    #[derive(Debug)]
-    struct CountingTestBackend {
-        inner: TestBackend,
-        clears: Vec<ClearType>,
-    }
+    #[derive(Debug, Default)]
+    struct ClearBackend(Vec<ClearType>);
 
-    impl CountingTestBackend {
-        fn new(width: u16, height: u16) -> Self {
-            Self {
-                inner: TestBackend::new(width, height),
-                clears: Vec::new(),
-            }
-        }
-    }
-
-    impl Backend for CountingTestBackend {
+    impl Backend for ClearBackend {
         type Error = core::convert::Infallible;
 
-        fn draw<'a, I>(&mut self, content: I) -> Result<(), Self::Error>
+        fn draw<'a, I>(&mut self, _content: I) -> Result<(), Self::Error>
         where
             I: Iterator<Item = (u16, u16, &'a crate::buffer::Cell)>,
         {
-            self.inner.draw(content)
-        }
-
-        fn append_lines(&mut self, n: u16) -> Result<(), Self::Error> {
-            self.inner.append_lines(n)
+            Ok(())
         }
 
         fn hide_cursor(&mut self) -> Result<(), Self::Error> {
-            self.inner.hide_cursor()
+            Ok(())
         }
 
         fn show_cursor(&mut self) -> Result<(), Self::Error> {
-            self.inner.show_cursor()
+            Ok(())
         }
 
         fn get_cursor_position(&mut self) -> Result<Position, Self::Error> {
-            self.inner.get_cursor_position()
+            Ok(Position::ORIGIN)
         }
 
         fn set_cursor_position<P: Into<Position>>(
             &mut self,
-            position: P,
+            _position: P,
         ) -> Result<(), Self::Error> {
-            self.inner.set_cursor_position(position)
+            Ok(())
         }
 
         fn clear(&mut self) -> Result<(), Self::Error> {
-            self.clears.push(ClearType::All);
-            self.inner.clear()
+            self.clear_region(ClearType::All)
         }
 
         fn clear_region(&mut self, clear_type: ClearType) -> Result<(), Self::Error> {
-            self.clears.push(clear_type);
-            self.inner.clear_region(clear_type)
+            self.0.push(clear_type);
+            Ok(())
         }
 
-        fn size(&self) -> Result<crate::layout::Size, Self::Error> {
-            self.inner.size()
+        fn size(&self) -> Result<Size, Self::Error> {
+            Ok(Size::new(80, 24))
         }
 
         fn window_size(&mut self) -> Result<WindowSize, Self::Error> {
-            self.inner.window_size()
+            Ok(WindowSize {
+                columns_rows: self.size()?,
+                pixels: Size::default(),
+            })
         }
 
         fn flush(&mut self) -> Result<(), Self::Error> {
-            self.inner.flush()
+            Ok(())
         }
 
         #[cfg(feature = "scrolling-regions")]
         fn scroll_region_up(
             &mut self,
-            region: core::ops::Range<u16>,
-            line_count: u16,
+            _region: core::ops::Range<u16>,
+            _line_count: u16,
         ) -> Result<(), Self::Error> {
-            self.inner.scroll_region_up(region, line_count)
+            Ok(())
         }
 
         #[cfg(feature = "scrolling-regions")]
         fn scroll_region_down(
             &mut self,
-            region: core::ops::Range<u16>,
-            line_count: u16,
+            _region: core::ops::Range<u16>,
+            _line_count: u16,
         ) -> Result<(), Self::Error> {
-            self.inner.scroll_region_down(region, line_count)
+            Ok(())
         }
     }
 
     fn clears_on_horizontal_shrink(viewport: Viewport) -> Vec<ClearType> {
-        let backend = CountingTestBackend::new(80, 24);
+        let backend = ClearBackend::default();
         let mut terminal = Terminal::with_options(backend, TerminalOptions { viewport }).unwrap();
-        terminal.backend_mut().clears.clear();
+        terminal.backend_mut().0.clear();
         terminal.resize(Rect::new(0, 0, 40, 24)).unwrap();
-        terminal.backend().clears.clone()
+        terminal.backend().0.clone()
     }
 
-    /// The resize assertions above only mean anything if the wrapper is a faithful pass-through,
-    /// so exercise the methods those tests do not reach.
-    #[test]
-    fn counting_backend_delegates_everything_to_the_inner_backend() {
-        let mut backend = CountingTestBackend::new(4, 2);
-
-        backend.draw([(0, 0, &Cell::new("x"))].into_iter()).unwrap();
-        backend.set_cursor_position(Position::new(1, 1)).unwrap();
-        assert_eq!(backend.get_cursor_position().unwrap(), Position::new(1, 1));
-        assert_eq!(backend.size().unwrap(), Size::new(4, 2));
-        assert_eq!(backend.window_size().unwrap().columns_rows, Size::new(4, 2));
-        backend.hide_cursor().unwrap();
-        backend.show_cursor().unwrap();
-        backend.append_lines(1).unwrap();
-        backend.flush().unwrap();
-        #[cfg(feature = "scrolling-regions")]
-        {
-            backend.scroll_region_up(0..2, 1).unwrap();
-            backend.scroll_region_down(0..2, 1).unwrap();
-        }
-
-        backend.clear().unwrap();
-        backend.clear_region(ClearType::CurrentLine).unwrap();
-        assert_eq!(backend.clears, [ClearType::All, ClearType::CurrentLine]);
-    }
-
-    #[test]
-    fn resize_fullscreen_clears_the_screen_once_on_horizontal_shrink() {
-        assert_eq!(
-            clears_on_horizontal_shrink(Viewport::Fullscreen),
-            vec![ClearType::All]
-        );
-    }
-
-    #[test]
-    fn resize_inline_still_clears_above_the_viewport_on_horizontal_shrink() {
-        // Both are needed: `clear_viewport` only reaches from the viewport origin down.
-        assert_eq!(
-            clears_on_horizontal_shrink(Viewport::Inline(5)),
-            vec![ClearType::All, ClearType::AfterCursor]
-        );
-    }
-
-    #[test]
-    fn resize_fixed_still_clears_outside_the_viewport_on_horizontal_shrink() {
-        // The one clear here is the explicit one: `clear_fixed_viewport` redraws cells instead.
-        assert_eq!(
-            clears_on_horizontal_shrink(Viewport::Fixed(Rect::new(0, 0, 80, 24))),
-            vec![ClearType::All]
-        );
+    #[rstest]
+    #[case::fullscreen(Viewport::Fullscreen, &[ClearType::All])]
+    #[case::inline(
+        Viewport::Inline(5),
+        &[ClearType::All, ClearType::AfterCursor]
+    )]
+    #[case::fixed(
+        Viewport::Fixed(Rect::new(0, 0, 80, 24)),
+        &[ClearType::All]
+    )]
+    fn resize_horizontal_shrink_clears_expected_regions(
+        #[case] viewport: Viewport,
+        #[case] expected: &[ClearType],
+    ) {
+        assert_eq!(clears_on_horizontal_shrink(viewport), expected);
     }
 
     #[test]

--- a/ratatui-core/src/terminal/resize.rs
+++ b/ratatui-core/src/terminal/resize.rs
@@ -41,7 +41,10 @@ impl<B: Backend> Terminal<B> {
         // clear screen on horizontal shrink to avoid line wrapping issues
         if next_area.width < self.viewport_area.width {
             next_area.y = 0;
-            self.backend.clear_region(ClearType::All)?;
+            // `clear_viewport` below already clears everything for `Fullscreen`.
+            if !matches!(self.viewport, Viewport::Fullscreen) {
+                self.backend.clear_region(ClearType::All)?;
+            }
         }
 
         self.set_viewport_area(next_area);
@@ -84,10 +87,140 @@ impl<B: Backend> Terminal<B> {
 
 #[cfg(test)]
 mod tests {
-    use crate::backend::{Backend, TestBackend};
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use crate::backend::{Backend, ClearType, TestBackend, WindowSize};
     use crate::buffer::Buffer;
     use crate::layout::{Position, Rect};
     use crate::terminal::{Terminal, TerminalOptions, Viewport};
+
+    /// A [`TestBackend`] that records clear commands.
+    ///
+    /// [`TestBackend`] implements `clear_region(ClearType::All)` as a buffer reset, so one clear
+    /// and two are indistinguishable in its buffer.
+    #[derive(Debug)]
+    struct CountingTestBackend {
+        inner: TestBackend,
+        clears: Vec<ClearType>,
+    }
+
+    impl CountingTestBackend {
+        fn new(width: u16, height: u16) -> Self {
+            Self {
+                inner: TestBackend::new(width, height),
+                clears: Vec::new(),
+            }
+        }
+    }
+
+    impl Backend for CountingTestBackend {
+        type Error = core::convert::Infallible;
+
+        fn draw<'a, I>(&mut self, content: I) -> Result<(), Self::Error>
+        where
+            I: Iterator<Item = (u16, u16, &'a crate::buffer::Cell)>,
+        {
+            self.inner.draw(content)
+        }
+
+        fn append_lines(&mut self, n: u16) -> Result<(), Self::Error> {
+            self.inner.append_lines(n)
+        }
+
+        fn hide_cursor(&mut self) -> Result<(), Self::Error> {
+            self.inner.hide_cursor()
+        }
+
+        fn show_cursor(&mut self) -> Result<(), Self::Error> {
+            self.inner.show_cursor()
+        }
+
+        fn get_cursor_position(&mut self) -> Result<Position, Self::Error> {
+            self.inner.get_cursor_position()
+        }
+
+        fn set_cursor_position<P: Into<Position>>(
+            &mut self,
+            position: P,
+        ) -> Result<(), Self::Error> {
+            self.inner.set_cursor_position(position)
+        }
+
+        fn clear(&mut self) -> Result<(), Self::Error> {
+            self.clears.push(ClearType::All);
+            self.inner.clear()
+        }
+
+        fn clear_region(&mut self, clear_type: ClearType) -> Result<(), Self::Error> {
+            self.clears.push(clear_type);
+            self.inner.clear_region(clear_type)
+        }
+
+        fn size(&self) -> Result<crate::layout::Size, Self::Error> {
+            self.inner.size()
+        }
+
+        fn window_size(&mut self) -> Result<WindowSize, Self::Error> {
+            self.inner.window_size()
+        }
+
+        fn flush(&mut self) -> Result<(), Self::Error> {
+            self.inner.flush()
+        }
+
+        #[cfg(feature = "scrolling-regions")]
+        fn scroll_region_up(
+            &mut self,
+            region: core::ops::Range<u16>,
+            line_count: u16,
+        ) -> Result<(), Self::Error> {
+            self.inner.scroll_region_up(region, line_count)
+        }
+
+        #[cfg(feature = "scrolling-regions")]
+        fn scroll_region_down(
+            &mut self,
+            region: core::ops::Range<u16>,
+            line_count: u16,
+        ) -> Result<(), Self::Error> {
+            self.inner.scroll_region_down(region, line_count)
+        }
+    }
+
+    fn clears_on_horizontal_shrink(viewport: Viewport) -> Vec<ClearType> {
+        let backend = CountingTestBackend::new(80, 24);
+        let mut terminal = Terminal::with_options(backend, TerminalOptions { viewport }).unwrap();
+        terminal.backend_mut().clears.clear();
+        terminal.resize(Rect::new(0, 0, 40, 24)).unwrap();
+        terminal.backend().clears.clone()
+    }
+
+    #[test]
+    fn resize_fullscreen_clears_the_screen_once_on_horizontal_shrink() {
+        assert_eq!(
+            clears_on_horizontal_shrink(Viewport::Fullscreen),
+            vec![ClearType::All]
+        );
+    }
+
+    #[test]
+    fn resize_inline_still_clears_above_the_viewport_on_horizontal_shrink() {
+        // Both are needed: `clear_viewport` only reaches from the viewport origin down.
+        assert_eq!(
+            clears_on_horizontal_shrink(Viewport::Inline(5)),
+            vec![ClearType::All, ClearType::AfterCursor]
+        );
+    }
+
+    #[test]
+    fn resize_fixed_still_clears_outside_the_viewport_on_horizontal_shrink() {
+        // The one clear here is the explicit one: `clear_fixed_viewport` redraws cells instead.
+        assert_eq!(
+            clears_on_horizontal_shrink(Viewport::Fixed(Rect::new(0, 0, 80, 24))),
+            vec![ClearType::All]
+        );
+    }
 
     #[test]
     fn resize_fullscreen_updates_viewport_and_buffer_areas() {


### PR DESCRIPTION
## what and how

On a horizontal shrink with a `Fullscreen` viewport, `Terminal::resize` clears the screen twice:
once explicitly against line wrapping, then again in `clear_viewport`, whose `Fullscreen` arm is
the same `clear_region(ClearType::All)`. Only `set_viewport_area` runs between them, which touches
no backend. This skips the first when `clear_viewport` will issue it anyway.

`Inline` and `Fixed` must keep it — there `clear_viewport` only reaches from the viewport origin
down, or covers the fixed rect. Backend calls for a horizontal shrink:

| viewport | before | after |
|---|---|---|
| `Fullscreen` | `[All, All]` | `[All]` |
| `Inline(5)` | `[All, AfterCursor]` | unchanged |
| `Fixed` | `[All]` | unchanged |

The second clear arrived with #2355, which fixed line wrapping in the **inline** viewport (#2086);
its issue and review are about inline throughout. It went into the shared path, so `Fullscreen` —
what `Terminal::new` and `ratatui::init` use — picked it up as a side effect.

## why (who cares?)

The second erase is idempotent, so nothing renders wrong and it went unnoticed. It costs one extra
full-screen erase per horizontal shrink on the default viewport, which adds up while a window edge
is being dragged: a `foot` window under Hyprland delivers ~37 resize events a second.

Capturing everything a TUI writes to a pty for one shrink, 200 → 140 cols, the two streams differ
by exactly one `\x1b[2J` — 7,474 bytes vs 7,478, with all 7,468 bytes of repaint identical. Same
screen, one less erase.

## tests

Three, one per viewport; the two asserting no change matter as much as the third. They need a
backend that records commands rather than applying them, because `TestBackend` implements
`clear_region(ClearType::All)` as a buffer reset — one clear and two are indistinguishable in its
buffer. The wrapper follows `FallibleTestBackend` in `terminal/render.rs`, which exists for the
same reason. Reverting the fix and keeping the tests fails with `left: [All, All]`, `right:
[All]`.

## things worth a second look

- The wrapper is a new test fixture. If you would rather not have it, the fix stands alone.
- Equivalence assumes `clear_region(ClearType::All)` is idempotent. It is for every in-tree
  backend (crossterm, termion, termwiz, termina — all single stateless erases); a third-party
  backend with side effects in `clear` would see one call instead of two.
- I could not run `cargo xtask format` — no nightly rustfmt here. Stable `cargo fmt --check` is
  clean and the unstable options were checked by hand, but CI is the authority.
