### PR TITLE
feat(a11y): experimental Linux AT-SPI accessibility crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,57 @@
 version = 4
 
 [[package]]
+name = "accesskit"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
+dependencies = [
+ "uuid 1.18.0",
+]
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023da0e5097f46df7092d5280b02efb9bbf8d93298daeced42652463e357d636"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "atspi-common",
+ "phf 0.13.1",
+ "serde",
+ "zvariant",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e156ed3802e35eefe894ef2671bc6c889303d8a7e110b5e1b48f504b91362f"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common",
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite",
+ "futures-util",
+ "serde",
+ "zbus",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +194,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "async-github"
 version = "0.0.0"
 dependencies = [
@@ -153,6 +242,88 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -172,6 +343,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atspi"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus",
 ]
 
 [[package]]
@@ -250,6 +464,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -554,6 +781,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,7 +964,7 @@ dependencies = [
  "futures-core",
  "mio",
  "parking_lot",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "serde",
  "signal-hook",
  "signal-hook-mio",
@@ -1058,6 +1294,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1343,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1242,6 +1525,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1427,6 +1723,12 @@ dependencies = [
  "crossterm 0.29.0",
  "ratatui",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1903,9 +2205,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -1939,9 +2241,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2281,6 +2583,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,6 +2683,12 @@ dependencies = [
  "crossterm 0.29.0",
  "ratatui",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2594,6 +2912,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,6 +2969,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2862,6 +3205,17 @@ dependencies = [
  "serde",
  "serde_json",
  "time",
+]
+
+[[package]]
+name = "ratatui-a11y"
+version = "0.1.0"
+dependencies = [
+ "accesskit",
+ "accesskit_unix",
+ "color-eyre",
+ "crossterm 0.29.0",
+ "ratatui",
 ]
 
 [[package]]
@@ -3147,19 +3501,19 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.52.0",
 ]
 
@@ -3361,6 +3715,17 @@ checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -3684,6 +4049,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3700,9 +4078,9 @@ checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
  "bitflags 2.13.1",
  "parking_lot",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3961,7 +4339,7 @@ dependencies = [
  "toml_datetime 0.7.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.12",
 ]
 
 [[package]]
@@ -3987,7 +4365,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "toml_datetime 0.6.11",
- "winnow",
+ "winnow 0.7.12",
 ]
 
 [[package]]
@@ -3996,7 +4374,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
- "winnow",
+ "winnow 0.7.12",
 ]
 
 [[package]]
@@ -4183,6 +4561,17 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "uncased"
@@ -4601,7 +4990,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4850,6 +5239,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4995,6 +5393,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing 0.1.44",
+ "uds_windows",
+ "uuid 1.18.0",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
+dependencies = [
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus-lockstep",
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_xml"
+version = "5.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5079,3 +5583,44 @@ name = "zmij"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f4a4e8e9dc5c62d159f04fcdbe07f4c3fb710415aab4754bf11505501e3251d"
+
+[[package]]
+name = "zvariant"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.2",
+ "winnow 1.0.4",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ thiserror = { version = "2.0.12", default-features = false }
 time = { version = "0.3.37", default-features = false }
 tokio = "1.35"
 tokio-stream = "0.1"
-tracing = "0.1.37"
+tracing = "0.1.40"
 tracing-appender = "0.2"
 tracing-subscriber = "0.3.10"
 trybuild = "1.0.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ default-members = [
   "ratatui-macros",
   # this is not included as it doesn't compile on windows
   # "ratatui-termion",
+  # this is experimental and Linux-only (AT-SPI)
+  # "ratatui-a11y",
   "ratatui-termina",
   "ratatui-termwiz",
   "ratatui-widgets",
@@ -52,6 +54,7 @@ pretty_assertions = "1"
 rand = "0.10"
 rand_chacha = "0.10"
 ratatui = { path = "ratatui", version = "0.30.2" }
+ratatui-a11y = { path = "ratatui-a11y", version = "0.1.0" }
 ratatui-core = { path = "ratatui-core", version = "0.1.2" }
 ratatui-crossterm = { path = "ratatui-crossterm", version = "0.1.2" }
 ratatui-macros = { path = "ratatui-macros", version = "0.7.2" }

--- a/ratatui-a11y/Cargo.toml
+++ b/ratatui-a11y/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ratatui-a11y"
+version = "0.1.0"
+description = "Experimental Linux (AT-SPI) accessibility tree support for Ratatui."
+documentation = "https://docs.rs/ratatui-a11y"
+readme = "README.md"
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+exclude.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+accesskit = "0.24"
+accesskit_unix = "0.22"
+
+[dev-dependencies]
+color-eyre.workspace = true
+crossterm.workspace = true
+ratatui.workspace = true
+
+[lints]
+workspace = true

--- a/ratatui-a11y/Cargo.toml
+++ b/ratatui-a11y/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-accesskit = "0.24"
+accesskit = "0.24.1"
 accesskit_unix = "0.22"
 
 [dev-dependencies]

--- a/ratatui-a11y/README.md
+++ b/ratatui-a11y/README.md
@@ -1,0 +1,83 @@
+# ratatui-a11y
+
+Experimental Linux (AT-SPI) accessibility tree support for [Ratatui], via
+[AccessKit]. See [ratatui/ratatui#2610] for the background.
+
+This is **not** part of the default workspace build (`cargo build` /
+`cargo test` at the repo root skip it, same as `ratatui-termion`) it's an
+experimental crate, opted into explicitly with `-p ratatui-a11y`.
+
+## What this is
+
+Ratatui renders characters at cell positions; it has no concept of focus,
+selection, or semantic roles, and no retained widget tree. This crate
+doesn't try to infer any of that from the rendered `Buffer`. Instead, the
+app declares a small, separate accessibility tree by hand, alongside its
+normal rendering code, using [`TreeBuilder`], and this crate serves it to
+AT-SPI clients (screen readers, and testing tools like [xa11y]) via
+[`A11y`].
+
+Building that tree from scratch every frame gets repetitive fast, so the
+crate ships adapters that turn plain data (item strings, a selected index)
+into a `SubTree` ready to merge in with `TreeBuilder::subtree`:
+`list_nodes`, `table_nodes`, `tabs_nodes`, `gauge_nodes`, `text_nodes`, and
+`group_nodes` (for naming/nesting the others). They take data, not widgets
+`ratatui-widgets` types keep their fields private -- so they work with a
+hand-rolled widget or any TUI framework, not just Ratatui's built-ins. For
+a widget type you own, `Accessible`/`StatefulAccessible` give it a home for
+an `a11y_nodes` method built on top of the same adapters.
+
+## Try it
+
+```sh
+cargo run -p ratatui-a11y --example list       # selectable list, full round trip
+cargo run -p ratatui-a11y --example dashboard  # tabs + table + gauge, adapters composed
+```
+
+## The `IsEnabled` gotcha
+
+`A11y::new` only actually registers on the AT-SPI bus once the desktop
+reports `org.a11y.Status.IsEnabled = true`. That happens automatically once
+a screen reader like Orca is running, but is otherwise off by default on
+most Linux desktops -- including most CI runners and headless dev boxes.
+There's no error and no log line when it's off; `A11y::update` just
+quietly does nothing. If you're testing without a screen reader:
+
+```sh
+gsettings set org.gnome.desktop.interface toolkit-accessibility true
+```
+
+## Linux only
+
+Every AT-SPI adapter talks to apps over D-Bus, which needs no OS window
+handle. Windows (UIA) and macOS (NSAccessibility) both require binding to
+a real window, which a terminal app doesn't have. See
+[ratatui/ratatui#2610] for the discussion; this crate doesn't attempt
+either.
+
+## Known gaps
+
+- `Action::Focus` has no AT-SPI counterpart in the current
+  `accesskit_atspi_common` mapping AT-SPI drives focus from the tree's
+  `focus` field, it has no inbound "move focus here" request.
+  Only `Action::Click` round-trips.
+- Node identity (`node_id`) is a plain key hash the app supplies; nothing
+  here validates that it stays stable across frames. Get it wrong and
+  focus/selection tracking degrades silently. `TreeBuilder::build` does
+  catch duplicate ids and a dangling focus id in debug builds.
+  `gauge_nodes` reports its ratio as `0..=100`, clamped -- accesskit's
+  numeric-value fields are unitless, so the convention is documented but
+  not enforced.
+- The adapters cover list/table/tabs/gauge/text/group. Wiring
+  `ratatui-widgets`' actual widget types (`impl Accessible for List`, ...)
+  behind a feature flag is unstarted for now, an app builds subtrees
+  from its own data (see the `list` and `dashboard` examples), which also
+  means these adapters work outside Ratatui entirely.
+- Scrollbar, barchart, sparkline, chart, and calendar have no adapter yet.
+- Windows (UIA) and macOS (NSAccessibility) are unattempted -- see "Linux
+  only" above.
+
+[Ratatui]: https://ratatui.rs
+[AccessKit]: https://github.com/AccessKit/accesskit
+[xa11y]: https://github.com/xa11y/xa11y
+[ratatui/ratatui#2610]: https://github.com/ratatui/ratatui/issues/2610

--- a/ratatui-a11y/examples/dashboard.rs
+++ b/ratatui-a11y/examples/dashboard.rs
@@ -1,0 +1,209 @@
+//! Tabs + table + gauge in one app, proving the data-shaped adapters
+//! compose: each panel is built with its own adapter function and merged
+//! into one tree with `TreeBuilder::subtree`.
+//!
+//! Left/Right switch tabs, Up/Down move the table selection on the Tasks
+//! tab. Try it with Orca running (see the crate README for the `IsEnabled`
+//! gotcha).
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode, KeyEvent};
+use ratatui::layout::{Constraint, Layout};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Cell, Gauge, Paragraph, Row, Table, TableState, Tabs};
+use ratatui::{DefaultTerminal, Frame};
+use ratatui_a11y::{
+    A11y, Role, TreeBuilder, TreeUpdate, gauge_nodes, group_nodes, node_id, table_nodes,
+    tabs_nodes, text_nodes,
+};
+
+const TAB_TITLES: [&str; 3] = ["Overview", "Tasks", "Progress"];
+const OVERVIEW_TEXT: &str = "A small dashboard: pick a tab to see its content.";
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    ratatui::run(|terminal| App::default().run(terminal))
+}
+
+struct Task {
+    name: &'static str,
+    done: bool,
+}
+
+struct App {
+    should_exit: bool,
+    selected_tab: usize,
+    tasks: Vec<Task>,
+    table_state: TableState,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            should_exit: false,
+            selected_tab: 0,
+            tasks: vec![
+                Task {
+                    name: "Design mockups",
+                    done: true,
+                },
+                Task {
+                    name: "Wire up backend",
+                    done: false,
+                },
+                Task {
+                    name: "Write tests",
+                    done: false,
+                },
+            ],
+            table_state: TableState::default().with_selected(Some(0)),
+        }
+    }
+}
+
+impl App {
+    fn run(mut self, terminal: &mut DefaultTerminal) -> Result<()> {
+        let mut a11y = A11y::new(self.build_tree());
+        a11y.set_focused(true);
+
+        while !self.should_exit {
+            terminal.draw(|frame| self.render(frame))?;
+            a11y.update(self.build_tree());
+            let _ = a11y.actions().count();
+
+            if event::poll(std::time::Duration::from_millis(50))?
+                && let Some(key) = event::read()?.as_key_press_event()
+            {
+                self.handle_key(key);
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => self.should_exit = true,
+            KeyCode::Left | KeyCode::Char('h') => {
+                self.selected_tab = self
+                    .selected_tab
+                    .checked_sub(1)
+                    .unwrap_or(TAB_TITLES.len() - 1);
+            }
+            KeyCode::Right | KeyCode::Char('l') => {
+                self.selected_tab = (self.selected_tab + 1) % TAB_TITLES.len();
+            }
+            KeyCode::Down | KeyCode::Char('j') if self.selected_tab == 1 => {
+                let next = self
+                    .table_state
+                    .selected()
+                    .map_or(0, |i| (i + 1) % self.tasks.len());
+                self.table_state.select(Some(next));
+            }
+            KeyCode::Up | KeyCode::Char('k') if self.selected_tab == 1 => {
+                let prev = self
+                    .table_state
+                    .selected()
+                    .map_or(0, |i| i.checked_sub(1).unwrap_or(self.tasks.len() - 1));
+                self.table_state.select(Some(prev));
+            }
+            _ => {}
+        }
+    }
+
+    fn progress_ratio(&self) -> f64 {
+        let done = self.tasks.iter().filter(|t| t.done).count();
+        done as f64 / self.tasks.len() as f64
+    }
+
+    fn build_tree(&self) -> TreeUpdate {
+        let window_id = node_id("dashboard-window");
+        let mut tree = TreeBuilder::new();
+
+        let mut tabs = tabs_nodes(TAB_TITLES, Some(self.selected_tab), "dashboard-tabs");
+        let tabs_root = tabs.root;
+        for (id, node) in tabs.nodes_mut() {
+            if *id == tabs_root {
+                node.set_label("Dashboard sections");
+            }
+        }
+        let tabs_selected = tabs.selected;
+        let tabs_id = tree.subtree(tabs);
+
+        let mut content_selected = None;
+        let content_id = match self.selected_tab {
+            0 => tree.subtree(text_nodes(OVERVIEW_TEXT, "dashboard-overview")),
+            1 => {
+                let header = Some(["Task".to_string(), "Status".to_string()]);
+                let rows = self.tasks.iter().map(|t| {
+                    [
+                        t.name.to_string(),
+                        if t.done {
+                            "done".to_string()
+                        } else {
+                            "not done".to_string()
+                        },
+                    ]
+                });
+                let table = table_nodes(
+                    header,
+                    rows,
+                    self.table_state.selected(),
+                    None,
+                    "dashboard-tasks",
+                );
+                content_selected = table.selected;
+                tree.subtree(group_nodes("Tasks", [table], "dashboard-tasks-group"))
+            }
+            _ => tree.subtree(gauge_nodes(
+                Some("Overall progress"),
+                self.progress_ratio(),
+                "dashboard-progress",
+            )),
+        };
+
+        tree.node(
+            window_id,
+            Role::Window,
+            "Ratatui Dashboard",
+            [tabs_id, content_id],
+        );
+        tree.root(window_id);
+        tree.focus(content_selected.or(tabs_selected).unwrap_or(tabs_id));
+
+        tree.build()
+    }
+
+    fn render(&mut self, frame: &mut Frame) {
+        let [tabs_area, content_area] =
+            Layout::vertical([Constraint::Length(1), Constraint::Fill(1)]).areas(frame.area());
+
+        let tabs = Tabs::new(TAB_TITLES).select(self.selected_tab);
+        frame.render_widget(tabs, tabs_area);
+
+        match self.selected_tab {
+            0 => frame.render_widget(Paragraph::new(OVERVIEW_TEXT), content_area),
+            1 => {
+                let rows = self.tasks.iter().map(|t| {
+                    Row::new([
+                        Cell::from(t.name),
+                        Cell::from(if t.done { "done" } else { "not done" }),
+                    ])
+                });
+                let table = Table::new(rows, [Constraint::Fill(1), Constraint::Length(10)])
+                    .header(Row::new(["Task", "Status"]))
+                    .row_highlight_style(ratatui::style::Style::new().reversed())
+                    .block(Block::new().borders(Borders::TOP).title(Line::raw("Tasks")));
+                frame.render_stateful_widget(table, content_area, &mut self.table_state);
+            }
+            _ => {
+                let gauge = Gauge::default()
+                    .block(
+                        Block::new()
+                            .borders(Borders::TOP)
+                            .title(Line::raw("Progress")),
+                    )
+                    .ratio(self.progress_ratio());
+                frame.render_widget(gauge, content_area);
+            }
+        }
+    }
+}

--- a/ratatui-a11y/examples/list.rs
+++ b/ratatui-a11y/examples/list.rs
@@ -1,0 +1,318 @@
+//! A selectable list, wired up to AT-SPI end to end: `ListState::selected()`
+//! drives the accessible focus/selection state, and actions an AT client
+//! sends back (`Focus`, `Click`) drive `ListState` in return.
+//!
+//! Forked from ratatui's `todo-list` example; see that one for the plain
+//! (non-accessible) version of this app.
+//!
+//! Try it with Orca running, or walk the tree by hand -- see the crate
+//! README (and the `IsEnabled` gotcha in the crate docs).
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode, KeyEvent};
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::palette::tailwind::{BLUE, GREEN, SLATE};
+use ratatui::style::{Color, Modifier, Style, Stylize};
+use ratatui::text::Line;
+use ratatui::widgets::{
+    Block, Borders, HighlightSpacing, List, ListItem, ListState, Padding, Paragraph,
+    StatefulWidget, Widget, Wrap,
+};
+use ratatui::{DefaultTerminal, symbols};
+use ratatui_a11y::{
+    A11y, Action, NodeId, Role, TreeBuilder, TreeUpdate, list_nodes, node_id, text_nodes,
+};
+
+const TODO_HEADER_STYLE: Style = Style::new().fg(SLATE.c100).bg(BLUE.c800);
+const NORMAL_ROW_BG: Color = SLATE.c950;
+const ALT_ROW_BG_COLOR: Color = SLATE.c900;
+const SELECTED_STYLE: Style = Style::new().bg(SLATE.c800).add_modifier(Modifier::BOLD);
+const TEXT_FG_COLOR: Color = SLATE.c200;
+const COMPLETED_TEXT_FG_COLOR: Color = GREEN.c500;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    ratatui::run(|terminal| App::default().run(terminal))
+}
+
+struct App {
+    should_exit: bool,
+    todo_list: TodoList,
+}
+
+struct TodoList {
+    items: Vec<TodoItem>,
+    state: ListState,
+}
+
+#[derive(Debug)]
+struct TodoItem {
+    todo: String,
+    info: String,
+    status: Status,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Status {
+    Todo,
+    Completed,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            should_exit: false,
+            todo_list: TodoList::from_iter([
+                (
+                    Status::Todo,
+                    "Rewrite everything with Rust!",
+                    "I can't hold my inner voice. He tells me to rewrite the complete universe with Rust",
+                ),
+                (
+                    Status::Completed,
+                    "Rewrite all of your tui apps with Ratatui",
+                    "Yes, you heard that right. Go and replace your tui with Ratatui.",
+                ),
+                (
+                    Status::Todo,
+                    "Pet your cat",
+                    "Minnak loves to be pet by you! Don't forget to pet and give some treats!",
+                ),
+                (
+                    Status::Todo,
+                    "Walk with your dog",
+                    "Max is bored, go walk with him!",
+                ),
+                (
+                    Status::Completed,
+                    "Pay the bills",
+                    "Pay the train subscription!!!",
+                ),
+            ]),
+        }
+    }
+}
+
+impl FromIterator<(Status, &'static str, &'static str)> for TodoList {
+    fn from_iter<I: IntoIterator<Item = (Status, &'static str, &'static str)>>(iter: I) -> Self {
+        let items = iter
+            .into_iter()
+            .map(|(status, todo, info)| TodoItem {
+                status,
+                todo: todo.to_string(),
+                info: info.to_string(),
+            })
+            .collect();
+        Self {
+            items,
+            state: ListState::default(),
+        }
+    }
+}
+
+impl App {
+    fn run(mut self, terminal: &mut DefaultTerminal) -> Result<()> {
+        let mut a11y = A11y::new(self.build_tree());
+        a11y.set_focused(true);
+
+        while !self.should_exit {
+            terminal.draw(|frame| frame.render_widget(&mut self, frame.area()))?;
+            a11y.update(self.build_tree());
+
+            for request in a11y.actions().collect::<Vec<_>>() {
+                self.handle_action(&request);
+            }
+
+            if event::poll(std::time::Duration::from_millis(50))?
+                && let Some(key) = event::read()?.as_key_press_event()
+            {
+                self.handle_key(key);
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => self.should_exit = true,
+            KeyCode::Char('h') | KeyCode::Left => self.todo_list.state.select(None),
+            KeyCode::Char('j') | KeyCode::Down => self.todo_list.state.select_next(),
+            KeyCode::Char('k') | KeyCode::Up => self.todo_list.state.select_previous(),
+            KeyCode::Char('g') | KeyCode::Home => self.todo_list.state.select_first(),
+            KeyCode::Char('G') | KeyCode::End => self.todo_list.state.select_last(),
+            KeyCode::Char('l') | KeyCode::Right | KeyCode::Enter => self.toggle_status(),
+            _ => {}
+        }
+    }
+
+    /// Applies an action an AT client (e.g. Orca) sent back over AT-SPI.
+    fn handle_action(&mut self, request: &ratatui_a11y::ActionRequest) {
+        let Some(index) = self.item_index_for(request.target_node) else {
+            return;
+        };
+        if request.action == Action::Click {
+            self.todo_list.state.select(Some(index));
+            self.toggle_status();
+        }
+    }
+
+    fn item_index_for(&self, id: NodeId) -> Option<usize> {
+        (0..self.todo_list.items.len()).find(|&i| item_id(i) == id)
+    }
+
+    fn toggle_status(&mut self) {
+        if let Some(i) = self.todo_list.state.selected() {
+            self.todo_list.items[i].status = match self.todo_list.items[i].status {
+                Status::Completed => Status::Todo,
+                Status::Todo => Status::Completed,
+            };
+        }
+    }
+
+    /// Builds this frame's accessibility tree: a window containing the
+    /// list, containing one node per item, plus a static-text node for the
+    /// currently selected item's detail.
+    fn build_tree(&self) -> TreeUpdate {
+        let window_id = node_id("todo-window");
+
+        let mut tree = TreeBuilder::new();
+
+        let labels = self.todo_list.items.iter().map(|item| {
+            format!(
+                "{}, {}",
+                item.todo,
+                match item.status {
+                    Status::Todo => "not done",
+                    Status::Completed => "done",
+                }
+            )
+        });
+        let mut list = list_nodes(labels, self.todo_list.state.selected(), "todo-list");
+        list.add_action_to_children(Action::Click);
+        let list_root = list.root;
+        for (id, node) in list.nodes_mut() {
+            if *id == list_root {
+                node.set_label("Todo items");
+            }
+        }
+        let selected_item = list.selected;
+        let list_id = tree.subtree(list);
+
+        let info = match self.todo_list.state.selected() {
+            Some(i) => self.todo_list.items[i].info.clone(),
+            None => "Nothing selected".to_string(),
+        };
+        let info_id = tree.subtree(text_nodes(info, "todo-info"));
+
+        tree.node(
+            window_id,
+            Role::Window,
+            "Ratatui Todo List",
+            [list_id, info_id],
+        );
+        tree.root(window_id);
+        tree.focus(selected_item.unwrap_or(list_id));
+
+        tree.build()
+    }
+}
+
+fn item_id(index: usize) -> NodeId {
+    node_id((&"todo-list", index))
+}
+
+impl Widget for &mut App {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let main_layout = Layout::vertical([
+            Constraint::Length(2),
+            Constraint::Fill(1),
+            Constraint::Length(1),
+        ]);
+        let [header_area, content_area, footer_area] = area.layout(&main_layout);
+
+        let content_layout = Layout::vertical([Constraint::Fill(1), Constraint::Fill(1)]);
+        let [list_area, item_area] = content_area.layout(&content_layout);
+
+        App::render_header(header_area, buf);
+        App::render_footer(footer_area, buf);
+        self.render_list(list_area, buf);
+        self.render_selected_item(item_area, buf);
+    }
+}
+
+impl App {
+    fn render_header(area: Rect, buf: &mut Buffer) {
+        Paragraph::new("Ratatui Todo List Example (accessible)")
+            .bold()
+            .centered()
+            .render(area, buf);
+    }
+
+    fn render_footer(area: Rect, buf: &mut Buffer) {
+        Paragraph::new("Use ↓↑ to move, ← to unselect, → to change status, g/G to go top/bottom.")
+            .centered()
+            .render(area, buf);
+    }
+
+    fn render_list(&mut self, area: Rect, buf: &mut Buffer) {
+        let block = Block::new()
+            .title(Line::raw("TODO List").centered())
+            .borders(Borders::TOP)
+            .border_set(symbols::border::EMPTY)
+            .border_style(TODO_HEADER_STYLE)
+            .bg(NORMAL_ROW_BG);
+
+        let items: Vec<ListItem> = self
+            .todo_list
+            .items
+            .iter()
+            .enumerate()
+            .map(|(i, todo_item)| {
+                let bg = if i.is_multiple_of(2) {
+                    NORMAL_ROW_BG
+                } else {
+                    ALT_ROW_BG_COLOR
+                };
+                let line = match todo_item.status {
+                    Status::Todo => Line::styled(format!(" ☐ {}", todo_item.todo), TEXT_FG_COLOR),
+                    Status::Completed => {
+                        Line::styled(format!(" ✓ {}", todo_item.todo), COMPLETED_TEXT_FG_COLOR)
+                    }
+                };
+                ListItem::new(line).bg(bg)
+            })
+            .collect();
+
+        let list = List::new(items)
+            .block(block)
+            .highlight_style(SELECTED_STYLE)
+            .highlight_symbol(">")
+            .highlight_spacing(HighlightSpacing::Always);
+
+        StatefulWidget::render(list, area, buf, &mut self.todo_list.state);
+    }
+
+    fn render_selected_item(&self, area: Rect, buf: &mut Buffer) {
+        let info = match self.todo_list.state.selected() {
+            Some(i) => match self.todo_list.items[i].status {
+                Status::Completed => format!("✓ DONE: {}", self.todo_list.items[i].info),
+                Status::Todo => format!("☐ TODO: {}", self.todo_list.items[i].info),
+            },
+            None => "Nothing selected...".to_string(),
+        };
+
+        let block = Block::new()
+            .title(Line::raw("TODO Info").centered())
+            .borders(Borders::TOP)
+            .border_set(symbols::border::EMPTY)
+            .border_style(TODO_HEADER_STYLE)
+            .bg(NORMAL_ROW_BG)
+            .padding(Padding::horizontal(1));
+
+        Paragraph::new(info)
+            .block(block)
+            .fg(TEXT_FG_COLOR)
+            .wrap(Wrap { trim: false })
+            .render(area, buf);
+    }
+}

--- a/ratatui-a11y/src/accessible.rs
+++ b/ratatui-a11y/src/accessible.rs
@@ -1,0 +1,43 @@
+use accesskit::NodeId;
+
+use crate::subtree::SubTree;
+
+/// Opt-in extension point for a stateless widget to describe its own
+/// accessibility subtree.
+///
+/// Implement this for your own widget type (or, if you're a widget crate,
+/// behind a feature flag so `ratatui-a11y` stays optional for your users)
+/// and build the returned [`SubTree`] with the adapter functions in this
+/// crate (`list_nodes`, `table_nodes`, ...).
+///
+/// ```
+/// use ratatui_a11y::{Accessible, NodeId, SubTree, list_nodes};
+///
+/// struct Menu {
+///     items: Vec<String>,
+///     selected: Option<usize>,
+/// }
+///
+/// impl Accessible for Menu {
+///     fn a11y_nodes(&self, id: NodeId) -> SubTree {
+///         let _ = id; // menu roots itself; nothing to nest it under here
+///         list_nodes(&self.items, self.selected, "menu")
+///     }
+/// }
+/// ```
+pub trait Accessible {
+    /// Builds this widget's subtree. `id` is a caller-chosen key for this
+    /// instance, fold it into any ids you derive so two instances of the
+    /// same widget type don't collide.
+    fn a11y_nodes(&self, id: NodeId) -> SubTree;
+}
+
+/// Same as [`Accessible`], for widgets whose accessible state lives in a
+/// separate `State` type (mirrors Ratatui's `StatefulWidget` split).
+pub trait StatefulAccessible {
+    /// The state type this widget reads from (e.g. a selection index).
+    type State;
+
+    /// Builds this widget's subtree from `state`. See [`Accessible::a11y_nodes`].
+    fn a11y_nodes(&self, state: &Self::State, id: NodeId) -> SubTree;
+}

--- a/ratatui-a11y/src/adapt.rs
+++ b/ratatui-a11y/src/adapt.rs
@@ -1,0 +1,334 @@
+//! Adapters that turn plain data into a [`SubTree`], with no dependency on
+//! any particular widget type.
+//!
+//! Widget fields in `ratatui-widgets` are private, so these can't take
+//! `&List` or `&Table`. They take the same data you'd already have on hand
+//! to build one: item strings, a selected index. That also means they work
+//! for a hand-rolled widget, or any TUI framework, not just Ratatui's built-ins.
+//!
+//! All of them are pure: no `Rect`, no `Buffer`, no rendering, so they're
+//! testable without a terminal. `key` identifies *this instance* of the
+//! widget; child ids are derived from `key` plus each item's index.
+
+use std::hash::Hash;
+
+use accesskit::{Node, Role};
+
+use crate::id::node_id;
+use crate::subtree::SubTree;
+
+/// Builds a subtree for any flat, selectable collection: `container_role`
+/// wraps one `item_role` node per entry.
+///
+/// This is the general shape behind [`list_nodes`] and [`tabs_nodes`] --
+/// both are just this with the AT-SPI roles for their case already picked.
+/// Reach for it directly for a collection that isn't a list or tabs
+/// (a radio group, a menu, a listbox, ...): `items_nodes(options, selected,
+/// Role::RadioGroup, Role::RadioButton, key)`.
+pub fn items_nodes<I, S>(
+    items: I,
+    selected: Option<usize>,
+    container_role: Role,
+    item_role: Role,
+    key: impl Hash,
+) -> SubTree
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let mut nodes = Vec::new();
+    let mut child_ids = Vec::new();
+    let mut selected_id = None;
+
+    for (i, item) in items.into_iter().enumerate() {
+        let id = node_id((&key, i));
+        let mut node = Node::new(item_role);
+        node.set_label(item.into());
+        let is_selected = selected == Some(i);
+        node.set_selected(is_selected);
+        if is_selected {
+            selected_id = Some(id);
+        }
+        child_ids.push(id);
+        nodes.push((id, node));
+    }
+
+    let root = node_id(&key);
+    let mut root_node = Node::new(container_role);
+    root_node.set_children(child_ids);
+    nodes.push((root, root_node));
+
+    let mut sub = SubTree::new(root, nodes);
+    sub.selected = selected_id;
+    sub
+}
+
+/// Builds an unlabeled `List` subtree, one `ListItem` per entry.
+/// Wrap it in [`group_nodes`] to give the list itself a name.
+pub fn list_nodes<I, S>(items: I, selected: Option<usize>, key: impl Hash) -> SubTree
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    items_nodes(items, selected, Role::List, Role::ListItem, key)
+}
+
+/// Builds `Table` subtree: an optional header row, then one `Row` of `Cell`s per data row.
+///
+/// A selected cell needs both `selected_row` and `selected_col`; a selected
+/// row with `selected_col: None` marks the whole row selected instead.
+pub fn table_nodes<H, R, C, S>(
+    header: Option<H>,
+    rows: R,
+    selected_row: Option<usize>,
+    selected_col: Option<usize>,
+    key: impl Hash,
+) -> SubTree
+where
+    H: IntoIterator<Item = S>,
+    R: IntoIterator<Item = C>,
+    C: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let mut nodes = Vec::new();
+    let mut row_ids = Vec::new();
+    let mut selected_id = None;
+
+    if let Some(header) = header {
+        let header_id = node_id((&key, "header"));
+        let mut cell_ids = Vec::new();
+        for (c, cell) in header.into_iter().enumerate() {
+            let id = node_id((&key, "header-cell", c));
+            let mut node = Node::new(Role::ColumnHeader);
+            node.set_label(cell.into());
+            cell_ids.push(id);
+            nodes.push((id, node));
+        }
+        let mut header_node = Node::new(Role::Row);
+        header_node.set_children(cell_ids);
+        nodes.push((header_id, header_node));
+        row_ids.push(header_id);
+    }
+
+    for (r, row) in rows.into_iter().enumerate() {
+        let row_id = node_id((&key, "row", r));
+        let mut cell_ids = Vec::new();
+        let mut row_selected = false;
+        for (c, cell) in row.into_iter().enumerate() {
+            let id = node_id((&key, "cell", r, c));
+            let mut node = Node::new(Role::Cell);
+            let is_selected = selected_row == Some(r) && selected_col == Some(c);
+            node.set_label(cell.into());
+            node.set_selected(is_selected);
+            if is_selected {
+                selected_id = Some(id);
+                row_selected = true;
+            }
+            cell_ids.push(id);
+            nodes.push((id, node));
+        }
+        let mut row_node = Node::new(Role::Row);
+        row_node.set_children(cell_ids);
+        nodes.push((row_id, row_node));
+        // No column picked out => the whole row is the selection.
+        if !row_selected && selected_row == Some(r) && selected_col.is_none() {
+            selected_id = Some(row_id);
+        }
+        row_ids.push(row_id);
+    }
+
+    let root = node_id(&key);
+    let mut root_node = Node::new(Role::Table);
+    root_node.set_children(row_ids);
+    nodes.push((root, root_node));
+
+    let mut sub = SubTree::new(root, nodes);
+    sub.selected = selected_id;
+    sub
+}
+
+/// Builds a `TabList` subtree, one `Tab` per title.
+pub fn tabs_nodes<I, S>(titles: I, selected: Option<usize>, key: impl Hash) -> SubTree
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    items_nodes(titles, selected, Role::TabList, Role::Tab, key)
+}
+
+/// Builds a single `ProgressIndicator` node. `ratio` is clamped to `0.0..=1.0` and reported as
+/// `0..=100`.
+pub fn gauge_nodes(label: Option<impl Into<String>>, ratio: f64, key: impl Hash) -> SubTree {
+    let id = node_id(&key);
+    let mut node = Node::new(Role::ProgressIndicator);
+    if let Some(label) = label {
+        node.set_label(label.into());
+    }
+    let percent = ratio.clamp(0.0, 1.0) * 100.0;
+    node.set_numeric_value(percent);
+    node.set_min_numeric_value(0.0);
+    node.set_max_numeric_value(100.0);
+    SubTree::new(id, vec![(id, node)])
+}
+
+/// Builds a single `Paragraph` node from source text. Pass the source string,
+/// not a reflowed/wrapped render of it a screen reader does its own line breaking.
+pub fn text_nodes(text: impl Into<String>, key: impl Hash) -> SubTree {
+    let id = node_id(&key);
+    let mut node = Node::new(Role::Paragraph);
+    node.set_label(text.into());
+    SubTree::new(id, vec![(id, node)])
+}
+
+/// Wraps child subtrees in a single labeled `Group` node, the way to
+/// attach a name to a [`list_nodes`]/[`table_nodes`]/[`tabs_nodes`] result,
+/// or to bundle several widgets under one heading.
+pub fn group_nodes<I>(label: impl Into<String>, children: I, key: impl Hash) -> SubTree
+where
+    I: IntoIterator<Item = SubTree>,
+{
+    let root = node_id(&key);
+    let mut nodes = Vec::new();
+    let mut child_ids = Vec::new();
+    let mut selected_id = None;
+
+    for child in children {
+        child_ids.push(child.root);
+        if child.selected.is_some() {
+            selected_id = child.selected;
+        }
+        nodes.extend(child.into_nodes());
+    }
+
+    let mut root_node = Node::new(Role::Group);
+    root_node.set_label(label.into());
+    root_node.set_children(child_ids);
+    nodes.push((root, root_node));
+
+    let mut sub = SubTree::new(root, nodes);
+    sub.selected = selected_id;
+    sub
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_nodes_labels_and_selection() {
+        let sub = list_nodes(["a", "b", "c"], Some(1), "k");
+        let nodes = &sub.into_nodes();
+        assert_eq!(nodes.len(), 4);
+        let root = nodes.iter().find(|(id, _)| *id == sub_root(nodes)).unwrap();
+        assert_eq!(root.1.role(), Role::List);
+    }
+
+    fn sub_root(nodes: &[(accesskit::NodeId, Node)]) -> accesskit::NodeId {
+        nodes
+            .iter()
+            .find(|(_, n)| n.role() == Role::List)
+            .unwrap()
+            .0
+    }
+
+    #[test]
+    fn list_nodes_selected_id_matches_selected_index() {
+        let sub = list_nodes(["a", "b"], Some(1), "k");
+        let expected = node_id((&"k", 1usize));
+        assert_eq!(sub.selected, Some(expected));
+    }
+
+    #[test]
+    fn list_nodes_no_selection() {
+        let sub = list_nodes(["a", "b"], None, "k");
+        assert_eq!(sub.selected, None);
+    }
+
+    #[test]
+    fn ids_stable_across_two_calls() {
+        let a = list_nodes(["a", "b"], Some(0), "same-key");
+        let b = list_nodes(["a", "b"], Some(0), "same-key");
+        assert_eq!(a.root, b.root);
+        assert_eq!(a.selected, b.selected);
+    }
+
+    #[test]
+    fn different_key_different_ids() {
+        let a = list_nodes(["a"], None, "k1");
+        let b = list_nodes(["a"], None, "k2");
+        assert_ne!(a.root, b.root);
+    }
+
+    #[test]
+    fn table_nodes_header_becomes_column_header() {
+        let sub = table_nodes(
+            Some(["Name", "Status"]),
+            [["a", "todo"], ["b", "done"]],
+            None,
+            None,
+            "t",
+        );
+        let nodes = sub.into_nodes();
+        // 2 header cells + 1 header row + (2 rows * 2 cells) + 2 row nodes + 1 root.
+        assert_eq!(nodes.len(), 2 + 1 + 4 + 2 + 1);
+        assert!(
+            nodes
+                .iter()
+                .any(|(_, n)| n.role() == Role::ColumnHeader && n.label() == Some("Name"))
+        );
+    }
+
+    #[test]
+    fn table_nodes_cell_selection() {
+        let sub = table_nodes(
+            None::<[&str; 0]>,
+            [["a", "b"], ["c", "d"]],
+            Some(1),
+            Some(0),
+            "t",
+        );
+        assert_eq!(sub.selected, Some(node_id((&"t", "cell", 1usize, 0usize))));
+    }
+
+    #[test]
+    fn table_nodes_whole_row_selection() {
+        let sub = table_nodes(None::<[&str; 0]>, [["a", "b"]], Some(0), None, "t");
+        assert_eq!(sub.selected, Some(node_id((&"t", "row", 0usize))));
+    }
+
+    #[test]
+    fn tabs_nodes_selection() {
+        let sub = tabs_nodes(["one", "two"], Some(0), "tabs");
+        assert_eq!(sub.selected, Some(node_id((&"tabs", 0usize))));
+    }
+
+    #[test]
+    fn gauge_nodes_clamps_ratio() {
+        let sub = gauge_nodes(Some("progress"), 1.5, "g");
+        let (_, node) = &sub.into_nodes()[0];
+        assert_eq!(node.numeric_value(), Some(100.0));
+    }
+
+    #[test]
+    fn gauge_nodes_negative_ratio_clamped_to_zero() {
+        let sub = gauge_nodes(Some("progress"), -0.5, "g");
+        let (_, node) = &sub.into_nodes()[0];
+        assert_eq!(node.numeric_value(), Some(0.0));
+    }
+
+    #[test]
+    fn text_nodes_single_node() {
+        let sub = text_nodes("hello", "t");
+        assert_eq!(sub.into_nodes().len(), 1);
+    }
+
+    #[test]
+    fn group_nodes_wraps_children_and_forwards_selection() {
+        let list = list_nodes(["a", "b"], Some(0), "list-key");
+        let expected_selected = list.selected;
+        let group = group_nodes("My list", [list], "group-key");
+        assert_eq!(group.selected, expected_selected);
+        let nodes = group.into_nodes();
+        assert!(nodes.iter().any(|(_, n)| n.role() == Role::Group));
+    }
+}

--- a/ratatui-a11y/src/adapter.rs
+++ b/ratatui-a11y/src/adapter.rs
@@ -1,0 +1,98 @@
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Arc, Mutex, PoisonError};
+
+use accesskit::{ActionHandler, ActionRequest, ActivationHandler, DeactivationHandler, TreeUpdate};
+use accesskit_unix::Adapter;
+
+/// Wires a Ratatui app into the Linux AT-SPI accessibility bus.
+///
+/// See the crate docs for the `IsEnabled` gotcha: creating this does
+/// nothing observable unless the desktop has accessibility turned on.
+pub struct A11y {
+    adapter: Adapter,
+    last_tree: Arc<Mutex<TreeUpdate>>,
+    actions: Receiver<ActionRequest>,
+}
+
+impl A11y {
+    /// Creates the adapter with an initial tree. `initial` is what's served
+    /// to AT clients that connect before the app's first [`Self::update`]
+    /// call, so it should be a real, complete tree rather than a
+    /// placeholder.
+    pub fn new(initial: TreeUpdate) -> Self {
+        let last_tree = Arc::new(Mutex::new(initial));
+        let (tx, rx) = mpsc::channel();
+
+        let adapter = Adapter::new(
+            Activation {
+                tree: Arc::clone(&last_tree),
+            },
+            Actions { tx },
+            Deactivation,
+        );
+
+        Self {
+            adapter,
+            last_tree,
+            actions: rx,
+        }
+    }
+
+    /// Pushes a new tree snapshot. Call this after every render.
+    /// This does no work at all when no AT client is attached: the closure that would
+    /// clone and stash `tree` only runs if the platform side is actually listening.
+    pub fn update(&mut self, tree: TreeUpdate) {
+        let last_tree = Arc::clone(&self.last_tree);
+        self.adapter.update_if_active(move || {
+            *lock(&last_tree) = tree.clone();
+            tree
+        });
+    }
+
+    /// Tells the platform side whether the app currently holds terminal
+    /// focus. Drive this from your backend's focus-gained/focus-lost events.
+    pub fn set_focused(&mut self, is_focused: bool) {
+        self.adapter.update_window_focus_state(is_focused);
+    }
+
+    /// Drains any actions AT clients have requested since the last poll.
+    /// Call this once per event-loop iteration; it never blocks.
+    pub fn actions(&self) -> impl Iterator<Item = ActionRequest> + '_ {
+        self.actions.try_iter()
+    }
+}
+
+/// A poisoned lock here just means a prior update panicked mid-write; the
+/// stale-but-valid tree underneath is still fine to read or overwrite, so
+/// recover instead of taking the whole app down over an accessibility
+/// side-channel.
+fn lock(tree: &Mutex<TreeUpdate>) -> std::sync::MutexGuard<'_, TreeUpdate> {
+    tree.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+struct Activation {
+    tree: Arc<Mutex<TreeUpdate>>,
+}
+
+impl ActivationHandler for Activation {
+    fn request_initial_tree(&mut self) -> Option<TreeUpdate> {
+        Some(lock(&self.tree).clone())
+    }
+}
+
+struct Actions {
+    tx: Sender<ActionRequest>,
+}
+
+impl ActionHandler for Actions {
+    fn do_action(&mut self, request: ActionRequest) {
+        // The receiver may already be gone at shutdown; nothing to do about that.
+        let _ = self.tx.send(request);
+    }
+}
+
+struct Deactivation;
+
+impl DeactivationHandler for Deactivation {
+    fn deactivate_accessibility(&mut self) {}
+}

--- a/ratatui-a11y/src/adapter.rs
+++ b/ratatui-a11y/src/adapter.rs
@@ -96,3 +96,46 @@ struct Deactivation;
 impl DeactivationHandler for Deactivation {
     fn deactivate_accessibility(&mut self) {}
 }
+
+#[cfg(test)]
+mod tests {
+    use accesskit::{Node, NodeId, Role, Tree, TreeId};
+
+    use super::*;
+
+    fn dummy_tree() -> TreeUpdate {
+        let id = NodeId(1);
+        TreeUpdate {
+            nodes: vec![(id, Node::new(Role::Window))],
+            tree: Some(Tree::new(id)),
+            tree_id: TreeId::ROOT,
+            focus: id,
+        }
+    }
+
+    // No AT client is the common case `Adapter::new` is documented to degrade silently
+    // rather than error or block, so none of this should panic or hang.
+    #[test]
+    fn new_update_focus_actions_never_panic() {
+        let mut a11y = A11y::new(dummy_tree());
+        a11y.update(dummy_tree());
+        a11y.set_focused(true);
+        a11y.set_focused(false);
+        assert_eq!(a11y.actions().count(), 0);
+    }
+
+    #[test]
+    fn lock_recovers_from_a_poisoned_mutex() {
+        let mutex = Arc::new(Mutex::new(dummy_tree()));
+        let poison_it = Arc::clone(&mutex);
+        let _ = std::thread::spawn(move || {
+            let _guard = poison_it.lock().unwrap();
+            panic!("poisoning the lock on purpose");
+        })
+        .join();
+
+        assert!(mutex.is_poisoned());
+        let guard = lock(&mutex); // must recover, not panic
+        drop(guard);
+    }
+}

--- a/ratatui-a11y/src/builder.rs
+++ b/ratatui-a11y/src/builder.rs
@@ -1,0 +1,202 @@
+use std::collections::HashSet;
+
+use accesskit::{Node, NodeId, Role, Tree, TreeId, TreeUpdate};
+
+use crate::id::node_id;
+use crate::subtree::SubTree;
+
+/// Builds a [`TreeUpdate`] by hand, one frame at a time.
+///
+/// Ratatui has no retained widget tree to derive an accessibility tree
+/// from (see the crate docs), so the app declares one explicitly, alongside
+/// its normal rendering code. Build bottom-up: create child nodes first so
+/// you have their ids on hand when you create the parent.
+///
+/// ```
+/// use ratatui_a11y::{Role, TreeBuilder, node_id};
+///
+/// let window_id = node_id("window");
+/// let item_id = node_id(("item", 0));
+///
+/// let mut tree = TreeBuilder::new();
+/// tree.node(item_id, Role::ListItem, "First item", []);
+/// tree.node(window_id, Role::Window, "My app", [item_id]);
+/// tree.root(window_id);
+/// tree.focus(window_id);
+/// let update = tree.build();
+/// ```
+#[derive(Debug, Default)]
+pub struct TreeBuilder {
+    nodes: Vec<(NodeId, Node)>,
+    root: Option<NodeId>,
+    focus: Option<NodeId>,
+}
+
+impl TreeBuilder {
+    /// Creates an empty builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a node with the given role, label, and children, returning it
+    /// for further configuration.
+    pub fn node(
+        &mut self,
+        id: NodeId,
+        role: Role,
+        label: impl Into<String>,
+        children: impl IntoIterator<Item = NodeId>,
+    ) -> &mut Node {
+        let mut node = Node::new(role);
+        node.set_label(label.into());
+        let children: Vec<NodeId> = children.into_iter().collect();
+        if !children.is_empty() {
+            node.set_children(children);
+        }
+        self.nodes.push((id, node));
+        &mut self.nodes.last_mut().expect("just pushed").1
+    }
+
+    /// Merges a pre-built subtree into this builder and returns its root id,
+    /// ready to use as a child elsewhere.
+    pub fn subtree(&mut self, sub: SubTree) -> NodeId {
+        let root = sub.root;
+        self.nodes.extend(sub.into_nodes());
+        root
+    }
+
+    /// Sets the tree's root node. Required before [`Self::build`].
+    pub const fn root(&mut self, id: NodeId) -> &mut Self {
+        self.root = Some(id);
+        self
+    }
+
+    /// Sets the currently focused node. Defaults to the root if unset.
+    pub const fn focus(&mut self, id: NodeId) -> &mut Self {
+        self.focus = Some(id);
+        self
+    }
+
+    /// Builds the [`TreeUpdate`].
+    ///
+    /// Forgetting to call [`Self::root`] never crashes the app: it serves
+    /// an empty placeholder root instead. In debug builds this also runs a
+    /// couple of `debug_assert!` checks duplicate node ids, and a focus
+    /// id absent from this update both of which desync AT clients if
+    /// shipped, so they're worth catching early in development.
+    pub fn build(self) -> TreeUpdate {
+        let mut nodes = self.nodes;
+        let root = self.root.unwrap_or_else(|| {
+            let id = node_id("ratatui-a11y:missing-root");
+            nodes.push((id, Node::new(Role::Unknown)));
+            id
+        });
+        let focus = self.focus.unwrap_or(root);
+
+        #[cfg(debug_assertions)]
+        {
+            let mut seen = HashSet::with_capacity(nodes.len());
+            for (id, _) in &nodes {
+                debug_assert!(seen.insert(*id), "duplicate NodeId in TreeBuilder: {id:?}");
+            }
+            debug_assert!(
+                focus == root || nodes.iter().any(|(id, _)| *id == focus),
+                "TreeBuilder::focus set to a node not present in this update: {focus:?}"
+            );
+        }
+
+        TreeUpdate {
+            nodes,
+            tree: Some(Tree::new(root)),
+            tree_id: TreeId::ROOT,
+            focus,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use accesskit::Action;
+
+    use super::*;
+
+    #[test]
+    fn focus_defaults_to_root() {
+        let root = node_id("root");
+        let mut tree = TreeBuilder::new();
+        tree.node(root, Role::Window, "w", []);
+        tree.root(root);
+        let update = tree.build();
+        assert_eq!(update.focus, root);
+    }
+
+    #[test]
+    fn explicit_focus_wins() {
+        let root = node_id("root");
+        let item = node_id("item");
+        let mut tree = TreeBuilder::new();
+        tree.node(item, Role::ListItem, "i", []);
+        tree.node(root, Role::Window, "w", [item]);
+        tree.root(root);
+        tree.focus(item);
+        let update = tree.build();
+        assert_eq!(update.focus, item);
+    }
+
+    #[test]
+    fn missing_root_does_not_panic() {
+        let update = TreeBuilder::new().build();
+        assert!(update.nodes.iter().any(|(id, _)| *id == update.focus));
+    }
+
+    #[test]
+    fn subtree_merges_nodes_and_returns_root() {
+        let mut sub_nodes = Vec::new();
+        let child = node_id("child");
+        sub_nodes.push((child, Node::new(Role::ListItem)));
+        let sub_root = node_id("sub-root");
+        sub_nodes.push((sub_root, Node::new(Role::List)));
+        let sub = SubTree::new(sub_root, sub_nodes);
+
+        let mut tree = TreeBuilder::new();
+        let returned_root = tree.subtree(sub);
+        assert_eq!(returned_root, sub_root);
+        tree.root(sub_root);
+        let update = tree.build();
+        assert_eq!(update.nodes.len(), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate NodeId")]
+    fn debug_validator_catches_duplicate_ids() {
+        let id = node_id("dup");
+        let mut tree = TreeBuilder::new();
+        tree.node(id, Role::Window, "a", []);
+        tree.node(id, Role::Window, "b", []);
+        tree.root(id);
+        tree.build();
+    }
+
+    #[test]
+    #[should_panic(expected = "not present in this update")]
+    fn debug_validator_catches_dangling_focus() {
+        let root = node_id("root");
+        let ghost = node_id("ghost");
+        let mut tree = TreeBuilder::new();
+        tree.node(root, Role::Window, "w", []);
+        tree.root(root);
+        tree.focus(ghost);
+        tree.build();
+    }
+
+    #[test]
+    fn action_survives_build() {
+        let root = node_id("root");
+        let mut tree = TreeBuilder::new();
+        tree.node(root, Role::Button, "b", [])
+            .add_action(Action::Click);
+        tree.root(root);
+        let update = tree.build();
+        assert!(update.nodes[0].1.supports_action(Action::Click));
+    }
+}

--- a/ratatui-a11y/src/id.rs
+++ b/ratatui-a11y/src/id.rs
@@ -1,0 +1,40 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use accesskit::NodeId;
+
+/// Derives a stable [`NodeId`] from an app-chosen key.
+///
+/// Ratatui redraws immediate-mode every frame, so nothing about a widget's
+/// screen position is stable across frames. Accessibility clients rely on node
+/// identity being stable across updates, for focus tracking and tree diffing,
+/// so derive the id from something that identifies the underlying item.
+pub fn node_id(key: impl Hash) -> NodeId {
+    let mut hasher = DefaultHasher::new();
+    key.hash(&mut hasher);
+    NodeId(hasher.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_key_same_id() {
+        assert_eq!(node_id("todo-item"), node_id("todo-item"));
+        assert_eq!(node_id(("todo-item", 3)), node_id(("todo-item", 3)));
+    }
+
+    #[test]
+    fn different_key_different_id() {
+        assert_ne!(node_id("a"), node_id("b"));
+        assert_ne!(node_id(("todo-item", 1)), node_id(("todo-item", 2)));
+        assert_ne!(node_id("todo-item"), node_id(("todo-item", 0)));
+    }
+
+    #[test]
+    fn stable_across_calls_regardless_of_hasher_state() {
+        let ids: Vec<_> = (0..5).map(|_| node_id("stable")).collect();
+        assert!(ids.windows(2).all(|w| w[0] == w[1]));
+    }
+}

--- a/ratatui-a11y/src/lib.rs
+++ b/ratatui-a11y/src/lib.rs
@@ -1,0 +1,57 @@
+//! Experimental Linux accessibility support for Ratatui, via [AT-SPI] and
+//! [AccessKit].
+//!
+//! Ratatui renders characters at cell positions; it has no concept of
+//! focus, selection, or semantic roles, and no retained widget tree to
+//! derive them from. This crate doesn't try to infer any of that from the
+//! rendered [`Buffer`](ratatui::buffer::Buffer). Instead, the app declares
+//! a small, separate accessibility tree by hand see [`TreeBuilder`] and this
+//! crate serves it over AT-SPI via [`A11y`].
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use ratatui_a11y::{A11y, Role, TreeBuilder, node_id};
+//!
+//! let window_id = node_id("window");
+//! let mut tree = TreeBuilder::new();
+//! tree.node(window_id, Role::Window, "My app", []);
+//! tree.root(window_id);
+//!
+//! let mut a11y = A11y::new(tree.build());
+//!
+//! // ...in your render loop, after every draw:
+//! let mut tree = TreeBuilder::new();
+//! tree.node(window_id, Role::Window, "My app", []);
+//! tree.root(window_id);
+//! a11y.update(tree.build());
+//! ```
+//!
+//! # The `IsEnabled` gotcha
+//!
+//! [`A11y::new`] only actually registers on the AT-SPI bus once the desktop
+//! reports `org.a11y.Status.IsEnabled = true` which happens  automatically
+//! once a screen reader like Orca is running, but is otherwise off by default
+//! on most Linux desktops. There is no error and no log line when it's off:
+//! [`A11y::update`] just quietly does nothing.
+//! first:
+//!
+//! ```sh
+//! gsettings set org.gnome.desktop.interface toolkit-accessibility true
+
+mod accessible;
+mod adapt;
+mod adapter;
+mod builder;
+mod id;
+mod subtree;
+
+pub use accessible::{Accessible, StatefulAccessible};
+pub use accesskit::{Action, ActionRequest, Node, NodeId, Role, Tree, TreeId, TreeUpdate};
+pub use adapt::{
+    gauge_nodes, group_nodes, items_nodes, list_nodes, table_nodes, tabs_nodes, text_nodes,
+};
+pub use adapter::A11y;
+pub use builder::TreeBuilder;
+pub use id::node_id;
+pub use subtree::SubTree;

--- a/ratatui-a11y/src/subtree.rs
+++ b/ratatui-a11y/src/subtree.rs
@@ -1,0 +1,56 @@
+use accesskit::{Action, Node, NodeId};
+
+/// A self-contained chunk of accessibility nodes, produced by one of the
+/// adapter functions (`list_nodes`, `table_nodes`, ...) and merged into a
+/// [`TreeBuilder`](crate::TreeBuilder) with [`TreeBuilder::subtree`].
+///
+/// Adapters build these from plain data (strings, indices), not from
+/// Ratatui widgets, so they have no idea what your app wants to happen when
+/// an AT client activates a node -- see [`Self::add_action_to_children`] to
+/// opt in.
+#[derive(Debug)]
+pub struct SubTree {
+    /// The node other parents should link to (and pass to
+    /// `TreeBuilder::focus`, via [`Self::selected`]).
+    pub root: NodeId,
+    /// The child node currently marked selected, if any. Callers building a
+    /// selectable widget should generally pass this to
+    /// `TreeBuilder::focus` so the AT client's focus follows the app's
+    /// selection.
+    pub selected: Option<NodeId>,
+    nodes: Vec<(NodeId, Node)>,
+}
+
+impl SubTree {
+    pub(crate) const fn new(root: NodeId, nodes: Vec<(NodeId, Node)>) -> Self {
+        Self {
+            root,
+            selected: None,
+            nodes,
+        }
+    }
+
+    pub(crate) fn into_nodes(self) -> Vec<(NodeId, Node)> {
+        self.nodes
+    }
+
+    /// Direct access to every node in this subtree (root included), for
+    /// tweaks the adapter didn't anticipate.
+    pub fn nodes_mut(&mut self) -> &mut [(NodeId, Node)] {
+        &mut self.nodes
+    }
+
+    /// Advertises `action` on every child node (root excluded) so an AT
+    /// client can invoke it. Adapters never do this on their own, an
+    /// action with no handler behind it is a broken control for a screen
+    /// reader user, so only add one you actually handle in
+    /// [`A11y::actions`](crate::A11y::actions).
+    pub fn add_action_to_children(&mut self, action: Action) -> &mut Self {
+        for (id, node) in &mut self.nodes {
+            if *id != self.root {
+                node.add_action(action);
+            }
+        }
+        self
+    }
+}

--- a/ratatui-a11y/src/subtree.rs
+++ b/ratatui-a11y/src/subtree.rs
@@ -54,3 +54,56 @@ impl SubTree {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use accesskit::Role;
+
+    use super::*;
+    use crate::id::node_id;
+
+    fn two_node_subtree() -> SubTree {
+        let root = node_id("root");
+        let child = node_id("child");
+        SubTree::new(
+            root,
+            vec![
+                (root, Node::new(Role::List)),
+                (child, Node::new(Role::ListItem)),
+            ],
+        )
+    }
+
+    #[test]
+    fn nodes_mut_exposes_every_node_including_root() {
+        let mut sub = two_node_subtree();
+        assert_eq!(sub.nodes_mut().len(), 2);
+        for (_, node) in sub.nodes_mut() {
+            node.set_label("tweaked");
+        }
+        assert!(
+            sub.into_nodes()
+                .iter()
+                .all(|(_, n)| n.label() == Some("tweaked"))
+        );
+    }
+
+    #[test]
+    fn add_action_to_children_skips_root() {
+        let mut sub = two_node_subtree();
+        let root = sub.root;
+        sub.add_action_to_children(Action::Click);
+
+        let nodes = sub.into_nodes();
+        let root_node = &nodes.iter().find(|(id, _)| *id == root).unwrap().1;
+        let child_node = &nodes.iter().find(|(id, _)| *id != root).unwrap().1;
+        assert!(!root_node.supports_action(Action::Click));
+        assert!(child_node.supports_action(Action::Click));
+    }
+
+    #[test]
+    fn new_starts_with_no_selection() {
+        let sub = two_node_subtree();
+        assert_eq!(sub.selected, None);
+    }
+}


### PR DESCRIPTION
## What

Adds `ratatui-a11y`: an opt-in, Linux-only crate that serves an app-declared accessibility tree to AT-SPI clients (screen readers like Orca) via AccessKit.
See #2610 for the background discussion.

## Why this shape

- Ratatui is immediate-mode, no retained widget tree, nothing can infer semantics from the rendered `Buffer` (cells only). The app declares the tree explicitly, alongside its normal render code.
- AT-SPI needs no OS window handle (unlike Windows UIA / macOS NSAccessibility, which both need a real window a terminal app doesn't have) -- that's why this PR is Linux-only.
- Adapters (`list_nodes`, `table_nodes`, `tabs_nodes`, `gauge_nodes`, `text_nodes`, `group_nodes`, `items_nodes`) take plain data, not widget references `ratatui-widgets` fields are private, and this also means the crate works with any hand-rolled widget or TUI framework, not just Ratatui's built-ins.
- `ratatui-a11y` has zero dependency on `ratatui` outside dev-deps.

## What this PR does NOT touch

- No changes to `ratatui`, `ratatui-widgets`, or `ratatui-core`.
- Excluded from `default-members` (see `Cargo.toml`), same as `ratatui-termion` -- `cargo build`/`cargo test` at the repo root are unaffected on every platform.
- Windows/macOS are not attempted here (see crate docs for why).

## Try it

```sh
gsettings set org.gnome.desktop.interface toolkit-accessibility true  # if needed
cargo run -p ratatui-a11y --example list       # full focus/selection round trip
cargo run -p ratatui-a11y --example dashboard  # tabs + table + gauge composed
```

Verified with Orca 46.1: auto-discovers the app, announces role + label + state, tracks live selection.

## Testing

- Unit tests: `cargo test -p ratatui-a11y`
- Doc tests included
- Manual: Orca screen reader against all three examples

## AI disclosure

Used AI for generating comments and Docs.