### PR TITLE
fix(rect): empty Rect never intersects

### DIFF
--- a/ratatui-core/src/layout/rect.rs
+++ b/ratatui-core/src/layout/rect.rs
@@ -333,8 +333,13 @@ impl Rect {
     }
 
     /// Returns true if the two `Rect`s intersect.
+    ///
+    /// An empty `Rect` covers no cells, so it never intersects, not even with itself. This matches
+    /// [`Rect::intersection`], which returns an empty `Rect` for the same pair.
     pub const fn intersects(self, other: Self) -> bool {
-        self.x < other.right()
+        !self.is_empty()
+            && !other.is_empty()
+            && self.x < other.right()
             && self.right() > other.x
             && self.y < other.bottom()
             && self.bottom() > other.y
@@ -843,6 +848,28 @@ mod tests {
     fn intersects() {
         assert!(Rect::new(1, 2, 3, 4).intersects(Rect::new(2, 3, 4, 5)));
         assert!(!Rect::new(1, 2, 3, 4).intersects(Rect::new(5, 6, 7, 8)));
+    }
+
+    /// An empty `Rect` covers no cells, so it cannot intersect anything.
+    #[rstest]
+    #[case::empty_inside(Rect::new(0, 0, 10, 10), Rect::new(5, 5, 0, 0))]
+    #[case::zero_height(Rect::new(0, 0, 1, 2), Rect::new(0, 1, 1, 0))]
+    #[case::zero_width(Rect::new(0, 0, 2, 1), Rect::new(1, 0, 0, 1))]
+    #[case::both_empty(Rect::new(3, 3, 0, 0), Rect::new(3, 3, 0, 0))]
+    fn intersects_empty(#[case] rect0: Rect, #[case] rect1: Rect) {
+        assert!(!rect0.intersects(rect1));
+        assert!(!rect1.intersects(rect0));
+        assert!(rect0.intersection(rect1).is_empty());
+    }
+
+    /// A one cell `Rect` is not empty, so it still intersects.
+    #[rstest]
+    #[case::single_cell_inside(Rect::new(0, 0, 10, 10), Rect::new(5, 5, 1, 1))]
+    #[case::single_cell_overlap(Rect::new(1, 2, 1, 1), Rect::new(1, 2, 1, 1))]
+    fn intersects_single_cell(#[case] rect0: Rect, #[case] rect1: Rect) {
+        assert!(rect0.intersects(rect1));
+        assert!(rect1.intersects(rect0));
+        assert!(!rect0.intersection(rect1).is_empty());
     }
 
     #[rstest]


### PR DESCRIPTION
## Problem

`Rect::intersects` reports `true` for pairs that share no cells, and contradicts `Rect::intersection` on those same pairs.

The check at `ratatui-core/src/layout/rect.rs:336` uses the pairwise form:

```rust
self.x < other.right() && self.right() > other.x
    && self.y < other.bottom() && self.bottom() > other.y
```

That is equivalent to `max(a.x, b.x) < min(a.right(), b.right())` only when both intervals are non-empty. When `width == 0`, `right() == x`, so a degenerate interval sitting strictly inside the other still satisfies both comparisons on that axis.

Probe on the current `main` (`99168f8`):

```text
Rect { x: 0, y: 0, width: 10, height: 10 } vs Rect { x: 5, y: 5, width:  0, height:  0 }
    -> intersects=true   intersection.is_empty()=true
Rect { x: 0, y: 0, width:  1, height:  2 } vs Rect { x: 0, y: 1, width:  1, height:  0 }
    -> intersects=true   intersection.is_empty()=true
Rect { x: 0, y: 0, width:  2, height:  1 } vs Rect { x: 1, y: 0, width:  0, height:  1 }
    -> intersects=true   intersection.is_empty()=true
```

An empty `Rect` covers no cells, so `intersects` should be `false` there. `Rect::intersection` already agrees: it returns an empty `Rect` for every one of those pairs. `Rect::contains` documents the same half-open convention at `rect.rs:360` ("A `Rect` covers the half-open range `x..right()` by `y..bottom()`"), and `Rect::is_empty` at `rect.rs:196` already defines exactly the predicate needed.

Not every degenerate pair is currently wrong: `Rect::new(3, 3, 0, 0).intersects(Rect::new(3, 3, 0, 0))` is already `false`, because the `self.x < other.right()` comparison short-circuits. That case is included below as a regression pin, not as a witness.

## Why this convention

This does not add API or change any signature. It makes `intersects` agree with the convention you already stated in #1047, when `intersect_opt` was proposed:

> Taking a quick look at the current usage of intersection in the wild, I think we probably shouldn't deprecate this, and perhaps shouldn't have the _opt version at all as a `.is_empty()` check seems like it's good enough. Making users have to specifically handle the empty case differently than just treating it the same as if they'd been passed an empty area is annoying and is inconsistent with other places that return empty rects (e.g. `layout::split()`) where calling `is_empty()` would be idiomatic.

If an empty `Rect` is ratatui's canonical "no area" value and `is_empty()` is the idiomatic check, then `intersects` returning `true` for an area of zero cells is the odd one out.

`git log -L 333,341:ratatui-core/src/layout/rect.rs` shows only three touches to these lines: two mechanical refactors in #974 (`clippy::doc_markdown` and `clippy::use_self`), and #543 `fix(rect): fix arithmetic overflow edge cases`, which rewrote `self.x + other.width` into `other.right()`. The edge cases weighed there were arithmetic overflow; degenerate rects were never ruled on. `is_empty()` had landed three days earlier in #534, "to simplify some common checks".

## Who reaches it

There is no in-repo production caller: the only other `.intersects(` hits in this repo are `Borders::intersects` and `Modifier::intersects`, which are bitflags. The affected callers are downstream, where `intersects` is used as a visibility test before a layout or render decision:

- `thscharler/rat-salsa`, `rat-widget/src/clipper.rs:721` (`locate_area`, documented as "returns None if the given area is outside the buffer"), and `:532` / `:998`
- `xai-org/grok-build`, `crates/codegen/xai-grok-pager/src/app/agent_view/links.rs:78` (`rect_occluded`)

A widget with a zero-height area currently reads as visible, and the follow-up `intersection` then hands back an empty `Rect`.

## Prior art searched

Open and closed issues/PRs for `intersects`, `intersection`, and empty/zero-size rects: #1047 (`intersect_opt`, closed, quoted above), #2124 (visual buffer tests for `Rect` methods), and the 0.21-era overflow panics #249-#252 / #258, all already fixed. Nothing covers the empty-rect case.

## Verification

`cargo test -p ratatui-core --all-features --lib`, with the file `touch`ed before every run and its md5 printed, so no result comes from a cached build:

| run | md5 | result |
| --- | --- | --- |
| `main` unchanged | `4feecbb6a38f180ab274b4c8bf2a1afd` | baseline, 1579 passed |
| new tests on unchanged impl | `5285d8c2618e2debecabda473fc373cf` | **3 failed** (`intersects_empty` cases 1-3) |
| this PR | `372e4586952bee5a28715dbae79a4821` | 1582 passed, 0 failed |
| revert the guards, keep tests | `6df1bff799da55a7d02f725d47c1091d` | 3 failed: `intersects_empty` 1-3 |
| over-correct to `area() > 1` | `1f267b4a6e4a29b2aaa68a3e55ecbf16` | 2 failed: `intersects_single_cell` 1-2 |

The two mutations fail disjoint sets, so the tests pin the behaviour from both sides rather than only forbidding the current result. `intersects` stays `const`; `is_empty` is already a `const fn`.

CI gates run locally:

- `RUSTUP_TOOLCHAIN=nightly cargo fmt --all --check` - exit 0
- `cargo xtask clippy` - exit 0
- `cargo xtask check --all-features` - exit 0
- `cargo xtask test-libs` - exit 0, 46 `test result: ok`, zero failures

Not run: `cargo xtask format --check` completes its nightly rustfmt step but then invokes `tombi`, which I do not have installed; this PR touches no TOML. `cargo-semver-checks` is not installed locally, though the change alters no signature.

## AI disclosure

Per CONTRIBUTING's "AI Generated Content" section: this patch was written with AI assistance (Claude). I reviewed every line, and the red/green and both-direction mutation runs above were executed against this branch rather than described. The change is one function plus its tests.
