### PR TITLE
fix(backend): avoid overflow when tracking cursor position

### DIFF
--- a/ratatui-crossterm/src/lib.rs
+++ b/ratatui-crossterm/src/lib.rs
@@ -243,7 +243,7 @@ where
         for (x, y, cell) in content {
             // Move the cursor unless it already sits at (x, y), i.e. this cell directly follows
             // the previous one on the same row, accounting for the width of what was printed.
-            if !matches!(last, Some((p, w)) if x == p.x + w && y == p.y) {
+            if !matches!(last, Some((p, w)) if p.x.checked_add(w) == Some(x) && y == p.y) {
                 queue!(self.writer, MoveTo(x, y))?;
             }
             last = Some((Position { x, y }, cell.cell_width()));
@@ -855,6 +855,15 @@ mod tests {
         assert!(!output.contains(&MoveTo(2, 0).to_string()));
         let output = draw_to_string(&[(0, 0, &forced), (1, 0, &next)]);
         assert!(output.contains(&MoveTo(1, 0).to_string()));
+    }
+
+    #[test]
+    fn draw_moves_cursor_when_previous_width_overflows() {
+        let mut forced = Cell::new("a");
+        forced.set_diff_option(CellDiffOption::ForcedWidth(NonZeroU16::MAX));
+        let next = Cell::new("b");
+        let output = draw_to_string(&[(1, 0, &forced), (0, 0, &next)]);
+        assert!(output.contains(&MoveTo(0, 0).to_string()));
     }
 
     #[test]

--- a/ratatui-termina/src/lib.rs
+++ b/ratatui-termina/src/lib.rs
@@ -151,7 +151,7 @@ where
         for (x, y, cell) in content {
             // Move the cursor unless it already sits at (x, y), i.e. this cell directly follows
             // the previous one on the same row, accounting for the width of what was printed.
-            if !matches!(last, Some((p, w)) if x == p.x + w && y == p.y) {
+            if !matches!(last, Some((p, w)) if p.x.checked_add(w) == Some(x) && y == p.y) {
                 let command = Csi::Cursor(cursor_position(Position { x, y })?);
                 write!(string, "{command}").unwrap();
             }
@@ -525,9 +525,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU16;
     use std::time::Duration;
 
-    use ratatui_core::buffer::Cell;
+    use ratatui_core::buffer::{Cell, CellDiffOption};
     use termina::EventReader;
     use termina::escape::csi::Csi;
 
@@ -796,6 +797,21 @@ mod tests {
         let output = backend.terminal.output();
         let cursor = Csi::Cursor(cursor_position(Position::new(2, 0)).unwrap());
         assert!(!output.contains(&cursor.to_string()));
+    }
+
+    #[test]
+    fn moves_cursor_when_previous_width_overflows() {
+        let mut backend = backend();
+        let mut forced = Cell::new("a");
+        forced.set_diff_option(CellDiffOption::ForcedWidth(NonZeroU16::MAX));
+        let next = Cell::new("b");
+        let content = [(1, 0, &forced), (0, 0, &next)];
+
+        backend.draw(content.into_iter()).unwrap();
+
+        let output = backend.terminal.output();
+        let cursor = Csi::Cursor(cursor_position(Position::new(0, 0)).unwrap());
+        assert!(output.contains(&cursor.to_string()));
     }
 
     #[test]

--- a/ratatui-termion/src/lib.rs
+++ b/ratatui-termion/src/lib.rs
@@ -234,7 +234,7 @@ where
         for (x, y, cell) in content {
             // Move the cursor unless it already sits at (x, y), i.e. this cell directly follows
             // the previous one on the same row, accounting for the width of what was printed.
-            if !matches!(last, Some((p, w)) if x == p.x + w && y == p.y) {
+            if !matches!(last, Some((p, w)) if p.x.checked_add(w) == Some(x) && y == p.y) {
                 write!(string, "{}", termion::cursor::Goto(x + 1, y + 1)).unwrap();
             }
             last = Some((Position { x, y }, cell.cell_width()));
@@ -577,6 +577,10 @@ impl fmt::Display for ResetRegion {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU16;
+
+    use ratatui_core::buffer::CellDiffOption;
+
     use super::*;
 
     /// Renders `content` and returns the emitted bytes as a lossy string.
@@ -616,6 +620,15 @@ mod tests {
         let next = Cell::new("a");
         let output = draw_to_string(&[(0, 0, &wide), (2, 0, &next)]);
         assert!(!output.contains(&termion::cursor::Goto(3, 1).to_string()));
+    }
+
+    #[test]
+    fn draw_moves_cursor_when_previous_width_overflows() {
+        let mut forced = Cell::new("a");
+        forced.set_diff_option(CellDiffOption::ForcedWidth(NonZeroU16::MAX));
+        let next = Cell::new("b");
+        let output = draw_to_string(&[(1, 0, &forced), (0, 0, &next)]);
+        assert!(output.contains(&termion::cursor::Goto(1, 1).to_string()));
     }
 
     #[test]


### PR DESCRIPTION
follow up to #2721

Use checked arithmetic when tracking the expected terminal cursor position, preventing u16 overflow for cells with large widths.
